### PR TITLE
implement D2 - gRPC API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust stable with fmt and clippy
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ── Stage 1: install cargo-chef on a slim Rust image ─────────────────────────
 FROM rust:1.88-slim AS chef
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
+    && apt-get install -y --no-install-recommends build-essential protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -35,6 +35,7 @@ RUN mkdir /data
 VOLUME ["/data"]
 
 EXPOSE 8080
+EXPOSE 50051
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -qO- http://localhost:8080/health || exit 1

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -11,6 +11,13 @@ axum            = "0.7"
 tokio           = { version = "1", features = ["full"] }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
+tonic           = "0.12"
+prost           = "0.13"
+bytes           = "1"
+tokio-stream    = "0.1"
+
+[build-dependencies]
+tonic-build = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/likhadb-server/build.rs
+++ b/crates/likhadb-server/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/likhadb.proto")?;
+    Ok(())
+}

--- a/crates/likhadb-server/proto/likhadb.proto
+++ b/crates/likhadb-server/proto/likhadb.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+package likhadb;
+
+service LikhaDb {
+  rpc Health           (HealthRequest)          returns (HealthResponse);
+  rpc ListCollections  (ListCollectionsRequest)  returns (ListCollectionsResponse);
+  rpc CreateCollection (CreateCollectionRequest) returns (CreateCollectionResponse);
+  rpc GetCollection    (GetCollectionRequest)    returns (CollectionInfo);
+  rpc DropCollection   (DropCollectionRequest)   returns (DropCollectionResponse);
+  rpc InsertVector     (InsertVectorRequest)     returns (InsertVectorResponse);
+  rpc GetVector        (GetVectorRequest)        returns (VectorRecord);
+  rpc DeleteVector     (DeleteVectorRequest)     returns (DeleteVectorResponse);
+  rpc Query            (QueryRequest)            returns (QueryResponse);
+  // Server-streaming variant — results arrive as an async stream.
+  rpc QueryStream      (QueryRequest)            returns (stream ScoredResult);
+}
+
+// ── Health ───────────────────────────────────────────────────────────────────
+
+message HealthRequest  {}
+message HealthResponse { string status = 1; }
+
+// ── Collections ──────────────────────────────────────────────────────────────
+
+message ListCollectionsRequest  {}
+message ListCollectionsResponse { repeated string collections = 1; }
+
+message FlatConfig    {}
+message IvfConfig     { uint32 nlist = 1; uint32 nprobe = 2; }
+message IvfSq8Config  { uint32 nlist = 1; uint32 nprobe = 2; }
+message HnswConfig    { uint32 m = 1; uint32 ef_construction = 2; uint32 ef_search = 3; }
+
+message CreateCollectionRequest {
+  string name   = 1;
+  uint32 dim    = 2;
+  string metric = 3;
+  oneof index_config {
+    FlatConfig   flat    = 4;
+    IvfConfig    ivf     = 5;
+    IvfSq8Config ivf_sq8 = 6;
+    HnswConfig   hnsw    = 7;
+  }
+}
+message CreateCollectionResponse {}
+
+message GetCollectionRequest { string name = 1; }
+
+message CollectionInfo {
+  string name       = 1;
+  uint32 dim        = 2;
+  string metric     = 3;
+  uint64 count      = 4;
+  string index_type = 5;
+}
+
+message DropCollectionRequest  { string name = 1; }
+message DropCollectionResponse {}
+
+// ── Vectors ───────────────────────────────────────────────────────────────────
+
+message InsertVectorRequest {
+  string         collection   = 1;
+  uint64         id           = 2;
+  repeated float vector       = 3;
+  // JSON-encoded payload object; omit or send empty bytes for no payload.
+  bytes          payload_json = 4;
+}
+message InsertVectorResponse {}
+
+message GetVectorRequest {
+  string collection = 1;
+  uint64 id         = 2;
+}
+
+message VectorRecord {
+  uint64         id           = 1;
+  repeated float vector       = 2;
+  bytes          payload_json = 3;
+}
+
+message DeleteVectorRequest  { string collection = 1; uint64 id = 2; }
+message DeleteVectorResponse {}
+
+// ── Query ─────────────────────────────────────────────────────────────────────
+
+message QueryRequest {
+  string         collection      = 1;
+  repeated float vector          = 2;
+  uint32         k               = 3;
+  // JSON-encoded filter object (see REST API); omit or send empty bytes for no filter.
+  bytes          filter_json     = 4;
+  bool           include_payload = 5;
+}
+
+message ScoredResult {
+  uint64 id           = 1;
+  float  score        = 2;
+  bytes  payload_json = 3;
+}
+
+message QueryResponse { repeated ScoredResult results = 1; }

