### PR TITLE
feat: implement F1 - Tantivy-backed FTS index (likhadb-fts)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/likhadb-persist",
     "crates/likhadb-server",
     "crates/likhadb-bench",
+    "crates/likhadb-fts",
 ]
 resolver = "2"
 
@@ -19,3 +20,4 @@ criterion     = { version = "0.5", features = ["html_reports"] }
 simsimd       = "6"
 rayon         = "1"
 bincode       = "1"
+tantivy       = "0.22"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ A progressively-layered, in-memory vector database written in Rust.
 
 likhadb stores float vectors alongside arbitrary JSON payloads, searches them with
 k-nearest-neighbour queries, and filters candidates using a simple JSON predicate language.
-The internal design is a clean stack of crates with one extension seam — the `VectorIndex`
-trait — so index implementations slot in without changing the store or API layers.
+Collections can optionally enable a Tantivy-backed full-text index over payload string fields.
+The internal design is a clean stack of crates with two extension seams — the `VectorIndex`
+and `FtsIndex` traits — so implementations slot in without changing the store or API layers.
 
 For a deep dive into crate structure, index algorithms, query flows, and persistence
 design, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
@@ -24,11 +25,16 @@ design, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 # Run all tests
 cargo test --workspace
 
+# Run FTS tests (requires the fts feature)
+cargo test -p likhadb-store --features fts
+cargo test -p likhadb-fts
+
 # Run benchmarks
 cargo bench -p likhadb-bench
 
 # Lint (zero warnings enforced)
 cargo clippy --workspace -- -D warnings
