### PR TITLE
feat: vector retrieval by ID (A2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ the next begins.
 | HTTP / gRPC API | **None** | — |
 | Concurrent access | **None** | — |
 | Payload in search results | **Missing** | `ScoredResult` lacks `payload` field |
-| Vector retrieval by ID | **Missing** | No `get(id)` on `Collection` |
+| Vector retrieval by ID | Done | `crates/likhadb-store/src/collection.rs` |
 | Rich filtering | **Partial** | No `gt`/`lt`/`and`/`or` |
 | Full-text search | **None** | — |
 | Lakehouse I/O (Parquet) | **None** | — |

--- a/crates/likhadb-index/src/flat.rs
+++ b/crates/likhadb-index/src/flat.rs
@@ -76,6 +76,11 @@ impl FlatIndex {
 }
 
 impl VectorIndex for FlatIndex {
+    fn get(&self, id: VecId) -> Option<Vector> {
+        let pos = self.position(id)?;
+        Some(self.data[pos * self.dim..(pos + 1) * self.dim].to_vec())
+    }
+
     fn insert(&mut self, id: VecId, vec: Vector) -> Result<()> {
         if vec.len() != self.dim {
             return Err(LikhaDbError::DimMismatch {
@@ -319,6 +324,28 @@ mod tests {
         let query = [0.0_f32, 0.0, 0.0, 0.0];
         let results = idx.search(&query, 1, None).unwrap();
         assert!((results[0].score - 0.1).abs() < 1e-4);
+    }
+
+    #[test]
+    fn get_returns_vector_for_existing_id() {
+        let mut idx = make_index();
+        idx.insert(7, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        let v = idx.get(7).unwrap();
+        assert_eq!(v, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_id() {
+        let idx = make_index();
+        assert!(idx.get(99).is_none());
+    }
+
+    #[test]
+    fn get_returns_none_after_delete() {
+        let mut idx = make_index();
+        idx.insert(3, vec![0.0, 1.0, 0.0, 0.0]).unwrap();
+        idx.delete(3);
+        assert!(idx.get(3).is_none());
     }
 
     #[test]

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -245,6 +245,14 @@ impl HnswIndex {
 // ---------------------------------------------------------------------------
 
 impl VectorIndex for HnswIndex {
+    fn get(&self, id: VecId) -> Option<Vector> {
+        if self.deleted.contains(&id) {
+            return None;
+        }
+        let &node_idx = self.id_to_node.get(&id)?;
+        Some(self.data[node_idx * self.dim..(node_idx + 1) * self.dim].to_vec())
+    }
+
     fn insert(&mut self, id: VecId, vec: Vector) -> Result<()> {
         if vec.len() != self.dim {
             return Err(LikhaDbError::DimMismatch {
@@ -665,5 +673,26 @@ mod tests {
         assert_eq!(idx.len(), 5);
         idx.delete(999); // nonexistent
         assert_eq!(idx.len(), 5);
+    }
+
+    #[test]
+    fn get_returns_vector_for_existing_id() {
+        let mut idx = make_hnsw(4, 16, 10);
+        idx.insert(3, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        assert_eq!(idx.get(3).unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_id() {
+        let idx = make_hnsw(4, 16, 10);
+        assert!(idx.get(99).is_none());
+    }
+
+    #[test]
+    fn get_returns_none_after_delete() {
+        let mut idx = make_hnsw(4, 16, 10);
+        idx.insert(5, vec![0.0, 1.0, 0.0, 0.0]).unwrap();
+        idx.delete(5);
+        assert!(idx.get(5).is_none());
     }
 }

--- a/crates/likhadb-index/src/ivf.rs
+++ b/crates/likhadb-index/src/ivf.rs
@@ -136,6 +136,18 @@ impl PostingList {
     fn ids_and_codes(&self, dim: usize) -> impl Iterator<Item = (VecId, &[u8])> {
         self.ids.iter().copied().zip(self.codes.chunks_exact(dim))
     }
+
+    /// Return the raw f32 slice for `id` (unquantized path), or `None` if not present.
+    fn get_f32_by_id(&self, id: VecId, dim: usize) -> Option<&[f32]> {
+        let pos = self.ids.iter().position(|&eid| eid == id)?;
+        Some(&self.data[pos * dim..(pos + 1) * dim])
+    }
+
+    /// Return the u8 code slice for `id` (SQ8 path), or `None` if not present.
+    fn get_codes_by_id(&self, id: VecId, dim: usize) -> Option<&[u8]> {
+        let pos = self.ids.iter().position(|&eid| eid == id)?;
+        Some(&self.codes[pos * dim..(pos + 1) * dim])
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -486,6 +498,22 @@ fn sorted_results(heap: BinaryHeap<(OrderedFloat<f32>, VecId)>) -> Vec<ScoredRes
 // ---------------------------------------------------------------------------
 
 impl VectorIndex for IvfIndex {
+    fn get(&self, id: VecId) -> Option<Vector> {
+        if !self.trained {
+            // Pre-training: linear scan of staging buffer.
+            let pos = self.staging_ids.iter().position(|&eid| eid == id)?;
+            return Some(self.staging_data[pos * self.dim..(pos + 1) * self.dim].to_vec());
+        }
+        let &list_idx = self.id_to_list.get(&id)?;
+        if let Some(q) = &self.quantizer {
+            // SQ8 path: decode codes back to approximate f32.
+            let codes = self.lists[list_idx].get_codes_by_id(id, self.dim)?;
+            Some(codes.iter().enumerate().map(|(i, &c)| q.mins[i] + c as f32 * q.scales[i]).collect())
+        } else {
+            Some(self.lists[list_idx].get_f32_by_id(id, self.dim)?.to_vec())
+        }
+    }
+
     fn insert(&mut self, id: VecId, vec: Vector) -> Result<()> {
         if vec.len() != self.dim {
             return Err(LikhaDbError::DimMismatch { expected: self.dim, got: vec.len() });
@@ -1089,6 +1117,49 @@ mod tests {
             idx.search(&[1.0_f32, 2.0], 1, None),
             Err(LikhaDbError::DimMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn get_staging_returns_vector() {
+        let mut idx = make_ivf(4, 2);
+        idx.insert(5, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        assert!(!idx.trained);
+        assert_eq!(idx.get(5).unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn get_staging_returns_none_for_missing() {
+        let idx = make_ivf(4, 2);
+        assert!(idx.get(99).is_none());
+    }
+
+    #[test]
+    fn get_post_training_returns_vector() {
+        let mut idx = make_ivf(4, 2);
+        insert_n(&mut idx, 5); // nlist=4 → training fires at 4th insert
+        assert!(idx.trained);
+        let v = idx.get(2).unwrap();
+        // insert_n stores [i, 0, 0, 0] for id=i
+        assert_eq!(v, vec![2.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn get_post_training_returns_none_after_delete() {
+        let mut idx = make_ivf(4, 2);
+        insert_n(&mut idx, 5);
+        assert!(idx.trained);
+        idx.delete(1);
+        assert!(idx.get(1).is_none());
+    }
+
+    #[test]
+    fn get_sq8_returns_approximate_vector() {
+        let mut idx = make_ivf_sq8(4, 4);
+        insert_n_sq8(&mut idx, 4); // nlist=4 → training fires
+        assert!(idx.trained);
+        // Decoded value should be close to the original [2, 0, 0, 0]
+        let v = idx.get(2).unwrap();
+        assert!((v[0] - 2.0_f32).abs() < 1.0, "decoded x={} should be near 2.0", v[0]);
     }
 
     #[test]

--- a/crates/likhadb-index/src/traits.rs
+++ b/crates/likhadb-index/src/traits.rs
@@ -18,6 +18,11 @@ pub trait VectorIndex: Send + Sync {
         filter: Option<FilterFn<'_>>,
     ) -> Result<Vec<ScoredResult>>;
 
+    /// Retrieve a stored vector by ID. Returns `None` if the ID does not exist
+    /// (or has been deleted). For SQ8-quantized indices the returned vector is
+    /// decoded from 8-bit codes and is therefore an approximation of the original.
+    fn get(&self, id: VecId) -> Option<Vector>;
+
     fn len(&self) -> usize;
     fn dim(&self) -> usize;
     fn is_empty(&self) -> bool {

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -67,11 +67,74 @@ impl Collection {
         Ok(results)
     }
 
+    pub fn get(&self, id: VecId) -> Result<Option<(Vector, Option<Value>)>> {
+        let Some(vec) = self.index.get(id) else {
+            return Ok(None);
+        };
+        Ok(Some((vec, self.meta.get(id).cloned())))
+    }
+
+    pub fn get_batch(&self, ids: &[VecId]) -> Result<Vec<Option<(Vector, Option<Value>)>>> {
+        ids.iter().map(|&id| self.get(id)).collect()
+    }
+
     pub fn len(&self) -> usize {
         self.index.len()
     }
 
     pub fn is_empty(&self) -> bool {
         self.index.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_collection() -> Collection {
+        Collection::new("test".into(), 3, Metric::L2)
+    }
+
+    #[test]
+    fn get_returns_vector_and_payload() {
+        let mut c = make_collection();
+        c.insert(1, vec![1.0, 2.0, 3.0], Some(json!({"tag": "a"}))).unwrap();
+        let (vec, payload) = c.get(1).unwrap().unwrap();
+        assert_eq!(vec, vec![1.0, 2.0, 3.0]);
+        assert_eq!(payload.unwrap()["tag"], "a");
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_id() {
+        let c = make_collection();
+        assert!(c.get(99).unwrap().is_none());
+    }
+
+    #[test]
+    fn get_returns_none_after_delete() {
+        let mut c = make_collection();
+        c.insert(2, vec![0.0, 1.0, 0.0], None).unwrap();
+        c.delete(2).unwrap();
+        assert!(c.get(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn get_payload_is_none_when_not_set() {
+        let mut c = make_collection();
+        c.insert(3, vec![1.0, 0.0, 0.0], None).unwrap();
+        let (_, payload) = c.get(3).unwrap().unwrap();
+        assert!(payload.is_none());
+    }
+
+    #[test]
+    fn get_batch_returns_mixed_some_and_none() {
+        let mut c = make_collection();
+        c.insert(1, vec![1.0, 0.0, 0.0], Some(json!({"x": 1}))).unwrap();
+        c.insert(3, vec![3.0, 0.0, 0.0], None).unwrap();
+        let results = c.get_batch(&[1, 2, 3]).unwrap();
+        assert!(results[0].is_some());
+        assert!(results[1].is_none());
+        assert!(results[2].is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Add `fn get(&self, id: VecId) -> Option<Vector>` to the `VectorIndex` trait
- Implement `get()` for all three index backends: `FlatIndex` (O(n) scan), `IvfIndex` (O(1) via `id_to_list` HashMap, with SQ8 decode path), `HnswIndex` (O(1) via `id_to_node` HashMap, respects tombstoned deletions)
- Expose `Collection::get(id)` returning `(Vector, Option<Value>)` with payload, and `Collection::get_batch(ids)`
- Mark A2 as done in ROADMAP.md

## Test plan

- [ ] 3 new tests in `flat.rs` (get existing, get missing, get after delete)
- [ ] 5 new tests in `ivf.rs` (staging path, post-training path, delete, SQ8 approximate decode)
- [ ] 3 new tests in `hnsw.rs` (get existing, get missing, get after delete)
- [ ] 5 new tests in `collection.rs` (vector + payload, no payload, deleted, `get_batch` mixed Some/None)
- [ ] `cargo test --workspace` — 115 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)