### PR TITLE
feat: snapshot persistence (B1) — save/load CollectionManager to disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/likhadb-core",
     "crates/likhadb-index",
     "crates/likhadb-store",
+    "crates/likhadb-persist",
     "crates/likhadb-bench",
 ]
 resolver = "2"
@@ -16,3 +17,4 @@ rand          = "0.8"
 criterion     = { version = "0.5", features = ["html_reports"] }
 simsimd       = "6"
 rayon         = "1"
+bincode       = "1"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ the store or API layers.
 likhadb/
 ├── crates/
 │   ├── likhadb-core/    # Primitives: VecId, Vector, ScoredResult, Metric, distance kernels
-│   ├── likhadb-index/   # VectorIndex trait + FlatIndex + IvfIndex
+│   ├── likhadb-index/   # VectorIndex trait + FlatIndex + IvfIndex + HnswIndex
 │   ├── likhadb-store/   # Collection, CollectionManager, MetaStore (JSON filtering)
+│   ├── likhadb-persist/ # Snapshot serialization — save/load CollectionManager to disk
 │   └── likhadb-bench/   # Criterion benchmarks
 └── images/
 ```
@@ -37,8 +38,9 @@ likhadb/
 | Crate | Role |
 |---|---|
 | `likhadb-core` | Shared primitives and error types — no index logic |
-| `likhadb-index` | `VectorIndex` trait (the extension seam) + `FlatIndex` + `IvfIndex` |
+| `likhadb-index` | `VectorIndex` trait (the extension seam) + `FlatIndex` + `IvfIndex` + `HnswIndex` |
 | `likhadb-store` | `Collection` wraps an index + metadata; `CollectionManager` names them |
+| `likhadb-persist` | Point-in-time snapshots via `bincode`; `PersistExt` trait adds `save`/`load` to `CollectionManager` |
 | `likhadb-bench` | Criterion benchmarks for 1 k / 10 k / 100 k vectors |
 
 ## Features
@@ -71,6 +73,14 @@ likhadb/
 - **Exact recall mode** — set `nprobe == nlist` to search all buckets (equivalent to brute-force)
 - **Same API** — drop-in replacement for `FlatIndex` via `create_ivf_collection`
 - **SQ8 scalar quantization** — opt-in 4× memory reduction via `create_ivf_sq8_collection`; posting lists store `u8` codes instead of `f32`; distances use asymmetric computation (query stays `f32`)
+
+### Tier 4 B1 — Snapshot persistence (`likhadb-persist`)
+
+- **Point-in-time snapshots** — serialize the full `CollectionManager` state (all collections, all index types, all payloads) to a single binary file
+- **Fast binary format** via [`bincode`](https://github.com/bincode-org/bincode) — raw `f32` slabs, no base64 inflation
+- **All three index types supported** — `FlatIndex`, `IvfIndex` (including SQ8), `HnswIndex` round-trip correctly including graph structure, tombstones, and training state
+- **Safe deserialization** — 16 GiB size cap prevents corrupt length fields from triggering multi-terabyte allocation attempts
+- **Extension trait API** — import `PersistExt` and call `mgr.save(path)` / `CollectionManager::load(path)`
 
 ## Getting started
 
@@ -223,6 +233,26 @@ fn main() {
 - Memory: 100k × d384 goes from ~146 MB (f32) to ~36 MB (u8).
 - Recall: typically >97% at d384 for normalized embeddings. Recall is lower for post-training inserts whose values fall outside the training distribution's range.
 
+### Snapshot persistence
+
+```rust
+use std::path::Path;
+use likhadb_persist::PersistExt;
+use likhadb_store::CollectionManager;
+
+// --- Save ---
+let mut mgr = CollectionManager::new();
+// ... create collections, insert vectors ...
+mgr.save(Path::new("snapshot.bin")).unwrap();
+
+// --- Load on next startup ---
+let mgr = CollectionManager::load(Path::new("snapshot.bin")).unwrap();
+// All collections, index state, and payloads are restored.
+// Searches work immediately — no retraining required.
+```
+
+All three index types (`FlatIndex`, `IvfIndex`/SQ8, `HnswIndex`) survive the round-trip, including HNSW graph edges, IVF training state, and JSON payloads.
+
 ## Distance metrics
 
 | Metric | Formula | Best for |
@@ -278,7 +308,8 @@ Rayon uses the default thread pool (all available cores).
 | **Tier 1** | Done | Exact brute-force search, in-memory, JSON metadata filtering |
 | **Tier 2** | Done | IVF (Inverted File Index) — approximate k-NN with k-means clustering |
 | **Tier 3** | Done | HNSW (Hierarchical Navigable Small World graphs) |
-| **Tier 4** | Future | Persistence / WAL, HTTP + gRPC API, vector quantisation |
+| **Tier 4 — B1** | Done | Snapshot persistence — `CollectionManager::save` / `load` via `likhadb-persist` |
+| **Tier 4 — B2+** | Future | WAL (crash durability), HTTP + gRPC API, observability |
 
 All future tiers implement `VectorIndex` — the store layer is unchanged.
 

--- a/crates/likhadb-index/Cargo.toml
+++ b/crates/likhadb-index/Cargo.toml
@@ -3,9 +3,13 @@ name    = "likhadb-index"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+serde = ["dep:serde"]
+
 [dependencies]
 likhadb-core  = { path = "../likhadb-core" }
 ordered-float = { workspace = true }
 simsimd       = { workspace = true }
 rayon         = { workspace = true }
 rand          = { workspace = true }
+serde         = { workspace = true, optional = true }

--- a/crates/likhadb-index/src/flat.rs
+++ b/crates/likhadb-index/src/flat.rs
@@ -49,6 +49,8 @@ pub(crate) fn simd_distance(metric: Metric, a: &[f32], b: &[f32]) -> f32 {
 /// Distance computation uses `simsimd` for hardware-accelerated kernels (NEON on
 /// aarch64/M2, AVX-512 on x86). A scalar fallback is used when `simsimd` returns
 /// `None` (empty slices or unsupported targets).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub struct FlatIndex {
     dim: usize,
     metric: Metric,
@@ -203,6 +205,11 @@ impl VectorIndex for FlatIndex {
 
     fn index_type(&self) -> &'static str {
         "FlatIndex"
+    }
+
+    #[cfg(feature = "serde")]
+    fn to_snapshot(&self) -> crate::snapshot::IndexSnapshot {
+        crate::snapshot::IndexSnapshot::Flat(self.clone())
     }
 }
 

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -14,6 +14,8 @@ const MAX_LEVEL: usize = 16;
 // Internal node type
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 struct HnswNode {
     id: VecId,
     /// `layers[l]` holds the indices into `HnswIndex::nodes` of neighbours at level `l`.
@@ -35,6 +37,8 @@ struct HnswNode {
 /// **Deletion** uses tombstoning: deleted nodes remain in the graph as traversal
 /// stepping-stones but are excluded from search results.  `len()` reports the
 /// number of live (non-deleted) vectors.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub struct HnswIndex {
     dim: usize,
     metric: Metric,
@@ -425,6 +429,11 @@ impl VectorIndex for HnswIndex {
 
     fn index_type(&self) -> &'static str {
         "HnswIndex"
+    }
+
+    #[cfg(feature = "serde")]
+    fn to_snapshot(&self) -> crate::snapshot::IndexSnapshot {
+        crate::snapshot::IndexSnapshot::Hnsw(self.clone())
     }
 }
 

--- a/crates/likhadb-index/src/ivf.rs
+++ b/crates/likhadb-index/src/ivf.rs
@@ -17,6 +17,8 @@ const KMEANS_TOL: f32 = 1e-4;
 // Sq8Quantizer — per-dimension scalar quantization (f32 → u8)
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 struct Sq8Quantizer {
     mins: Vec<f32>,   // [dim] per-dimension minimum observed during training
     scales: Vec<f32>, // [dim]: (max[i] - min[i]) / 255.0; 1.0 if range == 0
@@ -87,6 +89,8 @@ impl Sq8Quantizer {
 // PostingList — flat-slab storage for one IVF bucket
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 struct PostingList {
     ids: Vec<VecId>,
     data: Vec<f32>, // flat slab: ids[i] owns data[i*dim..(i+1)*dim]; used when NOT quantized
@@ -277,6 +281,8 @@ fn kmeans(data: &[f32], n: usize, dim: usize, k: usize, metric: Metric) -> Vec<f
 ///
 /// Setting `nprobe == nlist` searches every bucket and gives exact recall
 /// (equivalent to brute-force), which is useful for correctness testing.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub struct IvfIndex {
     dim: usize,
     metric: Metric,
@@ -662,6 +668,11 @@ impl VectorIndex for IvfIndex {
 
     fn index_type(&self) -> &'static str {
         "IvfIndex"
+    }
+
+    #[cfg(feature = "serde")]
+    fn to_snapshot(&self) -> crate::snapshot::IndexSnapshot {
+        crate::snapshot::IndexSnapshot::Ivf(self.clone())
     }
 }
 

--- a/crates/likhadb-index/src/lib.rs
+++ b/crates/likhadb-index/src/lib.rs
@@ -2,8 +2,12 @@ pub mod flat;
 pub mod hnsw;
 pub mod ivf;
 pub mod traits;
+#[cfg(feature = "serde")]
+pub mod snapshot;
 
 pub use flat::FlatIndex;
 pub use hnsw::HnswIndex;
 pub use ivf::IvfIndex;
 pub use traits::VectorIndex;
+#[cfg(feature = "serde")]
+pub use snapshot::IndexSnapshot;

--- a/crates/likhadb-index/src/snapshot.rs
+++ b/crates/likhadb-index/src/snapshot.rs
@@ -1,0 +1,21 @@
+use crate::{FlatIndex, HnswIndex, IvfIndex, VectorIndex};
+
+/// Tagged union over all concrete index types, used for snapshot serialization.
+/// Uses serde's default (externally tagged) representation so binary formats
+/// like bincode that lack `deserialize_any` work correctly.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum IndexSnapshot {
+    Flat(FlatIndex),
+    Ivf(IvfIndex),
+    Hnsw(HnswIndex),
+}
+
+impl IndexSnapshot {
+    pub fn into_box(self) -> Box<dyn VectorIndex> {
+        match self {
+            IndexSnapshot::Flat(f) => Box::new(f),
+            IndexSnapshot::Ivf(i) => Box::new(i),
+            IndexSnapshot::Hnsw(h) => Box::new(h),
+        }
+    }
+}

--- a/crates/likhadb-index/src/traits.rs
+++ b/crates/likhadb-index/src/traits.rs
@@ -31,4 +31,7 @@ pub trait VectorIndex: Send + Sync {
 
     /// Index type name — used for observability/logging only.
     fn index_type(&self) -> &'static str;
+
+    #[cfg(feature = "serde")]
+    fn to_snapshot(&self) -> crate::snapshot::IndexSnapshot;
 }

--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "likhadb-persist"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+likhadb-core  = { path = "../likhadb-core" }
+likhadb-index = { path = "../likhadb-index", features = ["serde"] }
+likhadb-store = { path = "../likhadb-store", features = ["persist"] }
+bincode       = { workspace = true }
+thiserror     = { workspace = true }
+serde         = { workspace = true }
+
+[dev-dependencies]
+serde_json    = { workspace = true }
+rand          = { workspace = true }

--- a/crates/likhadb-persist/src/error.rs
+++ b/crates/likhadb-persist/src/error.rs
@@ -1,0 +1,11 @@
+use std::io;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PersistError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("encode error: {0}")]
+    Encode(#[source] bincode::Error),
+    #[error("decode error: {0}")]
+    Decode(#[source] bincode::Error),
+}

--- a/crates/likhadb-persist/src/lib.rs
+++ b/crates/likhadb-persist/src/lib.rs
@@ -1,0 +1,53 @@
+mod error;
+
+pub use error::PersistError;
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::Path;
+
+use bincode::Options;
+use likhadb_store::{CollectionManager, ManagerSnapshot};
+
+/// 16 GiB hard cap on snapshot size — prevents a corrupt length field from
+/// causing a multi-terabyte allocation attempt on malformed input.
+const MAX_SNAPSHOT_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+fn bincode_opts() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(MAX_SNAPSHOT_BYTES)
+}
+
+/// Extension trait that adds `save` / `load` to [`CollectionManager`].
+///
+/// Import this trait to use:
+/// ```rust,ignore
+/// use likhadb_persist::PersistExt;
+/// mgr.save(Path::new("snapshot.bin"))?;
+/// let mgr = CollectionManager::load(Path::new("snapshot.bin"))?;
+/// ```
+pub trait PersistExt: Sized {
+    fn save(&self, path: &Path) -> Result<(), PersistError>;
+    fn load(path: &Path) -> Result<Self, PersistError>;
+}
+
+impl PersistExt for CollectionManager {
+    fn save(&self, path: &Path) -> Result<(), PersistError> {
+        let snap: ManagerSnapshot = self.to_snapshot();
+        let file = File::create(path).map_err(PersistError::Io)?;
+        let writer = BufWriter::new(file);
+        bincode_opts()
+            .serialize_into(writer, &snap)
+            .map_err(PersistError::Encode)
+    }
+
+    fn load(path: &Path) -> Result<Self, PersistError> {
+        let file = File::open(path).map_err(PersistError::Io)?;
+        let reader = BufReader::new(file);
+        let snap: ManagerSnapshot = bincode_opts()
+            .deserialize_from(reader)
+            .map_err(PersistError::Decode)?;
+        Ok(CollectionManager::from_snapshot(snap))
+    }
+}

