### PR TITLE
feat: WAL crash durability (B2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ the store or API layers.
 
 ## Query flows
 
-### Entry path (all index types)
+### Read path (all index types)
 
-Every query enters through the same store-layer path regardless of index type.
+Every search enters through the same store-layer path regardless of index type.
+With `WalManager`, reads delegate straight to the inner `CollectionManager` with no WAL involvement.
 
 ```mermaid
 flowchart TD
-    U([User]) -->|"mgr.get(&quot;col&quot;)?.search(query, k, predicate, include_payload)"| CM[CollectionManager]
+    U([User]) -->|"wal.get(&quot;col&quot;)?.search(query, k, predicate, include_payload)\nor mgr.get(&quot;col&quot;)?.search(...)"| EP{Entry point}
+    EP -->|WalManager| WAL_RD["WalManager::get — read-through\n(no WAL, no lock)"]
+    EP -->|CollectionManager| CM[CollectionManager]
+    WAL_RD --> CM
     CM --> C[Collection::search]
     C --> MF["MetaStore::make_filter(predicate)\nOption&lt;Box&lt;dyn Fn(VecId) → bool&gt;&gt;"]
     MF --> IDX{"index.search(query, k, filter)"}
@@ -42,6 +46,70 @@ flowchart TD
     PL -->|yes| META["MetaStore::get(id)\nattach payload to each result"]
     PL -->|no| OUT
     META --> OUT([Vec&lt;ScoredResult&gt; returned to user])
+```
+
+---
+
+### Write path (WalManager)
+
+Every mutation is durably logged **before** it is applied in memory.
+The WAL entry is flushed to `wal.log` before the in-memory store is touched — on crash, the uncommitted tail is simply ignored on recovery.
+
+```mermaid
+flowchart TD
+    U([User]) -->|"wal.insert / delete /\ncreate_collection / drop_collection"| WM[WalManager]
+    WM --> BUILD["build WalEntry { lsn, op }\nlsn = self.next_lsn"]
+    BUILD --> SER["bincode::serialize(WalEntry)"]
+    SER --> FRAME["write_frame to BufWriter\n[len: u32][crc32: u32][payload]"]
+    FRAME --> FLUSH["BufWriter::flush — ensure bytes reach OS"]
+    FLUSH --> LSN["next_lsn += 1"]
+    LSN --> APPLY["apply op to inner CollectionManager\n(get_mut / create_collection / drop_collection)"]
+    APPLY --> DONE([Ok returned to user])
+
+    FLUSH -->|"crash here"| CRASH["frame never committed\nnext open: FrameIter stops at truncated tail"]
+```
+
+---
+
+### Recovery on startup (`WalManager::open`)
+
+```mermaid
+flowchart TD
+    START([WalManager::open]) --> SNAP{snapshot.bin\nexists?}
+
+    SNAP -->|yes| LOAD["CollectionManager::load(snapshot.bin)\nread last_lsn from ManagerSnapshot"]
+    SNAP -->|no| EMPTY["inner = CollectionManager::new()\nsnapshot_lsn = 0"]
+
+    LOAD & EMPTY --> WAL_Q{wal.log\nexists?}
+
+    WAL_Q -->|no| OPEN_WAL
+    WAL_Q -->|yes| ITER["FrameIter over wal.log\nfor each frame:"]
+    ITER --> CRC{"CRC OK?"}
+    CRC -->|"no — tail frame"| STOP_ITER["stop iteration\n(partial crash write — safe to discard)"]
+    CRC -->|"no — mid-log"| ERR([Err PersistError::Crc])
+    CRC -->|yes| DESER["bincode::deserialize WalEntry"]
+    DESER --> SKIP{"entry.lsn\n≤ snapshot_lsn?"}
+    SKIP -->|yes| ITER
+    SKIP -->|no| REPLAY["apply_op(&mut inner, entry.op)\nCreateCollection is idempotent"]
+    REPLAY --> ITER
+
+    STOP_ITER --> OPEN_WAL["open wal.log in append mode"]
+    OPEN_WAL --> READY([WalManager ready])
+```
+
+---
+
+### Checkpoint
+
+Checkpoint bounds recovery time by collapsing all replayed WAL entries into a fresh snapshot, then truncating the log.
+
+```mermaid
+flowchart TD
+    U([caller: wal.checkpoint]) --> SNAP["serialize inner CollectionManager\nto snapshot.bin.tmp\n(with last_lsn embedded)"]
+    SNAP --> RENAME["rename snapshot.bin.tmp → snapshot.bin\n(atomic on POSIX — crash-safe)"]
+    RENAME --> TRUNC["truncate wal.log to zero bytes"]
+    TRUNC --> REOPEN["reopen wal.log in append mode\n(self.wal = fresh WalWriter)"]
+    REOPEN --> DONE([Ok — next open replays 0 WAL entries])
 ```
 
 ---
@@ -158,7 +226,7 @@ likhadb/
 │   ├── likhadb-core/    # Primitives: VecId, Vector, ScoredResult, Metric, distance kernels
 │   ├── likhadb-index/   # VectorIndex trait + FlatIndex + IvfIndex + HnswIndex
 │   ├── likhadb-store/   # Collection, CollectionManager, MetaStore (JSON filtering)
-│   ├── likhadb-persist/ # Snapshot serialization — save/load CollectionManager to disk
+│   ├── likhadb-persist/ # Snapshot + WAL persistence — PersistExt (save/load) + WalManager
 │   └── likhadb-bench/   # Criterion benchmarks
 └── images/
 ```
@@ -168,7 +236,7 @@ likhadb/
 | `likhadb-core` | Shared primitives and error types — no index logic |
 | `likhadb-index` | `VectorIndex` trait (the extension seam) + `FlatIndex` + `IvfIndex` + `HnswIndex` |
 | `likhadb-store` | `Collection` wraps an index + metadata; `CollectionManager` names them |
-| `likhadb-persist` | Point-in-time snapshots via `bincode`; `PersistExt` trait adds `save`/`load` to `CollectionManager` |
+| `likhadb-persist` | Snapshot (`PersistExt`) + Write-Ahead Log (`WalManager`) — durable mutations, crash recovery, checkpoint |
 | `likhadb-bench` | Criterion benchmarks for 1 k / 10 k / 100 k vectors |
 
 ## Features
@@ -209,6 +277,15 @@ likhadb/
 - **All three index types supported** — `FlatIndex`, `IvfIndex` (including SQ8), `HnswIndex` round-trip correctly including graph structure, tombstones, and training state
 - **Safe deserialization** — 16 GiB size cap prevents corrupt length fields from triggering multi-terabyte allocation attempts
 - **Extension trait API** — import `PersistExt` and call `mgr.save(path)` / `CollectionManager::load(path)`
+
+### Tier 4 B2 — Write-Ahead Log (`WalManager`)
+
+- **Crash durability** — every mutation (insert, delete, create/drop collection) is flushed to `wal.log` before being applied in memory; uncommitted tail entries are silently discarded on recovery
+- **Framed log format** — each record carries a 32-bit CRC checksum; mid-log corruption surfaces as `PersistError::Crc`, tail truncation is treated as a clean end-of-log
+- **LSN-based recovery** — snapshot embeds `last_lsn`; on restart only entries newer than the snapshot are replayed, making recovery sub-second for reasonable WAL sizes
+- **Atomic checkpoint** — `WalManager::checkpoint()` writes a new snapshot to `snapshot.bin.tmp`, renames it atomically, then truncates `wal.log`; a crash during checkpoint leaves the old snapshot intact
+- **All four DDL/DML operations logged** — `CreateCollection`, `DropCollection`, `Insert`, `Delete`; replay of `CreateCollection` is idempotent
+- **All index types supported** — `FlatIndex`, `IvfIndex`, `IvfSq8`, `HnswIndex` all survive WAL round-trips
 
 ## Getting started
 
@@ -381,6 +458,35 @@ let mgr = CollectionManager::load(Path::new("snapshot.bin")).unwrap();
 
 All three index types (`FlatIndex`, `IvfIndex`/SQ8, `HnswIndex`) survive the round-trip, including HNSW graph edges, IVF training state, and JSON payloads.
 
+### WAL (Write-Ahead Log)
+
+```rust
+use std::path::Path;
+use likhadb_core::Metric;
+use likhadb_persist::WalManager;
+
+// Open (or create) a data directory.
+// On first run: creates empty state.
+// On restart after a crash: loads last snapshot then replays uncommitted WAL entries.
+let mut wal = WalManager::open(Path::new("/data/mydb")).unwrap();
+
+// All write operations are logged to wal.log before being applied.
+wal.create_collection("docs", 384, Metric::Cosine).unwrap();
+wal.insert("docs", 1, vec![0.1; 384], Some(serde_json::json!({"title": "hello"}))).unwrap();
+wal.insert("docs", 2, vec![0.9; 384], None).unwrap();
+wal.delete("docs", 1).unwrap();
+
+// Reads delegate straight through — no WAL overhead.
+let results = wal.get("docs").unwrap()
+    .search(&[0.5; 384], 10, None, false).unwrap();
+
+// Checkpoint: write a fresh snapshot and truncate wal.log.
+// Call on graceful shutdown or periodically to bound recovery time.
+wal.checkpoint().unwrap();
+```
+
+After a crash (before `checkpoint`), reopening the same directory replays all logged mutations automatically. No data loss for committed writes.
+
 ## Distance metrics
 
 | Metric | Formula | Best for |
@@ -437,7 +543,8 @@ Rayon uses the default thread pool (all available cores).
 | **Tier 2** | Done | IVF (Inverted File Index) — approximate k-NN with k-means clustering |
 | **Tier 3** | Done | HNSW (Hierarchical Navigable Small World graphs) |
 | **Tier 4 — B1** | Done | Snapshot persistence — `CollectionManager::save` / `load` via `likhadb-persist` |
-| **Tier 4 — B2+** | Future | WAL (crash durability), HTTP + gRPC API, observability |
+| **Tier 4 — B2** | Done | WAL crash durability — `WalManager` logs every mutation, replays on restart, atomic checkpoint |
+| **Tier 4 — C+** | Future | Concurrent access (RwLock), HTTP + gRPC API, observability |
 
 All future tiers implement `VectorIndex` — the store layer is unchanged.
 

--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -10,7 +10,8 @@ likhadb-store = { path = "../likhadb-store", features = ["persist"] }
 bincode       = { workspace = true }
 thiserror     = { workspace = true }
 serde         = { workspace = true }
+serde_json    = { workspace = true }
+crc32fast     = "1"
 
 [dev-dependencies]
-serde_json    = { workspace = true }
 rand          = { workspace = true }

--- a/crates/likhadb-persist/src/error.rs
+++ b/crates/likhadb-persist/src/error.rs
@@ -8,4 +8,8 @@ pub enum PersistError {
     Encode(#[source] bincode::Error),
     #[error("decode error: {0}")]
     Decode(#[source] bincode::Error),
+    #[error("WAL CRC mismatch at mid-log frame: expected {expected:#010x}, got {got:#010x}")]
+    Crc { expected: u32, got: u32 },
+    #[error("WAL replay error: {0}")]
+    Apply(#[from] likhadb_core::LikhaDbError),
 }

--- a/crates/likhadb-persist/src/lib.rs
+++ b/crates/likhadb-persist/src/lib.rs
@@ -1,6 +1,8 @@
 mod error;
+pub mod wal;
 
 pub use error::PersistError;
+pub use wal::WalManager;
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter};

--- a/crates/likhadb-persist/src/wal/entry.rs
+++ b/crates/likhadb-persist/src/wal/entry.rs
@@ -1,0 +1,75 @@
+use likhadb_core::{Metric, VecId};
+use serde_json::Value;
+
+/// Index configuration captured at collection-creation time so WAL replay can
+/// reconstruct the right index type without touching the store layer.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum IndexKind {
+    Flat,
+    Ivf    { nlist: usize, nprobe: usize },
+    IvfSq8 { nlist: usize, nprobe: usize },
+    Hnsw   { m: usize, ef_construction: usize, ef_search: usize },
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum WalOp {
+    CreateCollection {
+        name:   String,
+        dim:    usize,
+        metric: Metric,
+        kind:   IndexKind,
+    },
+    DropCollection {
+        name: String,
+    },
+    Insert {
+        collection: String,
+        id:         VecId,
+        vector:     Vec<f32>,
+        #[serde(with = "opt_json_value_as_string")]
+        payload:    Option<Value>,
+    },
+    Delete {
+        collection: String,
+        id:         VecId,
+    },
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct WalEntry {
+    pub lsn: u64,
+    pub op:  WalOp,
+}
+
+/// Serialize `Option<serde_json::Value>` as `Option<String>` so bincode (which
+/// does not support `deserialize_any`) can handle the JSON value payload.
+mod opt_json_value_as_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S>(v: &Option<Value>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::Serialize;
+        match v {
+            Some(val) => Some(val.to_string()).serialize(s),
+            None => None::<String>.serialize(s),
+        }
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Option<Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(d)?;
+        match s {
+            None => Ok(None),
+            Some(raw) => {
+                let v: Value =
+                    serde_json::from_str(&raw).map_err(serde::de::Error::custom)?;
+                Ok(Some(v))
+            }
+        }
+    }
+}

--- a/crates/likhadb-persist/src/wal/frame.rs
+++ b/crates/likhadb-persist/src/wal/frame.rs
@@ -1,0 +1,98 @@
+use std::io::{self, Read, Write};
+
+use crc32fast::Hasher;
+
+/// Write a length-prefixed, CRC32-checksummed frame.
+///
+/// Format: `[payload_len: u32 LE][crc32: u32 LE][payload: payload_len bytes]`
+pub fn write_frame(w: &mut impl Write, payload: &[u8]) -> io::Result<()> {
+    let len = payload.len() as u32;
+    let crc = checksum(payload);
+    w.write_all(&len.to_le_bytes())?;
+    w.write_all(&crc.to_le_bytes())?;
+    w.write_all(payload)
+}
+
+/// Read one frame.  Returns `None` when the stream ends cleanly at a frame
+/// boundary *or* when the last frame is truncated / CRC-mismatched (crash at
+/// tail).  Returns `Some(Err(_))` only for genuine mid-log I/O or CRC errors.
+pub fn read_frame(r: &mut impl Read) -> io::Result<Option<(Vec<u8>, u32)>> {
+    // Read the 4-byte length prefix.
+    let mut len_buf = [0u8; 4];
+    match r.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let payload_len = u32::from_le_bytes(len_buf) as usize;
+
+    // Read the 4-byte stored CRC.
+    let mut crc_buf = [0u8; 4];
+    match r.read_exact(&mut crc_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let stored_crc = u32::from_le_bytes(crc_buf);
+
+    // Read the payload.
+    let mut payload = vec![0u8; payload_len];
+    match r.read_exact(&mut payload) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+
+    Ok(Some((payload, stored_crc)))
+}
+
+pub fn checksum(data: &[u8]) -> u32 {
+    let mut h = Hasher::new();
+    h.update(data);
+    h.finalize()
+}
+
+/// Iterator over frames in a WAL file.  Stops at the first truncated/corrupt
+/// tail frame (sets `self.done = true`).  Mid-log CRC errors are surfaced as
+/// `Err` items so callers can distinguish them from a clean end-of-log.
+pub struct FrameIter<R> {
+    reader: R,
+    /// Frames successfully read so far — used to distinguish tail vs mid-log.
+    count: u64,
+    done: bool,
+}
+
+impl<R: Read> FrameIter<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader, count: 0, done: false }
+    }
+
+    pub fn frames_read(&self) -> u64 {
+        self.count
+    }
+}
+
+impl<R: Read> Iterator for FrameIter<R> {
+    /// `(raw_payload_bytes, stored_crc)`
+    type Item = io::Result<(Vec<u8>, u32)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        match read_frame(&mut self.reader) {
+            Ok(None) => {
+                self.done = true;
+                None
+            }
+            Ok(Some(frame)) => {
+                self.count += 1;
+                Some(Ok(frame))
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(e))
+            }
+        }
+    }
+}

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -1,0 +1,309 @@
+mod entry;
+mod frame;
+mod recovery;
+
+pub use entry::{IndexKind, WalEntry, WalOp};
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use bincode::Options as _;
+use likhadb_core::{Metric, VecId, Vector};
+use likhadb_store::{Collection, CollectionManager};
+use serde_json::Value;
+
+use crate::{bincode_opts, PersistError, PersistExt};
+use frame::{checksum, write_frame, FrameIter};
+use recovery::apply_op;
+
+// ── WalWriter ──────────────────────────────────────────────────────────────
+
+struct WalWriter {
+    file: BufWriter<File>,
+}
+
+impl WalWriter {
+    fn open_append(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self { file: BufWriter::new(file) })
+    }
+
+    fn append(&mut self, entry: &WalEntry) -> Result<(), PersistError> {
+        let payload = bincode_opts().serialize(entry).map_err(PersistError::Encode)?;
+        write_frame(&mut self.file, &payload).map_err(PersistError::Io)?;
+        self.file.flush().map_err(PersistError::Io)
+    }
+
+    fn truncate(path: &Path) -> std::io::Result<()> {
+        File::create(path)?; // O_TRUNC
+        Ok(())
+    }
+}
+
+// ── WalManager ─────────────────────────────────────────────────────────────
+
+/// A `CollectionManager` wrapper that durably logs every mutation to a
+/// Write-Ahead Log before applying it in memory.
+///
+/// # Data directory layout
+/// ```text
+/// <dir>/
+///   snapshot.bin      ← full snapshot (written on checkpoint)
+///   wal.log           ← append-only WAL
+/// ```
+///
+/// # Recovery
+/// On [`WalManager::open`], if a snapshot exists it is loaded first.  Then any
+/// WAL entries with LSN greater than the snapshot's `last_lsn` are replayed in
+/// order.  A truncated or CRC-corrupt tail frame (crash mid-write) is silently
+/// discarded — it was never committed.
+///
+/// # Error type
+/// All write methods return `Result<_, PersistError>` rather than
+/// `likhadb_core::Result<_>` because WAL I/O errors are distinct from logic
+/// errors and must be surfaced to the caller.
+pub struct WalManager {
+    inner:    CollectionManager,
+    wal:      WalWriter,
+    next_lsn: u64,
+    dir:      PathBuf,
+}
+
+impl WalManager {
+    const SNAPSHOT_FILE: &'static str = "snapshot.bin";
+    const WAL_FILE: &'static str = "wal.log";
+
+    /// Open (or create) a data directory, recovering from any existing
+    /// snapshot + WAL.
+    pub fn open(dir: &Path) -> Result<Self, PersistError> {
+        std::fs::create_dir_all(dir).map_err(PersistError::Io)?;
+
+        let snapshot_path = dir.join(Self::SNAPSHOT_FILE);
+        let wal_path      = dir.join(Self::WAL_FILE);
+
+        // 1. Load snapshot (if present).
+        let (mut inner, snapshot_lsn) = if snapshot_path.exists() {
+            let lsn = Self::read_snapshot_lsn(&snapshot_path)?;
+            let mgr = CollectionManager::load(&snapshot_path)?;
+            (mgr, lsn)
+        } else {
+            (CollectionManager::new(), 0)
+        };
+
+        // 2. Replay WAL entries newer than the snapshot.
+        let mut next_lsn = snapshot_lsn + 1;
+        if wal_path.exists() {
+            next_lsn = Self::replay_wal(&wal_path, &mut inner, snapshot_lsn)?;
+        }
+
+        // 3. Open WAL for appending.
+        let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+
+        Ok(Self { inner, wal, next_lsn, dir: dir.to_path_buf() })
+    }
+
+    fn read_snapshot_lsn(path: &Path) -> Result<u64, PersistError> {
+        use likhadb_store::ManagerSnapshot;
+        let file   = File::open(path).map_err(PersistError::Io)?;
+        let reader = BufReader::new(file);
+        let snap: ManagerSnapshot = bincode_opts()
+            .deserialize_from(reader)
+            .map_err(PersistError::Decode)?;
+        Ok(snap.last_lsn)
+    }
+
+    /// Replay WAL entries with LSN > `snapshot_lsn`.  Returns the `next_lsn`
+    /// to use for new writes.
+    fn replay_wal(
+        path:         &Path,
+        mgr:          &mut CollectionManager,
+        snapshot_lsn: u64,
+    ) -> Result<u64, PersistError> {
+        let file   = File::open(path).map_err(PersistError::Io)?;
+        let reader = BufReader::new(file);
+        let mut iter     = FrameIter::new(reader);
+        let mut last_lsn = snapshot_lsn;
+
+        for item in &mut iter {
+            let (payload, stored_crc) = item.map_err(PersistError::Io)?;
+
+            let computed = checksum(&payload);
+            if computed != stored_crc {
+                // Tail corruption: stop replay (last write was mid-frame crash).
+                if iter.frames_read() <= 1 {
+                    break;
+                }
+                return Err(PersistError::Crc { expected: stored_crc, got: computed });
+            }
+
+            let entry: WalEntry = bincode_opts()
+                .deserialize(&payload)
+                .map_err(PersistError::Decode)?;
+
+            if entry.lsn <= snapshot_lsn {
+                continue;
+            }
+
+            apply_op(mgr, entry.op)?;
+            last_lsn = entry.lsn;
+        }
+
+        Ok(last_lsn + 1)
+    }
+
+    /// Append a WAL entry then apply `f` to the inner manager.
+    fn log_and_apply<F>(&mut self, op: WalOp, f: F) -> Result<(), PersistError>
+    where
+        F: FnOnce(&mut CollectionManager) -> likhadb_core::Result<()>,
+    {
+        let entry = WalEntry { lsn: self.next_lsn, op };
+        self.wal.append(&entry)?;
+        self.next_lsn += 1;
+        f(&mut self.inner).map_err(PersistError::Apply)
+    }
+
+    // ── Collection DDL ─────────────────────────────────────────────────────
+
+    pub fn create_collection(
+        &mut self,
+        name: impl Into<String>,
+        dim: usize,
+        metric: Metric,
+    ) -> Result<(), PersistError> {
+        let name = name.into();
+        self.log_and_apply(
+            WalOp::CreateCollection { name: name.clone(), dim, metric, kind: IndexKind::Flat },
+            |mgr| mgr.create_collection(name, dim, metric),
+        )
+    }
+
+    pub fn create_ivf_collection(
+        &mut self,
+        name: impl Into<String>,
+        dim: usize,
+        metric: Metric,
+        nlist: usize,
+        nprobe: usize,
+    ) -> Result<(), PersistError> {
+        let name = name.into();
+        self.log_and_apply(
+            WalOp::CreateCollection {
+                name: name.clone(), dim, metric,
+                kind: IndexKind::Ivf { nlist, nprobe },
+            },
+            |mgr| mgr.create_ivf_collection(name, dim, metric, nlist, nprobe),
+        )
+    }
+
+    pub fn create_ivf_sq8_collection(
+        &mut self,
+        name: impl Into<String>,
+        dim: usize,
+        metric: Metric,
+        nlist: usize,
+        nprobe: usize,
+    ) -> Result<(), PersistError> {
+        let name = name.into();
+        self.log_and_apply(
+            WalOp::CreateCollection {
+                name: name.clone(), dim, metric,
+                kind: IndexKind::IvfSq8 { nlist, nprobe },
+            },
+            |mgr| mgr.create_ivf_sq8_collection(name, dim, metric, nlist, nprobe),
+        )
+    }
+
+    pub fn create_hnsw_collection(
+        &mut self,
+        name: impl Into<String>,
+        dim: usize,
+        metric: Metric,
+        m: usize,
+        ef_construction: usize,
+        ef_search: usize,
+    ) -> Result<(), PersistError> {
+        let name = name.into();
+        self.log_and_apply(
+            WalOp::CreateCollection {
+                name: name.clone(), dim, metric,
+                kind: IndexKind::Hnsw { m, ef_construction, ef_search },
+            },
+            |mgr| mgr.create_hnsw_collection(name, dim, metric, m, ef_construction, ef_search),
+        )
+    }
+
+    pub fn drop_collection(&mut self, name: &str) -> Result<(), PersistError> {
+        let name = name.to_owned();
+        self.log_and_apply(
+            WalOp::DropCollection { name: name.clone() },
+            |mgr| mgr.drop_collection(&name),
+        )
+    }
+
+    // ── Vector DML ─────────────────────────────────────────────────────────
+
+    pub fn insert(
+        &mut self,
+        collection: &str,
+        id: VecId,
+        vector: Vector,
+        payload: Option<Value>,
+    ) -> Result<(), PersistError> {
+        let col = collection.to_owned();
+        self.log_and_apply(
+            WalOp::Insert {
+                collection: col.clone(), id,
+                vector: vector.clone(),
+                payload: payload.clone(),
+            },
+            |mgr| mgr.get_mut(&col)?.insert(id, vector, payload),
+        )
+    }
+
+    pub fn delete(&mut self, collection: &str, id: VecId) -> Result<bool, PersistError> {
+        let col   = collection.to_owned();
+        let entry = WalEntry { lsn: self.next_lsn, op: WalOp::Delete { collection: col.clone(), id } };
+        self.wal.append(&entry)?;
+        self.next_lsn += 1;
+        self.inner.get_mut(&col)?.delete(id).map_err(PersistError::Apply)
+    }
+
+    // ── Read-through ────────────────────────────────────────────────────────
+
+    pub fn get(&self, name: &str) -> likhadb_core::Result<&Collection> {
+        self.inner.get(name)
+    }
+
+    pub fn list(&self) -> Vec<&str> {
+        self.inner.list()
+    }
+
+    // ── Checkpoint ─────────────────────────────────────────────────────────
+
+    /// Write a snapshot capturing the current state (including `last_lsn`),
+    /// then truncate `wal.log`.  Call on graceful shutdown or periodically to
+    /// bound recovery time.
+    pub fn checkpoint(&mut self) -> Result<(), PersistError> {
+        let last_lsn      = self.next_lsn.saturating_sub(1);
+        let snapshot_path = self.dir.join(Self::SNAPSHOT_FILE);
+        let tmp_path      = self.dir.join("snapshot.bin.tmp");
+        let wal_path      = self.dir.join(Self::WAL_FILE);
+
+        // Write snapshot to tmp then atomically rename.
+        {
+            use likhadb_store::ManagerSnapshot;
+            let snap: ManagerSnapshot = self.inner.to_snapshot_with_lsn(last_lsn);
+            let file   = File::create(&tmp_path).map_err(PersistError::Io)?;
+            let writer = BufWriter::new(file);
+            bincode_opts().serialize_into(writer, &snap).map_err(PersistError::Encode)?;
+        }
+        std::fs::rename(&tmp_path, &snapshot_path).map_err(PersistError::Io)?;
+
+        // Truncate WAL and reopen for appending.
+        WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;
+        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+
+        Ok(())
+    }
+}

--- a/crates/likhadb-persist/src/wal/recovery.rs
+++ b/crates/likhadb-persist/src/wal/recovery.rs
@@ -1,0 +1,51 @@
+use likhadb_core::LikhaDbError;
+use likhadb_store::CollectionManager;
+
+use crate::PersistError;
+
+use super::entry::{IndexKind, WalOp};
+
+/// Apply a single WAL operation to a live `CollectionManager`.
+///
+/// `CreateCollection` is idempotent: if the collection already exists (e.g.
+/// replaying after a partial checkpoint), the op is silently skipped.
+pub fn apply_op(mgr: &mut CollectionManager, op: WalOp) -> Result<(), PersistError> {
+    match op {
+        WalOp::CreateCollection { name, dim, metric, kind } => {
+            let result = match kind {
+                IndexKind::Flat => mgr.create_collection(name, dim, metric),
+                IndexKind::Ivf { nlist, nprobe } => {
+                    mgr.create_ivf_collection(name, dim, metric, nlist, nprobe)
+                }
+                IndexKind::IvfSq8 { nlist, nprobe } => {
+                    mgr.create_ivf_sq8_collection(name, dim, metric, nlist, nprobe)
+                }
+                IndexKind::Hnsw { m, ef_construction, ef_search } => {
+                    mgr.create_hnsw_collection(name, dim, metric, m, ef_construction, ef_search)
+                }
+            };
+            // Idempotent: ignore "already exists" errors that can occur when
+            // replaying WAL entries that were also captured in the snapshot.
+            match result {
+                Ok(()) | Err(LikhaDbError::CollectionAlreadyExists(_)) => Ok(()),
+                Err(e) => Err(PersistError::Apply(e)),
+            }
+        }
+        WalOp::DropCollection { name } => {
+            match mgr.drop_collection(&name) {
+                Ok(()) | Err(LikhaDbError::CollectionNotFound(_)) => Ok(()),
+                Err(e) => Err(PersistError::Apply(e)),
+            }
+        }
+        WalOp::Insert { collection, id, vector, payload } => {
+            mgr.get_mut(&collection)
+                .and_then(|col| col.insert(id, vector, payload))
+                .map_err(PersistError::Apply)
+        }
+        WalOp::Delete { collection, id } => {
+            mgr.get_mut(&collection)
+                .and_then(|col| col.delete(id).map(|_| ()))
+                .map_err(PersistError::Apply)
+        }
+    }
+}

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,0 +1,261 @@
+
+use likhadb_core::Metric;
+use likhadb_persist::{PersistError, WalManager};
+use serde_json::json;
+
+fn tmp_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir()
+        .join(format!("likhadb_wal_{label}_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+// ── Basic open / create ────────────────────────────────────────────────────
+
+#[test]
+fn open_empty_dir_succeeds() {
+    let dir = tmp_dir("open_empty");
+    let mgr = WalManager::open(&dir).unwrap();
+    assert!(mgr.list().is_empty());
+}
+
+// ── Insert survives restart ────────────────────────────────────────────────
+
+#[test]
+fn insert_survives_restart() {
+    let dir = tmp_dir("insert_restart");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        for i in 0..10u64 {
+            mgr.insert("col", i, vec![i as f32, 0.0, 0.0, 0.0], None).unwrap();
+        }
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("col").unwrap()
+        .search(&[0.0; 4], 10, None, false).unwrap();
+    assert_eq!(results.len(), 10);
+}
+
+// ── Delete survives restart ────────────────────────────────────────────────
+
+#[test]
+fn delete_survives_restart() {
+    let dir = tmp_dir("delete_restart");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        for i in 0..5u64 {
+            mgr.insert("col", i, vec![i as f32, 0.0, 0.0, 0.0], None).unwrap();
+        }
+        mgr.delete("col", 0).unwrap();
+        mgr.delete("col", 1).unwrap();
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("col").unwrap()
+        .search(&[0.0; 4], 10, None, false).unwrap();
+    assert_eq!(results.len(), 3);
+    let ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+    assert!(!ids.contains(&0));
+    assert!(!ids.contains(&1));
+}
+
+// ── Payload survives restart ───────────────────────────────────────────────
+
+#[test]
+fn payload_survives_restart() {
+    let dir = tmp_dir("payload_restart");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"tag": "cat"}))).unwrap();
+        mgr.insert("col", 2, vec![2.0, 0.0, 0.0, 0.0], None).unwrap();
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("col").unwrap()
+        .search(&[0.0; 4], 2, None, true).unwrap();
+    assert_eq!(results.len(), 2);
+    let r1 = results.iter().find(|r| r.id == 1).unwrap();
+    assert_eq!(r1.payload.as_ref().unwrap()["tag"], json!("cat"));
+    let r2 = results.iter().find(|r| r.id == 2).unwrap();
+    assert!(r2.payload.is_none());
+}
+
+// ── DDL survives restart ───────────────────────────────────────────────────
+
+#[test]
+fn create_drop_collection_survives_restart() {
+    let dir = tmp_dir("ddl_restart");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("a", 4, Metric::L2).unwrap();
+        mgr.create_collection("b", 4, Metric::L2).unwrap();
+        mgr.drop_collection("a").unwrap();
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    assert_eq!(mgr.list(), vec!["b"]);
+}
+
+// ── Checkpoint clears WAL ──────────────────────────────────────────────────
+
+#[test]
+fn checkpoint_clears_wal() {
+    let dir = tmp_dir("checkpoint");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None).unwrap();
+        mgr.checkpoint().unwrap();
+    }
+
+    let wal_path = dir.join("wal.log");
+    assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), 0, "WAL should be empty after checkpoint");
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("col").unwrap()
+        .search(&[0.0; 4], 1, None, false).unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+// ── Recovery across checkpoint boundary ───────────────────────────────────
+
+#[test]
+fn recovery_across_checkpoint_boundary() {
+    let dir = tmp_dir("checkpoint_boundary");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None).unwrap();
+        mgr.checkpoint().unwrap();
+        // Writes after checkpoint go to fresh WAL.
+        mgr.insert("col", 2, vec![2.0, 0.0, 0.0, 0.0], None).unwrap();
+        mgr.insert("col", 3, vec![3.0, 0.0, 0.0, 0.0], None).unwrap();
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("col").unwrap()
+        .search(&[0.0; 4], 10, None, false).unwrap();
+    assert_eq!(results.len(), 3, "all 3 vectors should be present");
+    let ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2));
+    assert!(ids.contains(&3));
+}
+
+// ── Truncated tail is silently ignored ────────────────────────────────────
+
+#[test]
+fn truncated_wal_tail_is_ignored() {
+    let dir = tmp_dir("truncated_tail");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None).unwrap();
+        // id=2 will be partially written (simulated by truncation below).
+        mgr.insert("col", 2, vec![2.0, 0.0, 0.0, 0.0], None).unwrap();
+    }
+
+    // Truncate the last 3 bytes of wal.log to simulate a crash mid-write.
+    let wal_path = dir.join("wal.log");
+    let original_len = std::fs::metadata(&wal_path).unwrap().len();
+    let truncated_len = original_len.saturating_sub(3);
+    let file = std::fs::OpenOptions::new().write(true).open(&wal_path).unwrap();
+    file.set_len(truncated_len).unwrap();
+
+    // Recovery should succeed and the last incomplete entry should be dropped.
+    // (At minimum id=1's CreateCollection must survive; id=2 may be gone.)
+    let mgr = WalManager::open(&dir).unwrap();
+    assert!(mgr.get("col").is_ok(), "collection should survive tail truncation");
+}
+
+// ── Mid-log CRC corruption returns an error ────────────────────────────────
+
+#[test]
+fn mid_log_corruption_is_error() {
+    let dir = tmp_dir("mid_log_corrupt");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None).unwrap();
+        mgr.insert("col", 2, vec![2.0, 0.0, 0.0, 0.0], None).unwrap();
+    }
+
+    // Flip a byte in the middle of the WAL (past the first frame).
+    let wal_path = dir.join("wal.log");
+    let mut data = std::fs::read(&wal_path).unwrap();
+    let mid = data.len() / 2;
+    data[mid] ^= 0xFF;
+    std::fs::write(&wal_path, &data).unwrap();
+
+    let result = WalManager::open(&dir);
+    assert!(
+        matches!(result, Err(PersistError::Crc { .. })),
+        "mid-log CRC corruption should surface as PersistError::Crc"
+    );
+}
+
+// ── All index types survive restart ───────────────────────────────────────
+
+#[test]
+fn all_index_types_survive_restart() {
+    let dir = tmp_dir("all_index_types");
+    let n = 20u64;
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("flat", 4, Metric::L2).unwrap();
+        mgr.create_ivf_collection("ivf", 4, Metric::L2, 4, 4).unwrap();
+        mgr.create_hnsw_collection("hnsw", 4, Metric::L2, 4, 8, 4).unwrap();
+
+        for i in 0..n {
+            let v = vec![i as f32, 0.0, 0.0, 0.0];
+            mgr.insert("flat", i, v.clone(), None).unwrap();
+            mgr.insert("ivf",  i, v.clone(), None).unwrap();
+            mgr.insert("hnsw", i, v.clone(), None).unwrap();
+        }
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    for col_name in ["flat", "ivf", "hnsw"] {
+        let col = mgr.get(col_name).unwrap();
+        let results = col.search(&[0.0; 4], 5, None, false).unwrap();
+        assert_eq!(results.len(), 5, "{col_name} should return 5 results after restart");
+        // Results must be sorted ascending.
+        for w in results.windows(2) {
+            assert!(w[0].score <= w[1].score, "{col_name}: results not sorted");
+        }
+    }
+}
+
+// ── IVF-SQ8 survives restart ───────────────────────────────────────────────
+
+#[test]
+fn ivf_sq8_survives_restart() {
+    let dir = tmp_dir("ivf_sq8_restart");
+    let nlist = 4usize;
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_ivf_sq8_collection("sq8", 4, Metric::L2, nlist, nlist).unwrap();
+        for i in 0..(nlist + 20) as u64 {
+            mgr.insert("sq8", i, vec![i as f32, 0.0, 0.0, 0.0], None).unwrap();
+        }
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr.get("sq8").unwrap()
+        .search(&[0.0; 4], 5, None, false).unwrap();
+    assert_eq!(results.len(), 5);
+}

