### PR TITLE
implement E - Observability (Prometheus metrics + structured tracing)

### DIFF
--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -12,6 +12,8 @@ thiserror     = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 crc32fast     = "1"
+metrics       = "0.23"
+tracing       = "0.1"
 
 [dev-dependencies]
 rand          = { workspace = true }

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -35,8 +35,12 @@ impl WalWriter {
         let payload = bincode_opts()
             .serialize(entry)
             .map_err(PersistError::Encode)?;
+        // Frame layout: 4-byte length prefix + 4-byte CRC + payload
+        let frame_bytes = 8u64 + payload.len() as u64;
         write_frame(&mut self.file, &payload).map_err(PersistError::Io)?;
-        self.file.flush().map_err(PersistError::Io)
+        self.file.flush().map_err(PersistError::Io)?;
+        metrics::counter!("likhadb_wal_bytes_written_total").increment(frame_bytes);
+        Ok(())
     }
 
     fn truncate(path: &Path) -> std::io::Result<()> {
@@ -173,6 +177,7 @@ impl WalManager {
     where
         F: FnOnce(&mut CollectionManager) -> likhadb_core::Result<()>,
     {
+        let _span = tracing::debug_span!("wal_append", lsn = self.next_lsn).entered();
         let entry = WalEntry {
             lsn: self.next_lsn,
             op,

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -4,17 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-likhadb-core    = { path = "../likhadb-core" }
-likhadb-store   = { path = "../likhadb-store" }
-likhadb-persist = { path = "../likhadb-persist" }
-axum            = "0.7"
-tokio           = { version = "1", features = ["full"] }
-serde           = { workspace = true }
-serde_json      = { workspace = true }
-tonic           = "0.12"
-prost           = "0.13"
-bytes           = "1"
-tokio-stream    = "0.1"
+likhadb-core                 = { path = "../likhadb-core" }
+likhadb-store                = { path = "../likhadb-store" }
+likhadb-persist              = { path = "../likhadb-persist" }
+axum                         = "0.7"
+tokio                        = { version = "1", features = ["full"] }
+serde                        = { workspace = true }
+serde_json                   = { workspace = true }
+tonic                        = "0.12"
+prost                        = "0.13"
+bytes                        = "1"
+tokio-stream                 = "0.1"
+metrics                      = "0.23"
+metrics-exporter-prometheus  = "0.15"
+tracing                      = "0.1"
+tracing-subscriber           = { version = "0.3", features = ["env-filter", "json"] }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/crates/likhadb-server/src/lib.rs
+++ b/crates/likhadb-server/src/lib.rs
@@ -1,9 +1,12 @@
 mod error;
 mod grpc;
+mod metrics;
 mod routes;
 mod state;
 mod types;
 
 pub use grpc::{LikhaDbGrpc, LikhaDbServer};
+pub use metrics::{install as install_prometheus, seed_collection_gauges};
+pub use metrics_exporter_prometheus::PrometheusHandle;
 pub use routes::router;
 pub use state::{spawn_checkpoint_task, AppState};

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -3,15 +3,27 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let prometheus = likhadb_server::install_prometheus();
+
     let data_dir = std::env::args()
         .nth(1)
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("data"));
 
     let wal = likhadb_persist::WalManager::open(&data_dir).unwrap_or_else(|e| {
-        eprintln!("error: failed to open '{}': {e}", data_dir.display());
+        tracing::error!(dir = %data_dir.display(), error = %e, "failed to open data directory");
         std::process::exit(1);
     });
+
+    likhadb_server::seed_collection_gauges(&wal);
 
     let state = likhadb_server::AppState::new(wal);
 
@@ -23,7 +35,7 @@ async fn main() {
         .unwrap_or_else(|_| "[::]:50051".into())
         .parse()
         .unwrap_or_else(|e| {
-            eprintln!("error: invalid GRPC_ADDR: {e}");
+            tracing::error!(error = %e, "invalid GRPC_ADDR");
             std::process::exit(1);
         });
 
@@ -32,15 +44,15 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&rest_addr)
         .await
         .unwrap_or_else(|e| {
-            eprintln!("error: failed to bind to {rest_addr}: {e}");
+            tracing::error!(addr = %rest_addr, error = %e, "failed to bind");
             std::process::exit(1);
         });
 
-    eprintln!(
-        "likhadb REST listening on {}",
-        listener.local_addr().unwrap()
+    tracing::info!(
+        addr = %listener.local_addr().unwrap(),
+        "likhadb REST listening"
     );
-    eprintln!("likhadb gRPC listening on {grpc_addr}");
+    tracing::info!(addr = %grpc_addr, "likhadb gRPC listening");
 
     let grpc_state = state.clone();
     let grpc_handle = tokio::spawn(async move {
@@ -52,12 +64,13 @@ async fn main() {
             .await
     });
 
-    let rest_handle =
-        tokio::spawn(async move { axum::serve(listener, likhadb_server::router(state)).await });
+    let rest_handle = tokio::spawn(async move {
+        axum::serve(listener, likhadb_server::router(state, prometheus)).await
+    });
 
     tokio::select! {
-        res = grpc_handle => eprintln!("error: gRPC server exited: {res:?}"),
-        res = rest_handle => eprintln!("error: REST server exited: {res:?}"),
+        res = grpc_handle => tracing::error!(?res, "gRPC server exited"),
+        res = rest_handle => tracing::error!(?res, "REST server exited"),
     }
     std::process::exit(1);
 }

--- a/crates/likhadb-server/src/metrics.rs
+++ b/crates/likhadb-server/src/metrics.rs
@@ -1,0 +1,44 @@
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
+
+// Buckets covering 100µs → 1s: captures fast flat searches at the low end
+// and slow HNSW/IVF searches or insert-time training at the high end.
+const LATENCY_BUCKETS: &[f64] = &[
+    0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+];
+
+/// Install the global Prometheus metrics recorder with per-metric bucket config.
+///
+/// Must be called once before any `metrics::*` macros are invoked.
+/// Panics if called more than once in the same process.
+pub fn install() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full("likhadb_search_duration_seconds".to_string()),
+            LATENCY_BUCKETS,
+        )
+        .expect("invalid search buckets")
+        .set_buckets_for_metric(
+            Matcher::Full("likhadb_insert_duration_seconds".to_string()),
+            LATENCY_BUCKETS,
+        )
+        .expect("invalid insert buckets")
+        .install_recorder()
+        .expect("failed to install Prometheus recorder")
+}
+
+/// Seed `likhadb_collection_vectors_total` from the already-loaded WAL state.
+///
+/// Called once after startup so the gauge reflects snapshot-loaded collections
+/// before any REST writes arrive.
+pub fn seed_collection_gauges(wal: &likhadb_persist::WalManager) {
+    for name in wal.list() {
+        if let Ok(col) = wal.get(name) {
+            metrics::gauge!(
+                "likhadb_collection_vectors_total",
+                "collection" => name.to_string(),
+                "index_type" => col.index_type().to_string()
+            )
+            .set(col.len() as f64);
+        }
+    }
+}

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -1,10 +1,13 @@
+use std::time::Instant;
+
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
+    Extension, Json, Router,
 };
+use metrics_exporter_prometheus::PrometheusHandle;
 use serde_json::json;
 
 use crate::{
@@ -16,9 +19,10 @@ use crate::{
     },
 };
 
-pub fn router(state: AppState) -> Router {
+pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/metrics", get(metrics_endpoint))
         .route(
             "/collections",
             get(list_collections).post(create_collection),
@@ -33,11 +37,16 @@ pub fn router(state: AppState) -> Router {
             get(get_vector).delete(delete_vector),
         )
         .route("/collections/:name/query", post(query_vectors))
+        .layer(Extension(prometheus))
         .with_state(state)
 }
 
 async fn health() -> impl IntoResponse {
     Json(json!({"status": "ok"}))
+}
+
+async fn metrics_endpoint(Extension(handle): Extension<PrometheusHandle>) -> impl IntoResponse {
+    handle.render()
 }
 
 async fn list_collections(State(state): State<AppState>) -> impl IntoResponse {
@@ -104,15 +113,27 @@ async fn drop_collection(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[tracing::instrument(skip(state, req), fields(collection = %name))]
 async fn insert_vector(
     State(state): State<AppState>,
     Path(name): Path<String>,
     Json(req): Json<InsertRequest>,
 ) -> Result<StatusCode, ApiError> {
-    state
-        .write()
-        .await
-        .insert(&name, req.id, req.vector, req.payload)?;
+    let start = Instant::now();
+    let (count, index_type) = {
+        let mut guard = state.write().await;
+        guard.insert(&name, req.id, req.vector, req.payload)?;
+        let col = guard.get(&name).map_err(ApiError::from)?;
+        (col.len(), col.index_type().to_string())
+    };
+    metrics::histogram!("likhadb_insert_duration_seconds", "collection" => name.clone())
+        .record(start.elapsed().as_secs_f64());
+    metrics::gauge!(
+        "likhadb_collection_vectors_total",
+        "collection" => name,
+        "index_type" => index_type
+    )
+    .set(count as f64);
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -143,19 +164,40 @@ async fn delete_vector(
     State(state): State<AppState>,
     Path((name, id)): Path<(String, u64)>,
 ) -> Result<StatusCode, ApiError> {
-    state.write().await.delete(&name, id)?;
+    let (count, index_type) = {
+        let mut guard = state.write().await;
+        guard.delete(&name, id)?;
+        let col = guard.get(&name).map_err(ApiError::from)?;
+        (col.len(), col.index_type().to_string())
+    };
+    metrics::gauge!(
+        "likhadb_collection_vectors_total",
+        "collection" => name,
+        "index_type" => index_type
+    )
+    .set(count as f64);
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[tracing::instrument(skip(state, req), fields(collection = %name, k = req.k))]
 async fn query_vectors(
     State(state): State<AppState>,
     Path(name): Path<String>,
     Json(req): Json<QueryRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let results = {
+    let start = Instant::now();
+    let (results, index_type) = {
         let guard = state.read().await;
         let col = guard.get(&name)?;
-        col.search(&req.vector, req.k, req.filter.as_ref(), req.include_payload)?
+        let index_type = col.index_type().to_string();
+        let results = col.search(&req.vector, req.k, req.filter.as_ref(), req.include_payload)?;
+        (results, index_type)
     };
+    metrics::histogram!(
+        "likhadb_search_duration_seconds",
+        "collection" => name,
+        "index_type" => index_type
+    )
+    .record(start.elapsed().as_secs_f64());
     Ok(Json(QueryResponse { results }))
 }

--- a/crates/likhadb-server/src/state.rs
+++ b/crates/likhadb-server/src/state.rs
@@ -53,7 +53,7 @@ pub fn spawn_checkpoint_task(state: AppState, interval: Duration) -> JoinHandle<
             ticker.tick().await;
             let mut guard = state.write().await;
             if let Err(e) = guard.checkpoint() {
-                eprintln!("checkpoint error: {e}");
+                tracing::error!(error = %e, "checkpoint failed");
             }
         }
     })


### PR DESCRIPTION
## Summary

- **E1 — Prometheus metrics**: `GET /metrics` endpoint served directly from the likhadb binary via `metrics-exporter-prometheus` — no external Prometheus server required to read metrics
- **E2 — Structured tracing**: JSON-formatted logs via `tracing-subscriber`, controlled by `RUST_LOG` (defaults to `info`); spans on insert/search handlers and WAL append

## Metrics exposed

| Metric | Type | Labels |
|---|---|---|
| `likhadb_collection_vectors_total` | Gauge | `collection`, `index_type` |
| `likhadb_search_duration_seconds` | Histogram | `collection`, `index_type` |
| `likhadb_insert_duration_seconds` | Histogram | `collection` |
| `likhadb_wal_bytes_written_total` | Counter | — |

## Implementation notes

- Histogram buckets are custom-tuned to `[100µs, 500µs, 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s]` — the default Prometheus buckets start at 5ms which would collapse all fast flat-index searches into one bucket
- `likhadb_collection_vectors_total` is seeded from the loaded snapshot at startup so the gauge is accurate before any REST write arrives (previously it started at zero)
- `PrometheusHandle` is passed via axum `Extension` so `AppState` is unchanged and existing tests continue to pass without modification
- WAL bytes counter tracks the full frame size (8-byte header + payload), matching what is actually written to disk

## Test plan

- [ ] `cargo test --workspace` passes (149 tests)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] Start server, run an insert and search, then `curl localhost:8080/metrics` — verify all four metrics appear with correct labels and non-zero values
- [ ] Check histogram buckets in `/metrics` output begin at `le="0.0001"` not `le="0.005"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)