--- a/crates/likhadb-persist/tests/round_trip.rs
+++ b/crates/likhadb-persist/tests/round_trip.rs
@@ -1,0 +1,197 @@
+use std::collections::HashSet;
+
+use likhadb_core::Metric;
+use likhadb_persist::PersistExt;
+use likhadb_store::CollectionManager;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use serde_json::json;
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("likhadb_test_{name}.bin"))
+}
+
+fn random_vecs(n: usize, dim: usize, seed: u64) -> Vec<Vec<f32>> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n).map(|_| (0..dim).map(|_| rng.gen::<f32>()).collect()).collect()
+}
+
+#[test]
+fn flat_round_trip() {
+    let dim = 4usize;
+    let vecs = random_vecs(100, dim, 1);
+
+    let mut mgr = CollectionManager::new();
+    mgr.create_collection("flat", dim, Metric::L2).unwrap();
+    let col = mgr.get_mut("flat").unwrap();
+    for (i, v) in vecs.iter().enumerate() {
+        col.insert(i as u64, v.clone(), Some(json!({"i": i}))).unwrap();
+    }
+
+    let query: Vec<f32> = vecs[0].clone();
+    let before = mgr.get("flat").unwrap().search(&query, 5, None, true).unwrap();
+
+    let path = tmp_path("flat");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+
+    let after = mgr2.get("flat").unwrap().search(&query, 5, None, true).unwrap();
+    let before_ids: Vec<u64> = before.iter().map(|r| r.id).collect();
+    let after_ids: Vec<u64> = after.iter().map(|r| r.id).collect();
+    assert_eq!(before_ids, after_ids, "flat: result IDs must match after round-trip");
+    assert_eq!(after[0].payload, Some(json!({"i": after[0].id as usize})));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn ivf_round_trip() {
+    let dim = 4usize;
+    let nlist = 8usize;
+    let vecs = random_vecs(nlist + 50, dim, 2);
+
+    let mut mgr = CollectionManager::new();
+    mgr.create_ivf_collection("ivf", dim, Metric::L2, nlist, nlist).unwrap();
+    let col = mgr.get_mut("ivf").unwrap();
+    for (i, v) in vecs.iter().enumerate() {
+        col.insert(i as u64, v.clone(), None).unwrap();
+    }
+
+    let query: Vec<f32> = vecs[0].clone();
+    let before = mgr.get("ivf").unwrap().search(&query, 5, None, false).unwrap();
+
+    let path = tmp_path("ivf");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+
+    let after = mgr2.get("ivf").unwrap().search(&query, 5, None, false).unwrap();
+    let before_ids: HashSet<u64> = before.iter().map(|r| r.id).collect();
+    let after_ids: HashSet<u64> = after.iter().map(|r| r.id).collect();
+    assert_eq!(before_ids, after_ids, "ivf: result IDs must match after round-trip");
+    assert_eq!(mgr2.get("ivf").unwrap().index_type(), "IvfIndex");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn ivf_sq8_round_trip() {
+    let dim = 4usize;
+    let nlist = 8usize;
+    let vecs = random_vecs(nlist + 50, dim, 3);
+
+    let mut mgr = CollectionManager::new();
+    mgr.create_ivf_sq8_collection("sq8", dim, Metric::L2, nlist, nlist).unwrap();
+    let col = mgr.get_mut("sq8").unwrap();
+    for (i, v) in vecs.iter().enumerate() {
+        col.insert(i as u64, v.clone(), None).unwrap();
+    }
+
+    let query: Vec<f32> = vecs[0].clone();
+    let before = mgr.get("sq8").unwrap().search(&query, 5, None, false).unwrap();
+
+    let path = tmp_path("ivf_sq8");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+
+    let after = mgr2.get("sq8").unwrap().search(&query, 5, None, false).unwrap();
+    assert!(!after.is_empty(), "sq8: results must not be empty after round-trip");
+    assert_eq!(mgr2.get("sq8").unwrap().index_type(), "IvfIndex");
+
+    let before_ids: HashSet<u64> = before.iter().map(|r| r.id).collect();
+    let after_ids: HashSet<u64> = after.iter().map(|r| r.id).collect();
+    let overlap = before_ids.intersection(&after_ids).count();
+    assert!(overlap >= 4, "sq8: expected ≥4/5 overlap, got {overlap}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn hnsw_round_trip() {
+    let dim = 4usize;
+    let vecs = random_vecs(200, dim, 4);
+
+    let mut mgr = CollectionManager::new();
+    mgr.create_hnsw_collection("hnsw", dim, Metric::L2, 4, 16, 20).unwrap();
+    let col = mgr.get_mut("hnsw").unwrap();
+    for (i, v) in vecs.iter().enumerate() {
+        col.insert(i as u64, v.clone(), None).unwrap();
+    }
+
+    let query: Vec<f32> = vecs[0].clone();
+    let before = mgr.get("hnsw").unwrap().search(&query, 10, None, false).unwrap();
+
+    let path = tmp_path("hnsw");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+
+    let after = mgr2.get("hnsw").unwrap().search(&query, 10, None, false).unwrap();
+    assert_eq!(mgr2.get("hnsw").unwrap().index_type(), "HnswIndex");
+
+    let before_ids: HashSet<u64> = before.iter().map(|r| r.id).collect();
+    let after_ids: HashSet<u64> = after.iter().map(|r| r.id).collect();
+    let overlap = before_ids.intersection(&after_ids).count();
+    assert!(overlap >= 9, "hnsw: expected ≥90% recall, got {overlap}/10");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn multi_collection_round_trip() {
+    let dim = 4usize;
+    let vecs = random_vecs(20, dim, 5);
+
+    let mut mgr = CollectionManager::new();
+    mgr.create_collection("flat", dim, Metric::L2).unwrap();
+    mgr.create_ivf_collection("ivf", dim, Metric::L2, 4, 4).unwrap();
+    mgr.create_hnsw_collection("hnsw", dim, Metric::L2, 4, 8, 10).unwrap();
+
+    for name in ["flat", "ivf", "hnsw"] {
+        let col = mgr.get_mut(name).unwrap();
+        for (i, v) in vecs.iter().enumerate() {
+            col.insert(i as u64, v.clone(), None).unwrap();
+        }
+    }
+
+    let path = tmp_path("multi");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+
+    let mut names = mgr2.list();
+    names.sort_unstable();
+    assert_eq!(names, vec!["flat", "hnsw", "ivf"]);
+    assert_eq!(mgr2.get("flat").unwrap().index_type(), "FlatIndex");
+    assert_eq!(mgr2.get("ivf").unwrap().index_type(), "IvfIndex");
+    assert_eq!(mgr2.get("hnsw").unwrap().index_type(), "HnswIndex");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn empty_manager_round_trip() {
+    let mgr = CollectionManager::new();
+    let path = tmp_path("empty");
+    mgr.save(&path).unwrap();
+    let mgr2 = CollectionManager::load(&path).unwrap();
+    assert!(mgr2.list().is_empty());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn missing_file_returns_io_error() {
+    let result = CollectionManager::load(std::path::Path::new("/nonexistent/path.bin"));
+    assert!(
+        matches!(result, Err(likhadb_persist::PersistError::Io(_))),
+        "expected Io error"
+    );
+}
+
+#[test]
+fn corrupt_file_returns_decode_error() {
+    let path = tmp_path("corrupt");
+    std::fs::write(&path, b"not valid bincode data at all").unwrap();
+    let result = CollectionManager::load(&path);
+    assert!(
+        matches!(result, Err(likhadb_persist::PersistError::Decode(_))),
+        "expected Decode error"
+    );
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/likhadb-store/Cargo.toml
+++ b/crates/likhadb-store/Cargo.toml
@@ -3,7 +3,11 @@ name    = "likhadb-store"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+persist = ["dep:serde", "likhadb-index/serde"]
+
 [dependencies]
 likhadb-core  = { path = "../likhadb-core" }
 likhadb-index = { path = "../likhadb-index" }
 serde_json    = { workspace = true }
+serde         = { workspace = true, optional = true }

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -4,12 +4,14 @@ use serde_json::Value;
 
 use crate::meta::MetaStore;
 
+pub type VectorWithPayload = (Vector, Option<Value>);
+
 pub struct Collection {
     pub name: String,
     pub dim: usize,
     pub metric: Metric,
-    index: Box<dyn VectorIndex>,
-    meta: MetaStore,
+    pub(crate) index: Box<dyn VectorIndex>,
+    pub(crate) meta: MetaStore,
 }
 
 impl Collection {
@@ -33,6 +35,12 @@ impl Collection {
             index,
             meta: MetaStore::new(),
         }
+    }
+
+    #[cfg(feature = "persist")]
+    pub(crate) fn with_meta(mut self, meta: crate::meta::MetaStore) -> Self {
+        self.meta = meta;
+        self
     }
 
     pub fn insert(&mut self, id: VecId, vec: Vector, payload: Option<Value>) -> Result<()> {
@@ -67,14 +75,14 @@ impl Collection {
         Ok(results)
     }
 
-    pub fn get(&self, id: VecId) -> Result<Option<(Vector, Option<Value>)>> {
+    pub fn get(&self, id: VecId) -> Result<Option<VectorWithPayload>> {
         let Some(vec) = self.index.get(id) else {
             return Ok(None);
         };
         Ok(Some((vec, self.meta.get(id).cloned())))
     }
 
-    pub fn get_batch(&self, ids: &[VecId]) -> Result<Vec<Option<(Vector, Option<Value>)>>> {
+    pub fn get_batch(&self, ids: &[VecId]) -> Result<Vec<Option<VectorWithPayload>>> {
         ids.iter().map(|&id| self.get(id)).collect()
     }
 
@@ -84,6 +92,10 @@ impl Collection {
 
     pub fn is_empty(&self) -> bool {
         self.index.is_empty()
+    }
+
+    pub fn index_type(&self) -> &'static str {
+        self.index.index_type()
     }
 }
 

--- a/crates/likhadb-store/src/lib.rs
+++ b/crates/likhadb-store/src/lib.rs
@@ -1,7 +1,11 @@
 pub mod collection;
 pub mod manager;
 pub mod meta;
+#[cfg(feature = "persist")]
+pub mod snapshot;
 
 pub use collection::Collection;
 pub use manager::CollectionManager;
 pub use meta::MetaStore;
+#[cfg(feature = "persist")]
+pub use snapshot::{CollectionSnapshot, ManagerSnapshot};

--- a/crates/likhadb-store/src/manager.rs
+++ b/crates/likhadb-store/src/manager.rs
@@ -132,6 +132,16 @@ impl CollectionManager {
         self.collections.insert(name, collection);
         Ok(())
     }
+
+    #[cfg(feature = "persist")]
+    pub(crate) fn insert_collection(&mut self, col: Collection) {
+        self.collections.insert(col.name.clone(), col);
+    }
+
+    #[cfg(feature = "persist")]
+    pub(crate) fn all_collections(&self) -> impl Iterator<Item = &Collection> {
+        self.collections.values()
+    }
 }
 
 impl Default for CollectionManager {

--- a/crates/likhadb-store/src/meta.rs
+++ b/crates/likhadb-store/src/meta.rs
@@ -4,7 +4,39 @@ use serde_json::Value;
 
 use likhadb_core::VecId;
 
+/// Serializes `serde_json::Value` as a JSON string so that binary formats
+/// (e.g. bincode) can handle it — bincode does not support `deserialize_any`.
+#[cfg(feature = "persist")]
+mod json_value_as_string {
+    use std::collections::HashMap;
+    use likhadb_core::VecId;
+    use serde::{Deserializer, Serializer, Deserialize};
+    use serde_json::Value;
+
+    pub fn serialize<S>(map: &HashMap<VecId, Value>, s: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        use serde::Serialize;
+        let encoded: HashMap<VecId, String> =
+            map.iter().map(|(k, v)| (*k, v.to_string())).collect();
+        encoded.serialize(s)
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<HashMap<VecId, Value>, D::Error>
+    where D: Deserializer<'de> {
+        let encoded: HashMap<VecId, String> = HashMap::deserialize(d)?;
+        encoded.into_iter()
+            .map(|(k, s)| {
+                let v: Value = serde_json::from_str(&s).map_err(serde::de::Error::custom)?;
+                Ok((k, v))
+            })
+            .collect()
+    }
+}
+
+#[cfg_attr(feature = "persist", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub struct MetaStore {
+    #[cfg_attr(feature = "persist", serde(with = "json_value_as_string"))]
     payloads: HashMap<VecId, Value>,
 }
 

--- a/crates/likhadb-store/src/snapshot.rs
+++ b/crates/likhadb-store/src/snapshot.rs
@@ -1,0 +1,53 @@
+use likhadb_core::Metric;
+use likhadb_index::IndexSnapshot;
+
+use crate::collection::Collection;
+use crate::manager::CollectionManager;
+use crate::meta::MetaStore;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CollectionSnapshot {
+    pub name: String,
+    pub dim: usize,
+    pub metric: Metric,
+    pub index: IndexSnapshot,
+    pub meta: MetaStore,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ManagerSnapshot {
+    pub collections: Vec<CollectionSnapshot>,
+}
+
+impl Collection {
+    pub fn to_snapshot(&self) -> CollectionSnapshot {
+        CollectionSnapshot {
+            name: self.name.clone(),
+            dim: self.dim,
+            metric: self.metric,
+            index: self.index.to_snapshot(),
+            meta: self.meta.clone(),
+        }
+    }
+
+    pub fn from_snapshot(snap: CollectionSnapshot) -> Self {
+        Self::with_index(snap.name, snap.dim, snap.metric, snap.index.into_box())
+            .with_meta(snap.meta)
+    }
+}
+
+impl CollectionManager {
+    pub fn to_snapshot(&self) -> ManagerSnapshot {
+        ManagerSnapshot {
+            collections: self.all_collections().map(|c| c.to_snapshot()).collect(),
+        }
+    }
+
+    pub fn from_snapshot(snap: ManagerSnapshot) -> Self {
+        let mut mgr = CollectionManager::new();
+        for col_snap in snap.collections {
+            mgr.insert_collection(Collection::from_snapshot(col_snap));
+        }
+        mgr
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `crates/likhadb-persist` — new crate that serializes the full `CollectionManager` state (all collections, index graphs, payloads) to a single binary file via `bincode`
- Opt-in `serde` feature on `likhadb-index` adds `Serialize`/`Deserialize`/`Clone` to all three index types and their internal structs; a new `IndexSnapshot` enum bridges `Box<dyn VectorIndex>` to a concrete serializable type via `VectorIndex::to_snapshot()`
- Opt-in `persist` feature on `likhadb-store` derives serde on `MetaStore` (with a JSON-string wrapper for `serde_json::Value`, which bincode cannot handle via `deserialize_any`); adds `CollectionSnapshot`/`ManagerSnapshot` structs and `to_snapshot`/`from_snapshot` on both `Collection` and `CollectionManager`
- `PersistExt` extension trait exposes `mgr.save(path)` and `CollectionManager::load(path)`; 16 GiB size cap on deserialization prevents a corrupt length field from triggering a multi-terabyte allocation

## Test plan

- [x] `flat_round_trip` — FlatIndex: insert 100 vecs + payloads, save, reload, assert top-5 IDs and payload values identical
- [x] `ivf_round_trip` — IvfIndex with `nprobe=nlist` (exact), assert result sets match
- [x] `ivf_sq8_round_trip` — IVF+SQ8, assert ≥4/5 recall overlap after round-trip
- [x] `hnsw_round_trip` — HnswIndex, assert ≥90% recall overlap on top-10
- [x] `multi_collection_round_trip` — 3 collections of different types in one manager; verify all present with correct `index_type()` after reload
- [x] `empty_manager_round_trip` — empty manager saves and loads cleanly
- [x] `missing_file_returns_io_error` — `load` on non-existent path returns `PersistError::Io`
- [x] `corrupt_file_returns_decode_error` — garbage bytes return `PersistError::Decode` (not a crash)
- [x] Full workspace `cargo test --workspace` passes (134 tests)
- [x] `cargo clippy --workspace -- -D warnings` clean

## Key design decisions

**Format: `bincode`** — vector data is dominated by `Vec<f32>` slabs; JSON would inflate them 4/3× via base64. `bincode` writes raw bytes with near-zero overhead.

**`IndexSnapshot` enum (externally tagged)** — `#[serde(tag = "type")]` (internally tagged) requires `deserialize_any` which bincode does not support. The default externally-tagged enum representation works correctly.

**`serde_json::Value` wrapper** — bincode also cannot deserialize `serde_json::Value` directly (`deserialize_any`). `MetaStore.payloads` is serialized as `HashMap<VecId, String>` where each value is the JSON string encoding of the payload, then parsed back on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)