--- a/crates/likhadb-server/src/grpc/error.rs
+++ b/crates/likhadb-server/src/grpc/error.rs
@@ -1,0 +1,32 @@
+use likhadb_core::LikhaDbError;
+use likhadb_persist::PersistError;
+
+use crate::error::ApiError;
+
+pub fn core_err(e: LikhaDbError) -> tonic::Status {
+    match e {
+        LikhaDbError::CollectionNotFound(_) | LikhaDbError::VectorNotFound(_) => {
+            tonic::Status::not_found(e.to_string())
+        }
+        LikhaDbError::CollectionAlreadyExists(_) => tonic::Status::already_exists(e.to_string()),
+        LikhaDbError::DimMismatch { .. } | LikhaDbError::InvalidArgument(_) => {
+            tonic::Status::invalid_argument(e.to_string())
+        }
+    }
+}
+
+pub fn persist_err(e: PersistError) -> tonic::Status {
+    match e {
+        PersistError::Apply(inner) => core_err(inner),
+        other => tonic::Status::internal(other.to_string()),
+    }
+}
+
+pub fn api_err(e: ApiError) -> tonic::Status {
+    match e {
+        ApiError::BadRequest(m) => tonic::Status::invalid_argument(m),
+        ApiError::NotFound(m) => tonic::Status::not_found(m),
+        ApiError::Conflict(m) => tonic::Status::already_exists(m),
+        ApiError::Internal(m) => tonic::Status::internal(m),
+    }
+}

--- a/crates/likhadb-server/src/grpc/mod.rs
+++ b/crates/likhadb-server/src/grpc/mod.rs
@@ -1,0 +1,5 @@
+mod error;
+mod service;
+
+pub use service::proto::likha_db_server::LikhaDbServer;
+pub use service::LikhaDbGrpc;

