### PR TITLE
integrate Prometheus into local infra and add metrics integration tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,5 +13,15 @@ services:
       start_period: 5s
       retries: 3
 
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      - likhadb
+    restart: unless-stopped
+
 volumes:
   likhadb-data:

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -25,3 +25,4 @@ tonic-build = "0.12"
 
 [dev-dependencies]
 tempfile = "3"
+tower    = { version = "0.5", features = ["util"] }

--- a/crates/likhadb-server/src/metrics.rs
+++ b/crates/likhadb-server/src/metrics.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
 // Buckets covering 100µs → 1s: captures fast flat searches at the low end
@@ -6,24 +8,30 @@ const LATENCY_BUCKETS: &[f64] = &[
     0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
 ];
 
+static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
 /// Install the global Prometheus metrics recorder with per-metric bucket config.
 ///
-/// Must be called once before any `metrics::*` macros are invoked.
-/// Panics if called more than once in the same process.
+/// Idempotent: safe to call from multiple tests or init paths — the recorder
+/// is installed exactly once and the same handle is returned on every call.
 pub fn install() -> PrometheusHandle {
-    PrometheusBuilder::new()
-        .set_buckets_for_metric(
-            Matcher::Full("likhadb_search_duration_seconds".to_string()),
-            LATENCY_BUCKETS,
-        )
-        .expect("invalid search buckets")
-        .set_buckets_for_metric(
-            Matcher::Full("likhadb_insert_duration_seconds".to_string()),
-            LATENCY_BUCKETS,
-        )
-        .expect("invalid insert buckets")
-        .install_recorder()
-        .expect("failed to install Prometheus recorder")
+    HANDLE
+        .get_or_init(|| {
+            PrometheusBuilder::new()
+                .set_buckets_for_metric(
+                    Matcher::Full("likhadb_search_duration_seconds".to_string()),
+                    LATENCY_BUCKETS,
+                )
+                .expect("invalid search buckets")
+                .set_buckets_for_metric(
+                    Matcher::Full("likhadb_insert_duration_seconds".to_string()),
+                    LATENCY_BUCKETS,
+                )
+                .expect("invalid insert buckets")
+                .install_recorder()
+                .expect("failed to install Prometheus recorder")
+        })
+        .clone()
 }
 
 /// Seed `likhadb_collection_vectors_total` from the already-loaded WAL state.

--- a/crates/likhadb-server/tests/metrics_integration.rs
+++ b/crates/likhadb-server/tests/metrics_integration.rs
@@ -1,0 +1,140 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use likhadb_persist::WalManager;
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, AppState};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn build_app() -> (axum::Router, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let wal = WalManager::open(dir.path()).unwrap();
+    let prometheus = install_prometheus();
+    seed_collection_gauges(&wal);
+    let state = AppState::new(wal);
+    (router(state, prometheus), dir)
+}
+
+fn json_request(method: &str, uri: &str, body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn body_text(res: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn metrics_endpoint_is_reachable() {
+    let (app, _dir) = build_app();
+
+    let res = app
+        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn metrics_endpoint_contains_expected_metric_names() {
+    let (app, _dir) = build_app();
+
+    // Create a collection then insert a vector so the insert histogram and
+    // the vector-count gauge are both emitted before we scrape /metrics.
+    let res = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/collections",
+            r#"{"name":"smoke","dim":3,"metric":"l2"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+
+    let res = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/collections/smoke/vectors",
+            r#"{"id":1,"vector":[1.0,2.0,3.0]}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+    let res = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/collections/smoke/query",
+            r#"{"vector":[1.0,2.0,3.0],"k":1}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Scrape /metrics and verify all four instrumented names appear.
+    let res = app
+        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let text = body_text(res).await;
+
+    for name in [
+        "likhadb_collection_vectors_total",
+        "likhadb_insert_duration_seconds",
+        "likhadb_search_duration_seconds",
+        "likhadb_wal_bytes_written_total",
+    ] {
+        assert!(
+            text.contains(name),
+            "metric '{name}' missing from /metrics output\n---\n{text}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn metrics_histogram_uses_custom_buckets() {
+    let (app, _dir) = build_app();
+
+    // Trigger the insert histogram.
+    app.clone()
+        .oneshot(json_request(
+            "POST",
+            "/collections",
+            r#"{"name":"buckets","dim":2,"metric":"l2"}"#,
+        ))
+        .await
+        .unwrap();
+    app.clone()
+        .oneshot(json_request(
+            "POST",
+            "/collections/buckets/vectors",
+            r#"{"id":1,"vector":[0.0,1.0]}"#,
+        ))
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let text = body_text(res).await;
+
+    // The custom lower bound (100µs) must appear; the default lower bound
+    // (5ms = 0.005) must NOT be the first bucket.
+    assert!(
+        text.contains("le=\"0.0001\""),
+        "custom 100µs bucket missing — default buckets may be in use\n---\n{text}"
+    );
+}

--- a/crates/likhadb-server/tests/metrics_integration.rs
+++ b/crates/likhadb-server/tests/metrics_integration.rs
@@ -35,7 +35,12 @@ async fn metrics_endpoint_is_reachable() {
     let (app, _dir) = build_app();
 
     let res = app
-        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -83,7 +88,12 @@ async fn metrics_endpoint_contains_expected_metric_names() {
 
     // Scrape /metrics and verify all four instrumented names appear.
     let res = app
-        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::OK);
@@ -126,7 +136,12 @@ async fn metrics_histogram_uses_custom_buckets() {
         .unwrap();
 
     let res = app
-        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     let text = body_text(res).await;

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: likhadb
+    static_configs:
+      - targets: ["likhadb:8080"]


### PR DESCRIPTION
## Summary

- **Local infra**: `compose.yml` now starts a `prom/prometheus` container alongside likhadb; Prometheus scrapes `likhadb:8080/metrics` every 15s and its UI is available at `http://localhost:9090`
- **`install()` idempotent**: wrapped in `OnceLock` so calling it from multiple tests or init paths no longer panics
- **Integration tests**: three tests in `tests/metrics_integration.rs` exercise the real route handlers and assert the scrape output is correct

## Tests

| Test | What it checks |
|---|---|
| `metrics_endpoint_is_reachable` | `GET /metrics` returns 200 |
| `metrics_endpoint_contains_expected_metric_names` | all four metric families appear after a create/insert/query round-trip |
| `metrics_histogram_uses_custom_buckets` | `le="0.0001"` bucket is present, confirming custom buckets are active |

## How to verify locally

```sh
# Start both services
docker compose up --build

# Confirm likhadb exposes metrics
curl -s http://localhost:8080/metrics | grep likhadb_

# Open Prometheus UI
open http://localhost:9090

# Query a metric in the Prometheus expression browser
likhadb_collection_vectors_total
likhadb_insert_duration_seconds_bucket
```

Prometheus will show `UP` for the likhadb target under **Status → Targets** once the first scrape completes (~15s after startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)