### PR TITLE
perf: eliminate per-vector heap allocation in SQ8 asym_distance

### DIFF
--- a/crates/likhadb-index/src/ivf.rs
+++ b/crates/likhadb-index/src/ivf.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 
@@ -54,17 +55,20 @@ impl Sq8Quantizer {
             .collect()
     }
 
-    fn decode(&self, codes: &[u8]) -> Vec<f32> {
-        codes
-            .iter()
-            .enumerate()
-            .map(|(i, &c)| self.mins[i] + c as f32 * self.scales[i])
-            .collect()
-    }
-
-    /// Asymmetric distance: query stays f32, stored codes decoded on-the-fly.
+    /// Asymmetric distance: query stays f32, stored codes decoded into a
+    /// thread-local buffer to avoid a heap allocation per vector.
     fn asym_distance(&self, metric: Metric, query: &[f32], codes: &[u8]) -> f32 {
-        simd_distance(metric, query, &self.decode(codes))
+        thread_local! {
+            static DECODE_BUF: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
+        }
+        DECODE_BUF.with(|buf| {
+            let mut buf = buf.borrow_mut();
+            buf.clear();
+            buf.extend(
+                codes.iter().enumerate().map(|(i, &c)| self.mins[i] + c as f32 * self.scales[i]),
+            );
+            simd_distance(metric, query, &buf)
+        })
     }
 }
 
@@ -588,6 +592,18 @@ impl VectorIndex for IvfIndex {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+// decode is only needed in tests (asym_distance uses a thread-local buffer instead).
+#[cfg(test)]
+impl Sq8Quantizer {
+    fn decode(&self, codes: &[u8]) -> Vec<f32> {
+        codes
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| self.mins[i] + c as f32 * self.scales[i])
+            .collect()
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #1

## Summary

- Replace `decode()` → `Vec<f32>` allocation per candidate with a thread-local buffer in `Sq8Quantizer::asym_distance`
- `decode()` moved to `#[cfg(test)]` impl block (only used by `sq8_encode_decode_roundtrip`)

## Why it matters

At 100k × d384 with `nprobe=16`, a single SQ8 query evaluated ~6 400 candidate vectors, each triggering a `Vec<f32>` allocation that was immediately dropped. The thread-local buffer grows once per thread to `dim` floats and is reused every call — steady-state cost is zero allocations per query.

## Test plan

- [ ] `cargo test --workspace` — all 76 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] `cargo bench -p likhadb-bench` — compare `ivf_sq8_search` latency before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)