+cargo clippy -p likhadb-store --features fts -- -D warnings
 ```
 
 ---
@@ -122,6 +128,41 @@ let results = col.search(&vec![0.5; 384], 10, None, false).unwrap();
 - `ef_construction`: must be ≥ `m`. 200 is a good default.
 - `ef_search`: must be ≥ 1. Increase to trade latency for recall. Start at 50.
 
+### Full-text search (FtsIndex)
+
+Enable per-collection with the `fts` Cargo feature. All string values in the JSON payload
+(including nested objects and arrays) are indexed automatically. Scores are BM25.
+
+```toml
+# Cargo.toml
+likhadb-store = { path = "crates/likhadb-store", features = ["fts"] }
+```
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+use serde_json::json;
+
+let mut mgr = CollectionManager::new();
+mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
+
+let col = mgr.get_mut("articles").unwrap();
+col.enable_fts().unwrap();   // activates the Tantivy in-memory index
+
+col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio and async-std"}))).unwrap();
+col.insert(2, vec![0.2; 384], Some(json!({"title": "Python data science", "body": "numpy pandas sklearn"}))).unwrap();
+col.insert(3, vec![0.3; 384], Some(json!({"title": "Rust memory model", "body": "ownership borrowing lifetimes"}))).unwrap();
+
+// BM25 full-text search — returns top-k results ranked by relevance
+let results = col.fts_search("Rust ownership", 5).unwrap();
+// results[0].id == 3  (highest BM25 score for "ownership")
+// results[1].id == 1  (matches "Rust")
+```
+
+Deletions are propagated automatically: `col.delete(id)` removes the vector, the payload, and the FTS document in one call.
+
+---
+
 ### Snapshot persistence
 
 ```rust
@@ -208,15 +249,18 @@ Rayon uses the default thread pool (all available cores).
 
 ## Roadmap
 
-| Tier | Status | Description |
+| Item | Status | Description |
 |---|---|---|
-| **Tier 1** | Done | Exact brute-force search, in-memory, JSON metadata filtering |
-| **Tier 2** | Done | IVF approximate k-NN with k-means clustering + SQ8 quantization |
-| **Tier 3** | Done | HNSW graph-based approximate search |
-| **Tier 4 — B1** | Done | Snapshot persistence |
-| **Tier 4 — B2** | Done | WAL crash durability — logs every mutation, replays on restart, atomic checkpoint |
-| **Tier 4 — C1** | Done | Concurrent shared state — `AppState` (`Arc<RwLock<WalManager>>`), background checkpoint task |
-| **Tier 4 — D+** | Done | HTTP REST + gRPC API |
+| **A — Foundation** | Done | Exact brute-force search, in-memory, JSON metadata filtering |
+| **B — Approximate k-NN** | Done | IVF (k-means + SQ8 quantization) + HNSW graph-based search |
+| **C — Persistence** | Done | Snapshot + WAL crash durability, atomic checkpoint |
+| **D — Concurrency** | Done | `Arc<RwLock<WalManager>>`, background checkpoint task |
+| **E — API** | Done | HTTP REST (axum) + gRPC (tonic) |
+| **F — Observability** | Done | Prometheus metrics (`/metrics`) + structured JSON tracing |
+| **F1 — Full-text search** | Done | Tantivy BM25 index per collection, opt-in via `fts` feature |
+| **F2 — Hybrid search** | Planned | RRF fusion of vector similarity + BM25 scores |
+| **L — Lakehouse I/O** | Planned | Parquet import/export, object storage (S3/GCS), Delta Lake |
+| **T — Vector transforms** | Planned | Insert-time L2 normalisation, scalar scaling |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ the next begins.
 | gRPC API (tonic) | Done | `crates/likhadb-server/` |
 | Prometheus metrics | Done | `crates/likhadb-server/` |
 | Structured tracing | Done | `crates/likhadb-server/` |
-| Full-text search | **None** | — |
+| Full-text search (`FtsIndex`, `TantivyFtsIndex`, `enable_fts`, `fts_search`) | Done (F1) | `crates/likhadb-fts/` |
 | Lakehouse I/O (Parquet) | **None** | — |
 | Vector transforms | **None** | — |
 | Hybrid search (vec + FTS) | **None** | — |
@@ -87,7 +87,7 @@ All collection and vector CRUD endpoints plus `POST /collections/:name/query` im
 
 New crate: `crates/likhadb-fts/` (depends on `tantivy`)
 
-### F1 — Tantivy-backed FTS index
+### F1 — Tantivy-backed FTS index ✅
 
 **Goal:** Give each collection an optional full-text index alongside the vector index.
 
@@ -98,11 +98,17 @@ New crate: `crates/likhadb-fts/` (depends on `tantivy`)
 - FTS query: `collection.fts_search(query_str, k) -> Vec<FtsResult>`
 
 **New files:**
-- `crates/likhadb-fts/src/lib.rs` — FtsIndex trait
-- `crates/likhadb-fts/src/tantivy_index.rs` — Tantivy wrapper
-- `crates/likhadb-store/src/collection.rs` — add `fts_index` field
+- `crates/likhadb-fts/src/lib.rs` — `FtsIndex` trait + `FtsResult` type
+- `crates/likhadb-fts/src/tantivy_index.rs` — `TantivyFtsIndex` (in-RAM BM25 via `RAMDirectory`)
+- `crates/likhadb-store/src/collection.rs` — `fts_index` field, `enable_fts()`, `fts_search()`
 
-**New dependency:** `tantivy = "0.22"`
+**New dependency:** `tantivy = "0.22"` (workspace), gated behind `likhadb-store/fts` feature flag.
+
+**Implementation notes:**
+- FTS is opt-in per collection: `collection.enable_fts()` activates it; no tantivy overhead otherwise.
+- All string values are recursively extracted from the JSON payload (nested objects and arrays included).
+- Thread safety: `IndexWriter` is wrapped in `Mutex`; reader is reloaded after each commit.
+- Delete calls `writer.delete_term(Term::from_field_u64(id_field, id))` and commits immediately.
 
 ---
 
@@ -236,7 +242,7 @@ likhadb/
 │   ├── likhadb-store/     # Collection, CollectionManager, MetaStore         ✅
 │   ├── likhadb-persist/   # Snapshot + WAL                                   ✅
 │   ├── likhadb-server/    # axum REST + tonic gRPC + Prometheus + tracing    ✅
-│   ├── likhadb-fts/       # Tantivy-backed FTS + hybrid query                [ Tier F ]
+│   ├── likhadb-fts/       # Tantivy-backed FTS + hybrid query                ✅ (F1 done)
 │   ├── likhadb-lakehouse/ # Parquet / Delta Lake import-export               [ Tier L ]
 │   ├── likhadb-transform/ # Insert-time vector transforms                    [ Tier T ]
 │   └── likhadb-bench/     # Criterion benchmarks                             ✅
@@ -255,7 +261,9 @@ A1 → A2 → A3           ✅ done
          ↓
     D1 → D2 → E1 → E2  ✅ done (likhadb-server complete)
          ↓
-    F1 → F2             ← next (full-text + hybrid search)
+    F1                  ✅ done (Tantivy FTS index, likhadb-fts)
+         ↓
+    F2                  ← next (hybrid vector + FTS search)
          ↓
     L1 → L2 → L3        (parquet → object store → delta lake)
          ↓

--- a/crates/likhadb-core/src/types.rs
+++ b/crates/likhadb-core/src/types.rs
@@ -24,6 +24,8 @@ pub enum LikhaDbError {
     CollectionAlreadyExists(String),
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
+    #[error("fts error: {0}")]
+    Fts(String),
 }
 
 pub type Result<T> = std::result::Result<T, LikhaDbError>;

--- a/crates/likhadb-fts/Cargo.toml
+++ b/crates/likhadb-fts/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name    = "likhadb-fts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+likhadb-core = { path = "../likhadb-core" }
+serde_json   = { workspace = true }
+tantivy      = { workspace = true }

--- a/crates/likhadb-fts/src/lib.rs
+++ b/crates/likhadb-fts/src/lib.rs
@@ -1,0 +1,17 @@
+pub mod tantivy_index;
+
+use likhadb_core::{Result, VecId};
+
+pub use tantivy_index::TantivyFtsIndex;
+
+#[derive(Debug, Clone)]
+pub struct FtsResult {
+    pub id: VecId,
+    pub score: f32,
+}
+
+pub trait FtsIndex: Send + Sync {
+    fn index_document(&mut self, id: VecId, text: &str) -> Result<()>;
+    fn delete_document(&mut self, id: VecId) -> Result<()>;
+    fn search(&self, query: &str, k: usize) -> Result<Vec<FtsResult>>;
+}

--- a/crates/likhadb-fts/src/tantivy_index.rs
+++ b/crates/likhadb-fts/src/tantivy_index.rs
@@ -1,0 +1,240 @@
+use std::sync::Mutex;
+
+use likhadb_core::{LikhaDbError, Result, VecId};
+use tantivy::{
+    collector::TopDocs,
+    query::QueryParser,
+    schema::{Field, Schema, Value, INDEXED, STORED, TEXT},
+    Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term,
+};
+
+use crate::{FtsIndex, FtsResult};
+
+pub struct TantivyFtsIndex {
+    index: Index,
+    writer: Mutex<IndexWriter>,
+    reader: IndexReader,
+    id_field: Field,
+    text_field: Field,
+}
+
+impl TantivyFtsIndex {
+    pub fn new() -> Result<Self> {
+        let mut schema_builder = Schema::builder();
+        let id_field = schema_builder.add_u64_field("id", INDEXED | STORED);
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+
+        let index = Index::create_in_ram(schema);
+        let writer = index
+            .writer(15_000_000)
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+
+        Ok(Self {
+            index,
+            writer: Mutex::new(writer),
+            reader,
+            id_field,
+            text_field,
+        })
+    }
+}
+
+impl FtsIndex for TantivyFtsIndex {
+    fn index_document(&mut self, id: VecId, text: &str) -> Result<()> {
+        let doc = tantivy::doc!(self.id_field => id, self.text_field => text);
+        {
+            let mut writer = self.writer.lock().unwrap();
+            writer
+                .add_document(doc)
+                .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+            writer
+                .commit()
+                .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+        }
+        self.reader
+            .reload()
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))
+    }
+
+    fn delete_document(&mut self, id: VecId) -> Result<()> {
+        let term = Term::from_field_u64(self.id_field, id);
+        {
+            let mut writer = self.writer.lock().unwrap();
+            writer.delete_term(term);
+            writer
+                .commit()
+                .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+        }
+        self.reader
+            .reload()
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))
+    }
+
+    fn search(&self, query: &str, k: usize) -> Result<Vec<FtsResult>> {
+        if k == 0 || query.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let searcher = self.reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, vec![self.text_field]);
+        let parsed = query_parser
+            .parse_query(query)
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+        let top_docs = searcher
+            .search(&parsed, &TopDocs::with_limit(k))
+            .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+
+        let mut results = Vec::with_capacity(top_docs.len());
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher
+                .doc(doc_address)
+                .map_err(|e| LikhaDbError::Fts(e.to_string()))?;
+            if let Some(id) = doc.get_first(self.id_field).and_then(|v| v.as_u64()) {
+                results.push(FtsResult { id, score });
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_index() -> TantivyFtsIndex {
+        TantivyFtsIndex::new().expect("index creation failed")
+    }
+
+    #[test]
+    fn new_index_search_returns_empty() {
+        let idx = make_index();
+        let results = idx.search("anything", 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let mut idx = make_index();
+        idx.index_document(1, "hello world").unwrap();
+        assert!(idx.search("", 10).unwrap().is_empty());
+        assert!(idx.search("   ", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn k_zero_returns_empty() {
+        let mut idx = make_index();
+        idx.index_document(1, "hello world").unwrap();
+        assert!(idx.search("hello", 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn index_and_search_finds_document() {
+        let mut idx = make_index();
+        idx.index_document(42, "tantivy full text search engine").unwrap();
+        let results = idx.search("tantivy", 5).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, 42);
+    }
+
+    #[test]
+    fn search_returns_positive_scores() {
+        let mut idx = make_index();
+        idx.index_document(1, "rust programming language").unwrap();
+        let results = idx.search("rust", 5).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            assert!(r.score > 0.0, "BM25 score must be positive");
+        }
+    }
+
+    #[test]
+    fn unrelated_query_returns_empty() {
+        let mut idx = make_index();
+        idx.index_document(1, "the quick brown fox").unwrap();
+        let results = idx.search("xylophone", 5).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn delete_removes_document_from_results() {
+        let mut idx = make_index();
+        idx.index_document(1, "delete me from results").unwrap();
+        idx.index_document(2, "keep this document in results").unwrap();
+
+        let before = idx.search("results", 10).unwrap();
+        assert_eq!(before.len(), 2);
+
+        idx.delete_document(1).unwrap();
+
+        let after = idx.search("delete", 10).unwrap();
+        assert!(after.is_empty(), "deleted doc should not appear");
+
+        let kept = idx.search("keep", 10).unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, 2);
+    }
+
+    #[test]
+    fn delete_nonexistent_is_a_noop() {
+        let mut idx = make_index();
+        idx.index_document(1, "only document").unwrap();
+        idx.delete_document(999).unwrap(); // should not error
+        let results = idx.search("only", 5).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn search_respects_top_k_limit() {
+        let mut idx = make_index();
+        for i in 0..20u64 {
+            idx.index_document(i, "common keyword in every document")
+                .unwrap();
+        }
+        let results = idx.search("common", 5).unwrap();
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn results_are_ordered_by_score_descending() {
+        let mut idx = make_index();
+        // doc 1 has "rust" once, doc 2 has it three times — doc 2 should score higher
+        idx.index_document(1, "rust").unwrap();
+        idx.index_document(2, "rust rust rust language").unwrap();
+        let results = idx.search("rust", 10).unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(
+            results[0].score >= results[1].score,
+            "results must be ordered score descending"
+        );
+    }
+
+    #[test]
+    fn multiple_fields_in_same_document_all_searchable() {
+        let mut idx = make_index();
+        idx.index_document(1, "alpha beta gamma").unwrap();
+        assert_eq!(idx.search("alpha", 5).unwrap().len(), 1);
+        assert_eq!(idx.search("beta", 5).unwrap().len(), 1);
+        assert_eq!(idx.search("gamma", 5).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn one_thousand_docs_top_result_is_best_match() {
+        let mut idx = make_index();
+        for i in 0..1000u64 {
+            let text = if i == 777 {
+                "exclusive unique term zephyr mountainpeak".to_string()
+            } else {
+                format!("generic document number {i} with common words")
+            };
+            idx.index_document(i, &text).unwrap();
+        }
+        let results = idx.search("zephyr", 5).unwrap();
+        assert!(!results.is_empty(), "should find the unique document");
+        assert_eq!(results[0].id, 777, "top result must be the unique doc");
+    }
+}

--- a/crates/likhadb-fts/src/tantivy_index.rs
+++ b/crates/likhadb-fts/src/tantivy_index.rs
@@ -135,7 +135,8 @@ mod tests {
     #[test]
     fn index_and_search_finds_document() {
         let mut idx = make_index();
-        idx.index_document(42, "tantivy full text search engine").unwrap();
+        idx.index_document(42, "tantivy full text search engine")
+            .unwrap();
         let results = idx.search("tantivy", 5).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, 42);
@@ -164,7 +165,8 @@ mod tests {
     fn delete_removes_document_from_results() {
         let mut idx = make_index();
         idx.index_document(1, "delete me from results").unwrap();
-        idx.index_document(2, "keep this document in results").unwrap();
+        idx.index_document(2, "keep this document in results")
+            .unwrap();
 
         let before = idx.search("results", 10).unwrap();
         assert_eq!(before.len(), 2);

--- a/crates/likhadb-server/src/error.rs
+++ b/crates/likhadb-server/src/error.rs
@@ -42,6 +42,7 @@ impl From<LikhaDbError> for ApiError {
             LikhaDbError::DimMismatch { .. } | LikhaDbError::InvalidArgument(_) => {
                 ApiError::BadRequest(e.to_string())
             }
+            LikhaDbError::Fts(_) => ApiError::Internal(e.to_string()),
         }
     }
 }

--- a/crates/likhadb-server/src/grpc/error.rs
+++ b/crates/likhadb-server/src/grpc/error.rs
@@ -12,6 +12,7 @@ pub fn core_err(e: LikhaDbError) -> tonic::Status {
         LikhaDbError::DimMismatch { .. } | LikhaDbError::InvalidArgument(_) => {
             tonic::Status::invalid_argument(e.to_string())
         }
+        LikhaDbError::Fts(_) => tonic::Status::internal(e.to_string()),
     }
 }
 

--- a/crates/likhadb-store/Cargo.toml
+++ b/crates/likhadb-store/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 
 [features]
 persist = ["dep:serde", "likhadb-index/serde"]
+fts     = ["dep:likhadb-fts"]
 
 [dependencies]
 likhadb-core  = { path = "../likhadb-core" }
 likhadb-index = { path = "../likhadb-index" }
+likhadb-fts   = { path = "../likhadb-fts", optional = true }
 serde_json    = { workspace = true }
 serde         = { workspace = true, optional = true }

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -6,12 +6,44 @@ use crate::meta::MetaStore;
 
 pub type VectorWithPayload = (Vector, Option<Value>);
 
+#[cfg(feature = "fts")]
+fn extract_text_fields(value: &Value) -> String {
+    let mut out = String::new();
+    collect_strings(value, &mut out);
+    out
+}
+
+#[cfg(feature = "fts")]
+fn collect_strings(value: &Value, out: &mut String) {
+    match value {
+        Value::String(s) => {
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(s);
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                collect_strings(v, out);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                collect_strings(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub struct Collection {
     pub name: String,
     pub dim: usize,
     pub metric: Metric,
     pub(crate) index: Box<dyn VectorIndex>,
     pub(crate) meta: MetaStore,
+    #[cfg(feature = "fts")]
+    pub(crate) fts_index: Option<Box<dyn likhadb_fts::FtsIndex>>,
 }
 
 impl Collection {
@@ -34,6 +66,8 @@ impl Collection {
             metric,
             index,
             meta: MetaStore::new(),
+            #[cfg(feature = "fts")]
+            fts_index: None,
         }
     }
 
@@ -43,9 +77,30 @@ impl Collection {
         self
     }
 
+    #[cfg(feature = "fts")]
+    pub fn enable_fts(&mut self) -> Result<()> {
+        self.fts_index = Some(Box::new(likhadb_fts::TantivyFtsIndex::new()?));
+        Ok(())
+    }
+
+    #[cfg(feature = "fts")]
+    pub fn fts_search(&self, query: &str, k: usize) -> Result<Vec<likhadb_fts::FtsResult>> {
+        match &self.fts_index {
+            Some(idx) => idx.search(query, k),
+            None => Ok(vec![]),
+        }
+    }
+
     pub fn insert(&mut self, id: VecId, vec: Vector, payload: Option<Value>) -> Result<()> {
         self.index.insert(id, vec)?;
         if let Some(p) = payload {
+            #[cfg(feature = "fts")]
+            if let Some(fts) = &mut self.fts_index {
+                let text = extract_text_fields(&p);
+                if !text.is_empty() {
+                    fts.index_document(id, &text)?;
+                }
+            }
             self.meta.set(id, p);
         }
         Ok(())
@@ -54,6 +109,10 @@ impl Collection {
     pub fn delete(&mut self, id: VecId) -> Result<bool> {
         let existed = self.index.delete(id);
         self.meta.remove(id);
+        #[cfg(feature = "fts")]
+        if let Some(fts) = &mut self.fts_index {
+            fts.delete_document(id)?;
+        }
         Ok(existed)
     }
 
@@ -150,5 +209,151 @@ mod tests {
         assert!(results[0].is_some());
         assert!(results[1].is_none());
         assert!(results[2].is_some());
+    }
+
+    #[cfg(feature = "fts")]
+    mod fts_tests {
+        use super::*;
+
+        fn make_fts_collection() -> Collection {
+            let mut c = Collection::new("fts_test".into(), 3, Metric::L2);
+            c.enable_fts().unwrap();
+            c
+        }
+
+        #[test]
+        fn fts_search_finds_exact_term() {
+            let mut c = make_fts_collection();
+            c.insert(
+                1,
+                vec![1.0, 0.0, 0.0],
+                Some(json!({"body": "the quick brown fox"})),
+            )
+            .unwrap();
+            c.insert(
+                2,
+                vec![0.0, 1.0, 0.0],
+                Some(json!({"body": "lazy dog sleeps"})),
+            )
+            .unwrap();
+            let results = c.fts_search("fox", 5).unwrap();
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].id, 1);
+        }
+
+        #[test]
+        fn fts_search_empty_query_returns_empty() {
+            let mut c = make_fts_collection();
+            c.insert(1, vec![1.0, 0.0, 0.0], Some(json!({"body": "hello world"})))
+                .unwrap();
+            let results = c.fts_search("", 5).unwrap();
+            assert!(results.is_empty());
+        }
+
+        #[test]
+        fn fts_search_no_fts_enabled_returns_empty() {
+            let mut c = Collection::new("no_fts".into(), 3, Metric::L2);
+            c.insert(1, vec![1.0, 0.0, 0.0], Some(json!({"body": "hello world"})))
+                .unwrap();
+            let results = c.fts_search("hello", 5).unwrap();
+            assert!(results.is_empty());
+        }
+
+        #[test]
+        fn fts_delete_removes_document_from_index() {
+            let mut c = make_fts_collection();
+            c.insert(
+                1,
+                vec![1.0, 0.0, 0.0],
+                Some(json!({"body": "tantivy full text search"})),
+            )
+            .unwrap();
+            c.insert(
+                2,
+                vec![0.0, 1.0, 0.0],
+                Some(json!({"body": "vector similarity search"})),
+            )
+            .unwrap();
+
+            // both are findable before delete
+            let before = c.fts_search("search", 5).unwrap();
+            assert_eq!(before.len(), 2);
+
+            c.delete(1).unwrap();
+            let after = c.fts_search("tantivy", 5).unwrap();
+            assert!(after.is_empty(), "deleted doc should not appear");
+        }
+
+        #[test]
+        fn fts_search_returns_top_k_only() {
+            let mut c = make_fts_collection();
+            for i in 0..10u64 {
+                c.insert(
+                    i,
+                    vec![i as f32, 0.0, 0.0],
+                    Some(json!({"body": "rust programming language"})),
+                )
+                .unwrap();
+            }
+            let results = c.fts_search("rust", 3).unwrap();
+            assert_eq!(results.len(), 3);
+        }
+
+        #[test]
+        fn fts_search_scores_are_positive() {
+            let mut c = make_fts_collection();
+            c.insert(
+                1,
+                vec![1.0, 0.0, 0.0],
+                Some(json!({"title": "hello world", "desc": "a test document"})),
+            )
+            .unwrap();
+            let results = c.fts_search("hello", 5).unwrap();
+            assert!(!results.is_empty());
+            for r in &results {
+                assert!(r.score > 0.0, "BM25 score should be positive");
+            }
+        }
+
+        #[test]
+        fn fts_indexes_nested_string_fields() {
+            let mut c = make_fts_collection();
+            c.insert(
+                1,
+                vec![1.0, 0.0, 0.0],
+                Some(
+                    json!({"metadata": {"title": "deep nested text", "tags": ["rust", "search"]}}),
+                ),
+            )
+            .unwrap();
+            let results = c.fts_search("nested", 5).unwrap();
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].id, 1);
+        }
+
+        #[test]
+        fn fts_insert_without_payload_does_not_index() {
+            let mut c = make_fts_collection();
+            c.insert(1, vec![1.0, 0.0, 0.0], None).unwrap();
+            let results = c.fts_search("anything", 5).unwrap();
+            assert!(results.is_empty());
+        }
+
+        #[test]
+        fn fts_1k_docs_top_result_is_best_match() {
+            let mut c = make_fts_collection();
+            for i in 0..1000u64 {
+                let body = if i == 42 {
+                    "exclusive unique term: xylophone music".to_string()
+                } else {
+                    format!("document number {i} with generic content")
+                };
+                c.insert(i, vec![i as f32, 0.0, 0.0], Some(json!({"body": body})))
+                    .unwrap();
+            }
+            let results = c.fts_search("xylophone", 5).unwrap();
+            assert!(!results.is_empty(), "should find the unique doc");
+            assert_eq!(results[0].id, 42, "best match should be id 42");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- New crate `crates/likhadb-fts/` wraps Tantivy's in-RAM BM25 index behind an `FtsIndex` trait, analogous to `VectorIndex`
- `Collection` gains opt-in FTS via `enable_fts()` and `fts_search(query, k)`, gated behind a `fts` Cargo feature (zero tantivy overhead when unused)
- All JSON payload string values are recursively extracted (including nested objects and arrays) and indexed at insert time; deletes are propagated automatically

## What changed

| File | Change |
|---|---|
| `crates/likhadb-fts/` | New crate — `FtsIndex` trait, `FtsResult`, `TantivyFtsIndex` |
| `crates/likhadb-store/src/collection.rs` | `fts_index` field, `enable_fts()`, `fts_search()`, FTS propagation in `insert`/`delete` |
| `crates/likhadb-store/Cargo.toml` | `fts` optional feature + `likhadb-fts` dep |
| `crates/likhadb-core/src/types.rs` | `LikhaDbError::Fts(String)` variant |
| `crates/likhadb-server/src/{error,grpc/error}.rs` | Exhaustive match on new error variant |
| `Cargo.toml` | `likhadb-fts` workspace member, `tantivy = "0.22"` workspace dep |
| `README.md` / `ROADMAP.md` | F1 marked done, FTS usage section added |

## Design decisions

- **In-RAM index** (`RAMDirectory`) — no external infrastructure needed
- **`Mutex<IndexWriter>`** — tantivy's writer is `Send` but `!Sync`; mutex satisfies the `Send + Sync` bound required by `FtsIndex`
- **Manual reader reload** after each commit — guarantees searches immediately reflect writes
- **Feature-gated** — `likhadb-store` without `--features fts` compiles with zero tantivy dependency

## Test plan

- [x] `cargo test -p likhadb-fts` — 12 unit tests on `TantivyFtsIndex` directly (empty index, delete, top-k, score ordering, 1k-doc precision)
- [x] `cargo test -p likhadb-store --features fts` — 8 integration tests through `Collection` (exact term, nested fields, delete propagation, no-FTS fallback, 1k-doc ROADMAP checkpoint)
- [x] `cargo test --workspace` — full workspace green (147 tests total)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo clippy -p likhadb-store --features fts -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)