--- a/crates/likhadb-server/src/grpc/service.rs
+++ b/crates/likhadb-server/src/grpc/service.rs
@@ -1,0 +1,295 @@
+// tonic::Status is inherently large (176 bytes); boxing it in every helper or
+// closure in a tonic service file would add more noise than this lint saves.
+#![allow(clippy::result_large_err)]
+
+#[allow(clippy::all)]
+pub mod proto {
+    tonic::include_proto!("likhadb");
+}
+
+use proto::{
+    likha_db_server::LikhaDb, CollectionInfo, CreateCollectionResponse, DeleteVectorResponse,
+    DropCollectionResponse, HealthRequest, HealthResponse, InsertVectorResponse,
+    ListCollectionsRequest, ListCollectionsResponse, QueryResponse, ScoredResult, VectorRecord,
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use crate::{
+    grpc::error::{api_err, core_err, persist_err},
+    state::AppState,
+    types::{metric_str, parse_metric},
+};
+
+pub struct LikhaDbGrpc {
+    state: AppState,
+}
+
+impl LikhaDbGrpc {
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl LikhaDb for LikhaDbGrpc {
+    async fn health(
+        &self,
+        _request: Request<HealthRequest>,
+    ) -> Result<Response<HealthResponse>, Status> {
+        Ok(Response::new(HealthResponse {
+            status: "ok".into(),
+        }))
+    }
+
+    async fn list_collections(
+        &self,
+        _request: Request<ListCollectionsRequest>,
+    ) -> Result<Response<ListCollectionsResponse>, Status> {
+        let collections: Vec<String> = {
+            let guard = self.state.read().await;
+            guard.list().into_iter().map(str::to_string).collect()
+        };
+        Ok(Response::new(ListCollectionsResponse { collections }))
+    }
+
+    async fn create_collection(
+        &self,
+        request: Request<proto::CreateCollectionRequest>,
+    ) -> Result<Response<CreateCollectionResponse>, Status> {
+        let req = request.into_inner();
+        let metric = parse_metric(&req.metric).map_err(api_err)?;
+        let dim = req.dim as usize;
+
+        use proto::create_collection_request::IndexConfig;
+        let mut guard = self.state.write().await;
+        match req.index_config {
+            None | Some(IndexConfig::Flat(_)) => guard
+                .create_collection(req.name, dim, metric)
+                .map_err(persist_err)?,
+            Some(IndexConfig::Ivf(c)) => guard
+                .create_ivf_collection(req.name, dim, metric, c.nlist as usize, c.nprobe as usize)
+                .map_err(persist_err)?,
+            Some(IndexConfig::IvfSq8(c)) => guard
+                .create_ivf_sq8_collection(
+                    req.name,
+                    dim,
+                    metric,
+                    c.nlist as usize,
+                    c.nprobe as usize,
+                )
+                .map_err(persist_err)?,
+            Some(IndexConfig::Hnsw(c)) => guard
+                .create_hnsw_collection(
+                    req.name,
+                    dim,
+                    metric,
+                    c.m as usize,
+                    c.ef_construction as usize,
+                    c.ef_search as usize,
+                )
+                .map_err(persist_err)?,
+        }
+        Ok(Response::new(CreateCollectionResponse {}))
+    }
+
+    async fn get_collection(
+        &self,
+        request: Request<proto::GetCollectionRequest>,
+    ) -> Result<Response<CollectionInfo>, Status> {
+        let name = request.into_inner().name;
+        let info = {
+            let guard = self.state.read().await;
+            let col = guard.get(&name).map_err(core_err)?;
+            CollectionInfo {
+                name: col.name.clone(),
+                dim: col.dim as u32,
+                metric: metric_str(col.metric).to_string(),
+                count: col.len() as u64,
+                index_type: col.index_type().to_string(),
+            }
+        };
+        Ok(Response::new(info))
+    }
+
+    async fn drop_collection(
+        &self,
+        request: Request<proto::DropCollectionRequest>,
+    ) -> Result<Response<DropCollectionResponse>, Status> {
+        let name = request.into_inner().name;
+        self.state
+            .write()
+            .await
+            .drop_collection(&name)
+            .map_err(persist_err)?;
+        Ok(Response::new(DropCollectionResponse {}))
+    }
+
+    async fn insert_vector(
+        &self,
+        request: Request<proto::InsertVectorRequest>,
+    ) -> Result<Response<InsertVectorResponse>, Status> {
+        let req = request.into_inner();
+        let payload = if req.payload_json.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::from_slice::<serde_json::Value>(&req.payload_json)
+                    .map_err(|e| Status::invalid_argument(format!("payload_json: {e}")))?,
+            )
+        };
+        self.state
+            .write()
+            .await
+            .insert(&req.collection, req.id, req.vector, payload)
+            .map_err(persist_err)?;
+        Ok(Response::new(InsertVectorResponse {}))
+    }
+
+    async fn get_vector(
+        &self,
+        request: Request<proto::GetVectorRequest>,
+    ) -> Result<Response<VectorRecord>, Status> {
+        let req = request.into_inner();
+        let record = {
+            let guard = self.state.read().await;
+            let col = guard.get(&req.collection).map_err(core_err)?;
+            match col.get(req.id).map_err(core_err)? {
+                None => {
+                    return Err(Status::not_found(format!(
+                        "vector {} not found in '{}'",
+                        req.id, req.collection
+                    )))
+                }
+                Some((vector, payload)) => {
+                    let payload_json = payload_to_bytes(payload)?;
+                    VectorRecord {
+                        id: req.id,
+                        vector,
+                        payload_json,
+                    }
+                }
+            }
+        };
+        Ok(Response::new(record))
+    }
+
+    async fn delete_vector(
+        &self,
+        request: Request<proto::DeleteVectorRequest>,
+    ) -> Result<Response<DeleteVectorResponse>, Status> {
+        let req = request.into_inner();
+        self.state
+            .write()
+            .await
+            .delete(&req.collection, req.id)
+            .map_err(persist_err)?;
+        Ok(Response::new(DeleteVectorResponse {}))
+    }
+
+    async fn query(
+        &self,
+        request: Request<proto::QueryRequest>,
+    ) -> Result<Response<QueryResponse>, Status> {
+        let req = request.into_inner();
+        let filter = decode_filter(&req.filter_json)?;
+        let results = {
+            let guard = self.state.read().await;
+            let col = guard.get(&req.collection).map_err(core_err)?;
+            col.search(
+                &req.vector,
+                req.k as usize,
+                filter.as_ref(),
+                req.include_payload,
+            )
+            .map_err(core_err)?
+        };
+        let results = encode_scored_results(results)?;
+        Ok(Response::new(QueryResponse { results }))
+    }
+
+    type QueryStreamStream = ReceiverStream<Result<ScoredResult, Status>>;
+
+    async fn query_stream(
+        &self,
+        request: Request<proto::QueryRequest>,
+    ) -> Result<Response<Self::QueryStreamStream>, Status> {
+        let req = request.into_inner();
+        let filter = decode_filter(&req.filter_json)?;
+        let results = {
+            let guard = self.state.read().await;
+            let col = guard.get(&req.collection).map_err(core_err)?;
+            col.search(
+                &req.vector,
+                req.k as usize,
+                filter.as_ref(),
+                req.include_payload,
+            )
+            .map_err(core_err)?
+        };
+
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        tokio::spawn(async move {
+            for r in results {
+                let item = encode_scored_result(r)
+                    .unwrap_or_else(|e| Err(Status::internal(e.to_string())));
+                if tx.send(item).await.is_err() {
+                    break; // client disconnected
+                }
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// tonic::Status is 176 bytes; boxing it throughout a tonic service file adds
+// more noise than the lint saves.
+#[allow(clippy::result_large_err)]
+fn decode_filter(raw: &[u8]) -> Result<Option<serde_json::Value>, Status> {
+    if raw.is_empty() {
+        Ok(None)
+    } else {
+        serde_json::from_slice::<serde_json::Value>(raw)
+            .map(Some)
+            .map_err(|e| Status::invalid_argument(format!("filter_json: {e}")))
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn payload_to_bytes(payload: Option<serde_json::Value>) -> Result<Vec<u8>, Status> {
+    match payload {
+        Some(p) => serde_json::to_vec(&p).map_err(|e| Status::internal(e.to_string())),
+        None => Ok(vec![]),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn encode_scored_result(
+    r: likhadb_core::ScoredResult,
+) -> Result<Result<ScoredResult, Status>, serde_json::Error> {
+    let payload_json = match r.payload {
+        Some(p) => serde_json::to_vec(&p)?,
+        None => vec![],
+    };
+    Ok(Ok(ScoredResult {
+        id: r.id,
+        score: r.score,
+        payload_json,
+    }))
+}
+
+#[allow(clippy::result_large_err)]
+fn encode_scored_results(
+    results: Vec<likhadb_core::ScoredResult>,
+) -> Result<Vec<ScoredResult>, Status> {
+    results
+        .into_iter()
+        .map(|r| {
+            encode_scored_result(r)
+                .map_err(|e| Status::internal(e.to_string()))
+                .and_then(|inner| inner)
+        })
+        .collect()
+}

--- a/crates/likhadb-server/src/lib.rs
+++ b/crates/likhadb-server/src/lib.rs
@@ -1,7 +1,9 @@
 mod error;
+mod grpc;
 mod routes;
 mod state;
 mod types;
 
+pub use grpc::{LikhaDbGrpc, LikhaDbServer};
 pub use routes::router;
 pub use state::{spawn_checkpoint_task, AppState};

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -36,7 +36,10 @@ async fn main() {
             std::process::exit(1);
         });
 
-    eprintln!("likhadb REST listening on {}", listener.local_addr().unwrap());
+    eprintln!(
+        "likhadb REST listening on {}",
+        listener.local_addr().unwrap()
+    );
     eprintln!("likhadb gRPC listening on {grpc_addr}");
 
     let grpc_state = state.clone();
@@ -49,9 +52,8 @@ async fn main() {
             .await
     });
 
-    let rest_handle = tokio::spawn(async move {
-        axum::serve(listener, likhadb_server::router(state)).await
-    });
+    let rest_handle =
+        tokio::spawn(async move { axum::serve(listener, likhadb_server::router(state)).await });
 
     tokio::select! {
         res = grpc_handle => eprintln!("error: gRPC server exited: {res:?}"),

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -18,20 +18,44 @@ async fn main() {
     let _checkpoint =
         likhadb_server::spawn_checkpoint_task(state.clone(), Duration::from_secs(300));
 
-    let addr = "0.0.0.0:8080";
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
+    // gRPC server on port 50051.
+    let grpc_addr = std::env::var("GRPC_ADDR")
+        .unwrap_or_else(|_| "[::]:50051".into())
+        .parse()
         .unwrap_or_else(|e| {
-            eprintln!("error: failed to bind to {addr}: {e}");
+            eprintln!("error: invalid GRPC_ADDR: {e}");
             std::process::exit(1);
         });
 
-    eprintln!("likhadb listening on {}", listener.local_addr().unwrap());
-
-    axum::serve(listener, likhadb_server::router(state))
+    // REST server on port 8080.
+    let rest_addr = std::env::var("HTTP_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".into());
+    let listener = tokio::net::TcpListener::bind(&rest_addr)
         .await
         .unwrap_or_else(|e| {
-            eprintln!("error: server exited unexpectedly: {e}");
+            eprintln!("error: failed to bind to {rest_addr}: {e}");
             std::process::exit(1);
         });
+
+    eprintln!("likhadb REST listening on {}", listener.local_addr().unwrap());
+    eprintln!("likhadb gRPC listening on {grpc_addr}");
+
+    let grpc_state = state.clone();
+    let grpc_handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(likhadb_server::LikhaDbServer::new(
+                likhadb_server::LikhaDbGrpc::new(grpc_state),
+            ))
+            .serve(grpc_addr)
+            .await
+    });
+
+    let rest_handle = tokio::spawn(async move {
+        axum::serve(listener, likhadb_server::router(state)).await
+    });
+
+    tokio::select! {
+        res = grpc_handle => eprintln!("error: gRPC server exited: {res:?}"),
+        res = rest_handle => eprintln!("error: REST server exited: {res:?}"),
+    }
+    std::process::exit(1);
 }


### PR DESCRIPTION
## Summary

- Adds a tonic + prost gRPC server mirroring the full REST API, sharing the same `AppState` (`Arc<RwLock<WalManager>>`)
- Defines `proto/likhadb.proto` with 10 RPCs: all collection DDL, vector DML, unary `Query`, and server-streaming `QueryStream` (the ML-pipeline differentiator vs REST)
- gRPC listens on `[::]:50051` (overridable via `GRPC_ADDR`); REST stays on `0.0.0.0:8080` (`HTTP_ADDR`)
- Fixes asymmetric failure handling in `main.rs`: both servers now spawn symmetrically and `tokio::select!` exits the process if either one dies

## New files

| File | Purpose |
|---|---|
| `proto/likhadb.proto` | Service + message definitions |
| `build.rs` | `tonic_build` code generation at build time |
| `src/grpc/error.rs` | `LikhaDbError` / `PersistError` → `tonic::Status` |
| `src/grpc/service.rs` | Full `LikhaDb` tonic service implementation |

## Test plan

- [ ] `cargo test --workspace` passes (141 tests)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Smoke test gRPC with `grpcurl` or a tonic client against a running server
- [ ] Verify `docker compose up` exposes both `:8080` (REST) and `:50051` (gRPC)
- [ ] Kill the gRPC listener manually and confirm the process exits (not just gRPC going dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)