### PR TITLE
feat: A1 — payload in search results

### DIFF
--- a/crates/likhadb-bench/benches/search_bench.rs
+++ b/crates/likhadb-bench/benches/search_bench.rs
@@ -88,7 +88,7 @@ fn bench_simd(c: &mut Criterion, label: &str, n: usize, dim: usize, k: usize) {
         let col = mgr.get("bench_simd").unwrap();
         b.iter(|| {
             pool.install(|| {
-                let results = col.search(black_box(q), k, None).unwrap();
+                let results = col.search(black_box(q), k, None, false).unwrap();
                 black_box(results);
             });
         });
@@ -110,7 +110,7 @@ fn bench_simd_rayon(c: &mut Criterion, label: &str, n: usize, dim: usize, k: usi
     c.bench_with_input(BenchmarkId::new("simd_rayon", label), &query, |b, q| {
         let col = mgr.get("bench_rayon").unwrap();
         b.iter(|| {
-            let results = col.search(black_box(q), k, None).unwrap();
+            let results = col.search(black_box(q), k, None, false).unwrap();
             black_box(results);
         });
     });
@@ -181,7 +181,7 @@ fn bench_ivf_sq8_search(
     c.bench_with_input(BenchmarkId::new(bench_label, label), &query, |b, q| {
         let col = mgr.get(&col_name).unwrap();
         b.iter(|| {
-            let results = col.search(black_box(q), 10, None).unwrap();
+            let results = col.search(black_box(q), 10, None, false).unwrap();
             black_box(results);
         });
     });
@@ -214,7 +214,7 @@ fn bench_ivf_search(
     c.bench_with_input(BenchmarkId::new(bench_label, label), &query, |b, q| {
         let col = mgr.get(&col_name).unwrap();
         b.iter(|| {
-            let results = col.search(black_box(q), 10, None).unwrap();
+            let results = col.search(black_box(q), 10, None, false).unwrap();
             black_box(results);
         });
     });
@@ -271,7 +271,7 @@ fn bench_hnsw_search(
     c.bench_with_input(BenchmarkId::new(bench_label, label), &query, |b, q| {
         let col = mgr.get(&col_name).unwrap();
         b.iter(|| {
-            let results = col.search(black_box(q), 10, None).unwrap();
+            let results = col.search(black_box(q), 10, None, false).unwrap();
             black_box(results);
         });
     });

--- a/crates/likhadb-core/src/types.rs
+++ b/crates/likhadb-core/src/types.rs
@@ -8,6 +8,8 @@ pub type FilterFn<'a> = &'a (dyn Fn(VecId) -> bool + Send + Sync);
 pub struct ScoredResult {
     pub id: VecId,
     pub score: f32, // lower = better for L2/cosine distance; higher = better for dot
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/likhadb-index/src/flat.rs
+++ b/crates/likhadb-index/src/flat.rs
@@ -174,6 +174,7 @@ impl VectorIndex for FlatIndex {
             .map(|(d, id)| ScoredResult {
                 id,
                 score: d.into_inner(),
+                payload: None,
             })
             .collect();
 

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -394,6 +394,7 @@ impl VectorIndex for HnswIndex {
             .map(|(d, idx)| ScoredResult {
                 id: self.nodes[idx].id,
                 score: d.into_inner(),
+                payload: None,
             })
             .collect();
 

--- a/crates/likhadb-index/src/ivf.rs
+++ b/crates/likhadb-index/src/ivf.rs
@@ -471,7 +471,7 @@ impl IvfIndex {
 fn sorted_results(heap: BinaryHeap<(OrderedFloat<f32>, VecId)>) -> Vec<ScoredResult> {
     let mut results: Vec<ScoredResult> = heap
         .into_iter()
-        .map(|(d, id)| ScoredResult { id, score: d.into_inner() })
+        .map(|(d, id)| ScoredResult { id, score: d.into_inner(), payload: None })
         .collect();
     results.sort_by(|a, b| {
         OrderedFloat(a.score)

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -54,10 +54,17 @@ impl Collection {
         query: &[f32],
         k: usize,
         predicate: Option<&Value>,
+        include_payload: bool,
     ) -> Result<Vec<ScoredResult>> {
         let filter_box = self.meta.make_filter(predicate);
         let filter = filter_box.as_deref();
-        self.index.search(query, k, filter)
+        let mut results = self.index.search(query, k, filter)?;
+        if include_payload {
+            for r in &mut results {
+                r.payload = self.meta.get(r.id).cloned();
+            }
+        }
+        Ok(results)
     }
 
     pub fn len(&self) -> usize {

--- a/crates/likhadb-store/src/manager.rs
+++ b/crates/likhadb-store/src/manager.rs
@@ -199,7 +199,7 @@ mod tests {
 
         // search top-5 near origin
         let query = [0.0_f32, 0.0, 0.0, 0.0];
-        let results = mgr.get("test").unwrap().search(&query, 5, None).unwrap();
+        let results = mgr.get("test").unwrap().search(&query, 5, None, false).unwrap();
         assert_eq!(results.len(), 5);
 
         // results must be ordered ascending by score
@@ -222,7 +222,7 @@ mod tests {
         assert!(col.delete(1).unwrap());
 
         // re-search
-        let results2 = mgr.get("test").unwrap().search(&query, 5, None).unwrap();
+        let results2 = mgr.get("test").unwrap().search(&query, 5, None, false).unwrap();
         assert_eq!(results2.len(), 5);
         let ids2: Vec<u64> = results2.iter().map(|r| r.id).collect();
         assert!(!ids2.contains(&0), "deleted id 0 should not appear");
@@ -248,7 +248,7 @@ mod tests {
         let pred = serde_json::json!({"field": "parity", "op": "eq", "value": "even"});
         let query = [0.0_f32, 0.0, 0.0, 0.0];
         let col = mgr.get("tagged").unwrap();
-        let results = col.search(&query, 5, Some(&pred)).unwrap();
+        let results = col.search(&query, 5, Some(&pred), false).unwrap();
         assert!(results.iter().all(|r| r.id % 2 == 0));
     }
 
@@ -286,7 +286,7 @@ mod tests {
         }
 
         let query = [0.0_f32, 0.0, 0.0, 0.0];
-        let results = mgr.get("ivf").unwrap().search(&query, 5, None).unwrap();
+        let results = mgr.get("ivf").unwrap().search(&query, 5, None, false).unwrap();
         assert_eq!(results.len(), 5);
         for w in results.windows(2) {
             assert!(w[0].score <= w[1].score, "results not sorted");
@@ -295,7 +295,7 @@ mod tests {
         // Delete the nearest vector and verify it disappears.
         let nearest_id = results[0].id;
         mgr.get_mut("ivf").unwrap().delete(nearest_id).unwrap();
-        let results2 = mgr.get("ivf").unwrap().search(&query, 5, None).unwrap();
+        let results2 = mgr.get("ivf").unwrap().search(&query, 5, None, false).unwrap();
         assert!(results2.iter().all(|r| r.id != nearest_id));
     }
 
@@ -312,7 +312,7 @@ mod tests {
         }
 
         let query = [0.0_f32, 0.0, 0.0, 0.0];
-        let results = mgr.get("ivf_sq8").unwrap().search(&query, 5, None).unwrap();
+        let results = mgr.get("ivf_sq8").unwrap().search(&query, 5, None, false).unwrap();
         assert_eq!(results.len(), 5);
         for w in results.windows(2) {
             assert!(w[0].score <= w[1].score, "SQ8 results not sorted");
@@ -321,7 +321,7 @@ mod tests {
         // Delete the nearest vector and verify it disappears.
         let nearest_id = results[0].id;
         mgr.get_mut("ivf_sq8").unwrap().delete(nearest_id).unwrap();
-        let results2 = mgr.get("ivf_sq8").unwrap().search(&query, 5, None).unwrap();
+        let results2 = mgr.get("ivf_sq8").unwrap().search(&query, 5, None, false).unwrap();
         assert!(results2.iter().all(|r| r.id != nearest_id));
     }
 
@@ -373,7 +373,7 @@ mod tests {
         }
 
         let query = [0.0_f32, 0.0, 0.0, 0.0];
-        let results = mgr.get("hnsw").unwrap().search(&query, 5, None).unwrap();
+        let results = mgr.get("hnsw").unwrap().search(&query, 5, None, false).unwrap();
         assert_eq!(results.len(), 5);
         for w in results.windows(2) {
             assert!(w[0].score <= w[1].score, "results not sorted");
@@ -382,7 +382,60 @@ mod tests {
         // Delete the nearest vector and verify it disappears.
         let nearest_id = results[0].id;
         mgr.get_mut("hnsw").unwrap().delete(nearest_id).unwrap();
-        let results2 = mgr.get("hnsw").unwrap().search(&query, 5, None).unwrap();
+        let results2 = mgr.get("hnsw").unwrap().search(&query, 5, None, false).unwrap();
         assert!(results2.iter().all(|r| r.id != nearest_id));
+    }
+
+    #[test]
+    fn include_payload_false_returns_none() {
+        let mut mgr = CollectionManager::new();
+        mgr.create_collection("p", 4, Metric::L2).unwrap();
+        let col = mgr.get_mut("p").unwrap();
+        col.insert(0, vec![0.0; 4], Some(json!({"tag": "a"}))).unwrap();
+
+        let results = mgr.get("p").unwrap().search(&[0.0; 4], 1, None, false).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].payload.is_none());
+    }
+
+    #[test]
+    fn include_payload_true_returns_payload() {
+        let mut mgr = CollectionManager::new();
+        mgr.create_collection("p", 4, Metric::L2).unwrap();
+        let col = mgr.get_mut("p").unwrap();
+        col.insert(0, vec![0.0; 4], Some(json!({"tag": "a"}))).unwrap();
+        col.insert(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"tag": "b"}))).unwrap();
+        col.insert(2, vec![2.0, 0.0, 0.0, 0.0], None).unwrap();
+
+        let results = mgr.get("p").unwrap().search(&[0.0; 4], 3, None, true).unwrap();
+        assert_eq!(results.len(), 3);
+
+        let r0 = results.iter().find(|r| r.id == 0).unwrap();
+        assert_eq!(r0.payload, Some(json!({"tag": "a"})));
+
+        let r1 = results.iter().find(|r| r.id == 1).unwrap();
+        assert_eq!(r1.payload, Some(json!({"tag": "b"})));
+
+        let r2 = results.iter().find(|r| r.id == 2).unwrap();
+        assert!(r2.payload.is_none());
+    }
+
+    #[test]
+    fn include_payload_with_filter() {
+        let mut mgr = CollectionManager::new();
+        mgr.create_collection("pf", 4, Metric::L2).unwrap();
+        let col = mgr.get_mut("pf").unwrap();
+        for i in 0..10u64 {
+            let tag = if i % 2 == 0 { "even" } else { "odd" };
+            col.insert(i, vec![i as f32, 0.0, 0.0, 0.0], Some(json!({"parity": tag}))).unwrap();
+        }
+
+        let pred = json!({"field": "parity", "op": "eq", "value": "even"});
+        let results = mgr.get("pf").unwrap().search(&[0.0; 4], 5, Some(&pred), true).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            let p = r.payload.as_ref().unwrap();
+            assert_eq!(p["parity"], json!("even"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `payload: Option<serde_json::Value>` to `ScoredResult` in `likhadb-core/src/types.rs`
- Extends `Collection::search` with an `include_payload: bool` flag; when `true`, payloads are fetched from `MetaStore` and attached to each result; when `false` (default), zero extra allocation
- Updates all existing call sites (manager tests, bench file) to pass the new flag as `false`

## Changes

| File | Change |
|---|---|
| `crates/likhadb-core/src/types.rs` | Add `payload` field to `ScoredResult` |
| `crates/likhadb-store/src/collection.rs` | Add `include_payload` param, populate from `MetaStore` |
| `crates/likhadb-index/src/{flat,ivf,hnsw}.rs` | Add `payload: None` to index-layer `ScoredResult` constructors |
| `crates/likhadb-store/src/manager.rs` | Update call sites + 3 new tests |
| `crates/likhadb-bench/benches/search_bench.rs` | Update call sites |

## Test plan

- [x] `include_payload_false_returns_none` — flag off → all payloads are `None`
- [x] `include_payload_true_returns_payload` — flag on → payloads present/absent per insert
- [x] `include_payload_with_filter` — filter + include_payload both work together
- [x] All 99 existing tests still pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)