--- a/crates/likhadb-store/src/snapshot.rs
+++ b/crates/likhadb-store/src/snapshot.rs
@@ -17,6 +17,8 @@ pub struct CollectionSnapshot {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ManagerSnapshot {
     pub collections: Vec<CollectionSnapshot>,
+    #[serde(default)]
+    pub last_lsn: u64,
 }
 
 impl Collection {
@@ -38,8 +40,13 @@ impl Collection {
 
 impl CollectionManager {
     pub fn to_snapshot(&self) -> ManagerSnapshot {
+        self.to_snapshot_with_lsn(0)
+    }
+
+    pub fn to_snapshot_with_lsn(&self, last_lsn: u64) -> ManagerSnapshot {
         ManagerSnapshot {
             collections: self.all_collections().map(|c| c.to_snapshot()).collect(),
+            last_lsn,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `WalManager` to `likhadb-persist` — a `CollectionManager` wrapper that logs every mutation to an append-only WAL before applying it in memory
- On restart, entries logged after the last snapshot are replayed; truncated tail frames (crash mid-write) are silently discarded
- Atomic checkpoint collapses WAL into a fresh snapshot then truncates the log

## Design

**Frame format:** `[payload_len: u32 LE][crc32: u32 LE][payload]`  
Mid-log CRC mismatch → `PersistError::Crc` (hard error). Tail truncation → clean end-of-log.

**LSN-based recovery:** `ManagerSnapshot` now embeds `last_lsn`; only WAL entries newer than the snapshot are replayed, keeping startup fast regardless of WAL size.

**Checkpoint:** write `snapshot.bin.tmp` → atomic rename → truncate `wal.log`. A crash during checkpoint leaves the previous snapshot intact.

**All four ops logged:** `CreateCollection`, `DropCollection`, `Insert`, `Delete`. Replay of `CreateCollection` is idempotent.

## New files

| File | Role |
|---|---|
| `src/wal/frame.rs` | `write_frame` / `read_frame` / `FrameIter` (CRC32 framing) |
| `src/wal/entry.rs` | `WalEntry`, `WalOp`, `IndexKind` serde types; `opt_json_value_as_string` for bincode-safe payload |
| `src/wal/recovery.rs` | `apply_op` — idempotent replay of all four op variants |
| `src/wal/mod.rs` | `WalManager` (public API) + `WalWriter` (private) |
| `tests/wal_recovery.rs` | 11 integration tests |

## Test plan

- [x] `cargo test --workspace` — all 145 tests pass, no regressions to B1 snapshot tests
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] 11 WAL integration tests: insert/delete/DDL survive restart, checkpoint clears WAL, recovery across checkpoint boundary, truncated tail ignored, mid-log CRC corruption errors, all four index types (Flat/IVF/IVF-SQ8/HNSW) survive WAL round-trip

## README

Added write-path, recovery, and checkpoint Mermaid diagrams; B2 features section; WAL usage example; roadmap updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)