### PR TITLE
feat: implement F2 — hybrid search (BM25 + vector RRF)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 likhadb_tier1_prompt.md
 .DS_Store
+BIZ.md

--- a/README.md
+++ b/README.md
@@ -161,6 +161,55 @@ let results = col.fts_search("Rust ownership", 5).unwrap();
 
 Deletions are propagated automatically: `col.delete(id)` removes the vector, the payload, and the FTS document in one call.
 
+### Hybrid search (vector + BM25 via RRF)
+
+Pass `enable_fts: true` at collection creation. Hybrid search fuses vector similarity ranks and BM25 text ranks using Reciprocal Rank Fusion:
+
+```
+rrf_score(id) = 1/(rrf_k + rank_vec) + 1/(rrf_k + rank_fts)    // default rrf_k = 60
+```
+
+A document that ranks 2nd by vector similarity and 3rd by keyword relevance beats a document that is top-1 in only one modality.
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+use serde_json::json;
+
+let mut mgr = CollectionManager::new();
+mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
+
+let col = mgr.get_mut("articles").unwrap();
+col.enable_fts().unwrap();   // activates Tantivy BM25 index
+
+col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio"}))).unwrap();
+col.insert(2, vec![0.5; 384], Some(json!({"title": "Python ML", "body": "numpy sklearn"}))).unwrap();
+col.insert(3, vec![0.2; 384], Some(json!({"title": "Rust memory model", "body": "ownership lifetimes"}))).unwrap();
+
+// Returns top-5 fusing semantic + keyword signals
+let results = col.hybrid_search(
+    &vec![0.15; 384],  // query embedding
+    "Rust ownership",  // keyword query
+    5,                 // k
+    60,                // rrf_k
+    None,              // metadata filter
+    true,              // include_payload
+).unwrap();
+```
+
+**REST API:**
+```sh
+# Create collection with FTS enabled
+curl -X POST localhost:8080/collections \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"articles","dim":384,"metric":"cosine","enable_fts":true}'
+
+# Hybrid query
+curl -X POST localhost:8080/collections/articles/hybrid-query \
+  -H 'Content-Type: application/json' \
+  -d '{"vector":[...],"text":"Rust ownership","k":5,"include_payload":true}'
+```
+
 ---
 
 ### Snapshot persistence

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ the next begins.
 | Full-text search (`FtsIndex`, `TantivyFtsIndex`, `enable_fts`, `fts_search`) | Done (F1) | `crates/likhadb-fts/` |
 | Lakehouse I/O (Parquet) | **None** | — |
 | Vector transforms | **None** | — |
-| Hybrid search (vec + FTS) | **None** | — |
+| Hybrid search (vec + FTS) | Done (F2) | `crates/likhadb-store/src/collection.rs`, `crates/likhadb-server/` |
 
 ---
 
@@ -112,29 +112,49 @@ New crate: `crates/likhadb-fts/` (depends on `tantivy`)
 
 ---
 
-### F2 — Hybrid search (vector + FTS)
+### F2 — Hybrid search (vector + FTS) ✅
 
 **Goal:** Single query that fuses vector similarity scores with BM25 text scores using Reciprocal Rank Fusion (RRF):
 
 ```
-rrf_score(id) = 1/(k + rank_vector(id)) + 1/(k + rank_fts(id))
+rrf_score(id) = 1/(rrf_k + rank_vector(id)) + 1/(rrf_k + rank_fts(id))
 ```
 
 **New types in `crates/likhadb-core/src/types.rs`:**
 ```rust
-pub struct HybridQuery<'a> {
-    pub vector: &'a [f32],
-    pub text: &'a str,
+pub struct HybridQuery {
+    pub vector: Vec<f32>,
+    pub text: String,
     pub k: usize,
     pub rrf_k: u32,           // default 60
-    pub filter: Option<&'a Value>,
+    pub filter: Option<serde_json::Value>,
     pub include_payload: bool,
 }
 ```
 
-**Files to change:**
-- `crates/likhadb-core/src/types.rs` — add `HybridQuery`
-- `crates/likhadb-store/src/collection.rs` — add `hybrid_search()`
+**Files changed:**
+- `crates/likhadb-core/src/types.rs` — `HybridQuery` type
+- `crates/likhadb-store/src/collection.rs` — `Collection::hybrid_search()`
+- `crates/likhadb-store/src/manager.rs` — `CollectionManager::enable_fts()`
+- `crates/likhadb-store/src/snapshot.rs` — `CollectionSnapshot.fts_enabled` (persists FTS-enabled state across checkpoints)
+- `crates/likhadb-persist/src/wal/entry.rs` — `WalOp::EnableFts` for WAL durability
+- `crates/likhadb-persist/src/wal/mod.rs` — `WalManager::enable_fts()`
+- `crates/likhadb-persist/src/wal/recovery.rs` — replay `EnableFts` ops
+- `crates/likhadb-server/proto/likhadb.proto` — `HybridQuery` RPC, `enable_fts` on `CreateCollectionRequest`
+- `crates/likhadb-server/src/routes.rs` — `POST /collections/:name/hybrid-query`
+- `crates/likhadb-server/src/grpc/service.rs` — `HybridQuery` RPC implementation
+
+**Implementation notes:**
+- `enable_fts: bool` on collection creation (REST + gRPC) activates the Tantivy index from the start; WAL logs this as `EnableFts` so it survives restarts, and the snapshot's `fts_enabled` field (with `#[serde(default)]`) handles post-checkpoint recovery.
+- Hybrid search retrieves `2k` candidates from each modality, fuses ranks via RRF, truncates to top `k`.
+- When FTS is not enabled on a collection, hybrid search falls back gracefully to vector-only results (FTS contributes no rank terms).
+
+**Build order summary:**
+```
+    F2                  ✅ done (hybrid vector + FTS search, RRF)
+         ↓
+    L1 → L2 → L3        ← next (parquet → object store → delta lake)
+```
 
 ---
 
@@ -263,9 +283,9 @@ A1 → A2 → A3           ✅ done
          ↓
     F1                  ✅ done (Tantivy FTS index, likhadb-fts)
          ↓
-    F2                  ← next (hybrid vector + FTS search)
+    F2                  ✅ done (hybrid vector + FTS search, RRF)
          ↓
-    L1 → L2 → L3        (parquet → object store → delta lake)
+    L1 → L2 → L3        ← next (parquet → object store → delta lake)
          ↓
     T1 → T2             (vector transforms)
 ```

--- a/crates/likhadb-core/src/types.rs
+++ b/crates/likhadb-core/src/types.rs
@@ -29,3 +29,17 @@ pub enum LikhaDbError {
 }
 
 pub type Result<T> = std::result::Result<T, LikhaDbError>;
+
+/// Parameters for a hybrid vector + full-text search using Reciprocal Rank Fusion.
+///
+/// RRF formula: `rrf_score(id) = 1/(rrf_k + rank_vec(id)) + 1/(rrf_k + rank_fts(id))`
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HybridQuery {
+    pub vector: Vec<f32>,
+    pub text: String,
+    pub k: usize,
+    /// Rank constant for RRF. Typical default is 60.
+    pub rrf_k: u32,
+    pub filter: Option<serde_json::Value>,
+    pub include_payload: bool,
+}

--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -3,6 +3,9 @@ name    = "likhadb-persist"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+fts = ["likhadb-store/fts"]
+
 [dependencies]
 likhadb-core  = { path = "../likhadb-core" }
 likhadb-index = { path = "../likhadb-index", features = ["serde"] }

--- a/crates/likhadb-persist/src/wal/entry.rs
+++ b/crates/likhadb-persist/src/wal/entry.rs
@@ -43,6 +43,9 @@ pub enum WalOp {
         collection: String,
         id: VecId,
     },
+    EnableFts {
+        collection: String,
+    },
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -322,9 +322,12 @@ impl WalManager {
     #[cfg(feature = "fts")]
     pub fn enable_fts(&mut self, name: &str) -> Result<(), PersistError> {
         let col = name.to_owned();
-        self.log_and_apply(WalOp::EnableFts { collection: col.clone() }, |mgr| {
-            mgr.enable_fts(&col)
-        })
+        self.log_and_apply(
+            WalOp::EnableFts {
+                collection: col.clone(),
+            },
+            |mgr| mgr.enable_fts(&col),
+        )
     }
 
     // ── Read-through ────────────────────────────────────────────────────────

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -317,6 +317,16 @@ impl WalManager {
             .map_err(PersistError::Apply)
     }
 
+    // ── FTS ────────────────────────────────────────────────────────────────
+
+    #[cfg(feature = "fts")]
+    pub fn enable_fts(&mut self, name: &str) -> Result<(), PersistError> {
+        let col = name.to_owned();
+        self.log_and_apply(WalOp::EnableFts { collection: col.clone() }, |mgr| {
+            mgr.enable_fts(&col)
+        })
+    }
+
     // ── Read-through ────────────────────────────────────────────────────────
 
     pub fn get(&self, name: &str) -> likhadb_core::Result<&Collection> {

--- a/crates/likhadb-persist/src/wal/recovery.rs
+++ b/crates/likhadb-persist/src/wal/recovery.rs
@@ -55,5 +55,15 @@ pub fn apply_op(mgr: &mut CollectionManager, op: WalOp) -> Result<(), PersistErr
             .get_mut(&collection)
             .and_then(|col| col.delete(id).map(|_| ()))
             .map_err(PersistError::Apply),
+        WalOp::EnableFts { collection } => {
+            #[cfg(feature = "fts")]
+            match mgr.enable_fts(&collection) {
+                Ok(()) | Err(LikhaDbError::CollectionNotFound(_)) => {}
+                Err(e) => return Err(PersistError::Apply(e)),
+            }
+            #[cfg(not(feature = "fts"))]
+            let _ = collection;
+            Ok(())
+        }
     }
 }

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 likhadb-core                 = { path = "../likhadb-core" }
-likhadb-store                = { path = "../likhadb-store" }
-likhadb-persist              = { path = "../likhadb-persist" }
+likhadb-store                = { path = "../likhadb-store", features = ["fts"] }
+likhadb-persist              = { path = "../likhadb-persist", features = ["fts"] }
 axum                         = "0.7"
 tokio                        = { version = "1", features = ["full"] }
 serde                        = { workspace = true }

--- a/crates/likhadb-server/proto/likhadb.proto
+++ b/crates/likhadb-server/proto/likhadb.proto
@@ -13,6 +13,8 @@ service LikhaDb {
   rpc Query            (QueryRequest)            returns (QueryResponse);
   // Server-streaming variant — results arrive as an async stream.
   rpc QueryStream      (QueryRequest)            returns (stream ScoredResult);
+  // Hybrid vector + full-text search using Reciprocal Rank Fusion.
+  rpc HybridQuery      (HybridQueryRequest)      returns (HybridQueryResponse);
 }
 
 // ── Health ───────────────────────────────────────────────────────────────────
@@ -31,15 +33,16 @@ message IvfSq8Config  { uint32 nlist = 1; uint32 nprobe = 2; }
 message HnswConfig    { uint32 m = 1; uint32 ef_construction = 2; uint32 ef_search = 3; }
 
 message CreateCollectionRequest {
-  string name   = 1;
-  uint32 dim    = 2;
-  string metric = 3;
+  string name       = 1;
+  uint32 dim        = 2;
+  string metric     = 3;
   oneof index_config {
     FlatConfig   flat    = 4;
     IvfConfig    ivf     = 5;
     IvfSq8Config ivf_sq8 = 6;
     HnswConfig   hnsw    = 7;
   }
+  bool enable_fts = 8;
 }
 message CreateCollectionResponse {}
 
@@ -99,3 +102,19 @@ message ScoredResult {
 }
 
 message QueryResponse { repeated ScoredResult results = 1; }
+
+// ── Hybrid Query ──────────────────────────────────────────────────────────────
+
+message HybridQueryRequest {
+  string         collection      = 1;
+  repeated float vector          = 2;
+  string         text            = 3;
+  uint32         k               = 4;
+  // RRF rank constant. If 0, the server uses the default of 60.
+  uint32         rrf_k           = 5;
+  // JSON-encoded filter object; omit or send empty bytes for no filter.
+  bytes          filter_json     = 6;
+  bool           include_payload = 7;
+}
+
+message HybridQueryResponse { repeated ScoredResult results = 1; }

--- a/crates/likhadb-server/src/grpc/service.rs
+++ b/crates/likhadb-server/src/grpc/service.rs
@@ -9,8 +9,9 @@ pub mod proto {
 
 use proto::{
     likha_db_server::LikhaDb, CollectionInfo, CreateCollectionResponse, DeleteVectorResponse,
-    DropCollectionResponse, HealthRequest, HealthResponse, InsertVectorResponse,
-    ListCollectionsRequest, ListCollectionsResponse, QueryResponse, ScoredResult, VectorRecord,
+    DropCollectionResponse, HealthRequest, HealthResponse, HybridQueryResponse,
+    InsertVectorResponse, ListCollectionsRequest, ListCollectionsResponse, QueryResponse,
+    ScoredResult, VectorRecord,
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -62,17 +63,19 @@ impl LikhaDb for LikhaDbGrpc {
         let dim = req.dim as usize;
 
         use proto::create_collection_request::IndexConfig;
+        let name = req.name;
+        let enable_fts = req.enable_fts;
         let mut guard = self.state.write().await;
         match req.index_config {
             None | Some(IndexConfig::Flat(_)) => guard
-                .create_collection(req.name, dim, metric)
+                .create_collection(name.clone(), dim, metric)
                 .map_err(persist_err)?,
             Some(IndexConfig::Ivf(c)) => guard
-                .create_ivf_collection(req.name, dim, metric, c.nlist as usize, c.nprobe as usize)
+                .create_ivf_collection(name.clone(), dim, metric, c.nlist as usize, c.nprobe as usize)
                 .map_err(persist_err)?,
             Some(IndexConfig::IvfSq8(c)) => guard
                 .create_ivf_sq8_collection(
-                    req.name,
+                    name.clone(),
                     dim,
                     metric,
                     c.nlist as usize,
@@ -81,7 +84,7 @@ impl LikhaDb for LikhaDbGrpc {
                 .map_err(persist_err)?,
             Some(IndexConfig::Hnsw(c)) => guard
                 .create_hnsw_collection(
-                    req.name,
+                    name.clone(),
                     dim,
                     metric,
                     c.m as usize,
@@ -89,6 +92,9 @@ impl LikhaDb for LikhaDbGrpc {
                     c.ef_search as usize,
                 )
                 .map_err(persist_err)?,
+        }
+        if enable_fts {
+            guard.enable_fts(&name).map_err(persist_err)?;
         }
         Ok(Response::new(CreateCollectionResponse {}))
     }
@@ -206,6 +212,30 @@ impl LikhaDb for LikhaDbGrpc {
         };
         let results = encode_scored_results(results)?;
         Ok(Response::new(QueryResponse { results }))
+    }
+
+    async fn hybrid_query(
+        &self,
+        request: Request<proto::HybridQueryRequest>,
+    ) -> Result<Response<HybridQueryResponse>, Status> {
+        let req = request.into_inner();
+        let filter = decode_filter(&req.filter_json)?;
+        let rrf_k = if req.rrf_k == 0 { 60 } else { req.rrf_k };
+        let results = {
+            let guard = self.state.read().await;
+            let col = guard.get(&req.collection).map_err(core_err)?;
+            col.hybrid_search(
+                &req.vector,
+                &req.text,
+                req.k as usize,
+                rrf_k,
+                filter.as_ref(),
+                req.include_payload,
+            )
+            .map_err(core_err)?
+        };
+        let results = encode_scored_results(results)?;
+        Ok(Response::new(HybridQueryResponse { results }))
     }
 
     type QueryStreamStream = ReceiverStream<Result<ScoredResult, Status>>;

--- a/crates/likhadb-server/src/grpc/service.rs
+++ b/crates/likhadb-server/src/grpc/service.rs
@@ -71,7 +71,13 @@ impl LikhaDb for LikhaDbGrpc {
                 .create_collection(name.clone(), dim, metric)
                 .map_err(persist_err)?,
             Some(IndexConfig::Ivf(c)) => guard
-                .create_ivf_collection(name.clone(), dim, metric, c.nlist as usize, c.nprobe as usize)
+                .create_ivf_collection(
+                    name.clone(),
+                    dim,
+                    metric,
+                    c.nlist as usize,
+                    c.nprobe as usize,
+                )
                 .map_err(persist_err)?,
             Some(IndexConfig::IvfSq8(c)) => guard
                 .create_ivf_sq8_collection(

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -14,8 +14,9 @@ use crate::{
     error::ApiError,
     state::AppState,
     types::{
-        metric_str, parse_metric, CollectionInfo, CreateCollectionRequest, IndexConfig,
-        InsertRequest, QueryRequest, QueryResponse, VectorResponse,
+        metric_str, parse_metric, CollectionInfo, CreateCollectionRequest, HybridQueryRequest,
+        HybridQueryResponse, IndexConfig, InsertRequest, QueryRequest, QueryResponse,
+        VectorResponse,
     },
 };
 
@@ -37,6 +38,10 @@ pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
             get(get_vector).delete(delete_vector),
         )
         .route("/collections/:name/query", post(query_vectors))
+        .route(
+            "/collections/:name/hybrid-query",
+            post(hybrid_query_vectors),
+        )
         .layer(Extension(prometheus))
         .with_state(state)
 }
@@ -62,27 +67,32 @@ async fn create_collection(
     Json(req): Json<CreateCollectionRequest>,
 ) -> Result<StatusCode, ApiError> {
     let metric = parse_metric(&req.metric)?;
+    let name = req.name;
+    let enable_fts = req.enable_fts;
     let mut guard = state.write().await;
     match req.index {
-        IndexConfig::Flat => guard.create_collection(req.name, req.dim, metric)?,
+        IndexConfig::Flat => guard.create_collection(name.clone(), req.dim, metric)?,
         IndexConfig::Ivf { nlist, nprobe } => {
-            guard.create_ivf_collection(req.name, req.dim, metric, nlist, nprobe)?
+            guard.create_ivf_collection(name.clone(), req.dim, metric, nlist, nprobe)?
         }
         IndexConfig::IvfSq8 { nlist, nprobe } => {
-            guard.create_ivf_sq8_collection(req.name, req.dim, metric, nlist, nprobe)?
+            guard.create_ivf_sq8_collection(name.clone(), req.dim, metric, nlist, nprobe)?
         }
         IndexConfig::Hnsw {
             m,
             ef_construction,
             ef_search,
         } => guard.create_hnsw_collection(
-            req.name,
+            name.clone(),
             req.dim,
             metric,
             m,
             ef_construction,
             ef_search,
         )?,
+    }
+    if enable_fts {
+        guard.enable_fts(&name)?;
     }
     Ok(StatusCode::CREATED)
 }
@@ -200,4 +210,34 @@ async fn query_vectors(
     )
     .record(start.elapsed().as_secs_f64());
     Ok(Json(QueryResponse { results }))
+}
+
+#[tracing::instrument(skip(state, req), fields(collection = %name, k = req.k))]
+async fn hybrid_query_vectors(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<HybridQueryRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let start = Instant::now();
+    let (results, index_type) = {
+        let guard = state.read().await;
+        let col = guard.get(&name)?;
+        let index_type = col.index_type().to_string();
+        let results = col.hybrid_search(
+            &req.vector,
+            &req.text,
+            req.k,
+            req.rrf_k,
+            req.filter.as_ref(),
+            req.include_payload,
+        )?;
+        (results, index_type)
+    };
+    metrics::histogram!(
+        "likhadb_search_duration_seconds",
+        "collection" => name,
+        "index_type" => index_type
+    )
+    .record(start.elapsed().as_secs_f64());
+    Ok(Json(HybridQueryResponse { results }))
 }

--- a/crates/likhadb-server/src/types.rs
+++ b/crates/likhadb-server/src/types.rs
@@ -13,6 +13,8 @@ pub struct CreateCollectionRequest {
     pub metric: String,
     #[serde(default)]
     pub index: IndexConfig,
+    #[serde(default)]
+    pub enable_fts: bool,
 }
 
 #[derive(Deserialize, Default)]
@@ -74,6 +76,29 @@ pub struct QueryRequest {
 
 #[derive(Serialize)]
 pub struct QueryResponse {
+    pub results: Vec<ScoredResult>,
+}
+
+// ── Hybrid Query ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct HybridQueryRequest {
+    pub vector: Vector,
+    pub text: String,
+    pub k: usize,
+    #[serde(default = "default_rrf_k")]
+    pub rrf_k: u32,
+    pub filter: Option<Value>,
+    #[serde(default)]
+    pub include_payload: bool,
+}
+
+fn default_rrf_k() -> u32 {
+    60
+}
+
+#[derive(Serialize)]
+pub struct HybridQueryResponse {
     pub results: Vec<ScoredResult>,
 }
 

--- a/crates/likhadb-server/tests/hybrid_integration.rs
+++ b/crates/likhadb-server/tests/hybrid_integration.rs
@@ -1,0 +1,150 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use likhadb_persist::WalManager;
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, AppState};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn build_app() -> (axum::Router, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let wal = WalManager::open(dir.path()).unwrap();
+    let prometheus = install_prometheus();
+    seed_collection_gauges(&wal);
+    let state = AppState::new(wal);
+    (router(state, prometheus), dir)
+}
+
+fn json_req(method: &str, uri: &str, body: impl Into<String>) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.into()))
+        .unwrap()
+}
+
+async fn body_json(res: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn hybrid_query_returns_results() {
+    let (app, _dir) = build_app();
+
+    // Create collection with FTS enabled
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections",
+            r#"{"name":"hybrid_test","dim":3,"metric":"l2","enable_fts":true}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+
+    // Insert documents
+    for (id, body) in [
+        (1u64, "the quick brown fox"),
+        (2u64, "lazy dog sleeps all day"),
+        (3u64, "rust programming language"),
+    ] {
+        let payload = serde_json::json!({"body": body});
+        let vec_vals: Vec<f32> = vec![id as f32, 0.0, 0.0];
+        let req_body = serde_json::json!({
+            "id": id,
+            "vector": vec_vals,
+            "payload": payload
+        })
+        .to_string();
+        let res = app
+            .clone()
+            .oneshot(json_req("POST", "/collections/hybrid_test/vectors", req_body))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    }
+
+    // Hybrid query
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections/hybrid_test/hybrid-query",
+            r#"{"vector":[1.0,0.0,0.0],"text":"fox","k":3,"include_payload":true}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = body_json(res).await;
+    let results = body["results"].as_array().unwrap();
+    assert!(!results.is_empty(), "hybrid query should return results");
+    // top result should have a payload
+    assert!(results[0]["payload"].is_object());
+}
+
+#[tokio::test]
+async fn hybrid_query_without_fts_still_returns_vector_results() {
+    // Collection without FTS: hybrid_search returns only vector results (no fts contribution)
+    let (app, _dir) = build_app();
+
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections",
+            r#"{"name":"no_fts","dim":3,"metric":"l2"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+
+    for id in 1u64..=5 {
+        let req_body = serde_json::json!({
+            "id": id,
+            "vector": [id as f32, 0.0, 0.0],
+            "payload": {"n": id}
+        })
+        .to_string();
+        app.clone()
+            .oneshot(json_req("POST", "/collections/no_fts/vectors", req_body))
+            .await
+            .unwrap();
+    }
+
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections/no_fts/hybrid-query",
+            r#"{"vector":[1.0,0.0,0.0],"text":"anything","k":3}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_json(res).await;
+    let results = body["results"].as_array().unwrap();
+    // Should still get vector results (FTS contributes nothing but vector ranks fill in)
+    assert!(!results.is_empty());
+}
+
+#[tokio::test]
+async fn create_collection_without_enable_fts_defaults_false() {
+    let (app, _dir) = build_app();
+
+    // Omitting enable_fts should default to false (no FTS)
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections",
+            r#"{"name":"plain","dim":2,"metric":"l2"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+}

--- a/crates/likhadb-server/tests/hybrid_integration.rs
+++ b/crates/likhadb-server/tests/hybrid_integration.rs
@@ -62,7 +62,11 @@ async fn hybrid_query_returns_results() {
         .to_string();
         let res = app
             .clone()
-            .oneshot(json_req("POST", "/collections/hybrid_test/vectors", req_body))
+            .oneshot(json_req(
+                "POST",
+                "/collections/hybrid_test/vectors",
+                req_body,
+            ))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NO_CONTENT);

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -437,17 +437,28 @@ mod tests {
             }
             // sorted descending
             for w in results.windows(2) {
-                assert!(w[0].score >= w[1].score, "results must be sorted by score descending");
+                assert!(
+                    w[0].score >= w[1].score,
+                    "results must be sorted by score descending"
+                );
             }
         }
 
         #[test]
         fn hybrid_include_payload_returns_payload() {
             let mut c = make_fts_collection();
-            c.insert(1, vec![1.0, 0.0, 0.0], Some(json!({"body": "hello world", "tag": "a"})))
-                .unwrap();
-            c.insert(2, vec![2.0, 0.0, 0.0], Some(json!({"body": "foo bar", "tag": "b"})))
-                .unwrap();
+            c.insert(
+                1,
+                vec![1.0, 0.0, 0.0],
+                Some(json!({"body": "hello world", "tag": "a"})),
+            )
+            .unwrap();
+            c.insert(
+                2,
+                vec![2.0, 0.0, 0.0],
+                Some(json!({"body": "foo bar", "tag": "b"})),
+            )
+            .unwrap();
 
             let with_payload = c
                 .hybrid_search(&[1.0, 0.0, 0.0], "hello", 2, 60, None, true)
@@ -482,18 +493,42 @@ mod tests {
             //   id=2:  1/66 + 1/62    ≈ 0.03128
             let mut c = make_fts_collection();
 
-            c.insert(0, vec![0.001, 0.0, 0.0], Some(json!({"body": "animals birds completely unrelated"})))
-                .unwrap();
-            c.insert(99, vec![0.1, 0.0, 0.0], Some(json!({"body": "special word"})))
-                .unwrap();
-            c.insert(3, vec![1.0, 0.0, 0.0], Some(json!({"body": "generic noise text"})))
-                .unwrap();
-            c.insert(4, vec![5.0, 0.0, 0.0], Some(json!({"body": "generic noise content"})))
-                .unwrap();
-            c.insert(1, vec![100.0, 0.0, 0.0], Some(json!({"body": "special special special highlight"})))
-                .unwrap();
-            c.insert(2, vec![101.0, 0.0, 0.0], Some(json!({"body": "special special mention"})))
-                .unwrap();
+            c.insert(
+                0,
+                vec![0.001, 0.0, 0.0],
+                Some(json!({"body": "animals birds completely unrelated"})),
+            )
+            .unwrap();
+            c.insert(
+                99,
+                vec![0.1, 0.0, 0.0],
+                Some(json!({"body": "special word"})),
+            )
+            .unwrap();
+            c.insert(
+                3,
+                vec![1.0, 0.0, 0.0],
+                Some(json!({"body": "generic noise text"})),
+            )
+            .unwrap();
+            c.insert(
+                4,
+                vec![5.0, 0.0, 0.0],
+                Some(json!({"body": "generic noise content"})),
+            )
+            .unwrap();
+            c.insert(
+                1,
+                vec![100.0, 0.0, 0.0],
+                Some(json!({"body": "special special special highlight"})),
+            )
+            .unwrap();
+            c.insert(
+                2,
+                vec![101.0, 0.0, 0.0],
+                Some(json!({"body": "special special mention"})),
+            )
+            .unwrap();
 
             let query_vec = [0.0_f32, 0.0, 0.0];
             let query_text = "special";
@@ -512,7 +547,8 @@ mod tests {
                 .hybrid_search(&query_vec, query_text, 6, 60, None, false)
                 .unwrap();
             assert_eq!(
-                hybrid[0].id, 99,
+                hybrid[0].id,
+                99,
                 "hybrid top-1 should be id=99; got {:?}",
                 hybrid.iter().map(|r| r.id).collect::<Vec<_>>()
             );

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -91,6 +91,65 @@ impl Collection {
         }
     }
 
+    /// Hybrid vector + full-text search using Reciprocal Rank Fusion.
+    ///
+    /// `rrf_score(id) = 1/(rrf_k + rank_vec(id)) + 1/(rrf_k + rank_fts(id))`
+    /// where ranks are 1-based. IDs appearing in only one result list
+    /// contribute that list's term alone.
+    #[cfg(feature = "fts")]
+    pub fn hybrid_search(
+        &self,
+        vector: &[f32],
+        text: &str,
+        k: usize,
+        rrf_k: u32,
+        filter: Option<&Value>,
+        include_payload: bool,
+    ) -> Result<Vec<ScoredResult>> {
+        use std::collections::HashMap;
+
+        let candidate_k = k.saturating_mul(2).max(k);
+
+        let vec_results = self.search(vector, candidate_k, filter, false)?;
+        let fts_results = match &self.fts_index {
+            Some(idx) => idx.search(text, candidate_k)?,
+            None => vec![],
+        };
+
+        let mut scores: HashMap<VecId, f32> = HashMap::new();
+
+        for (rank0, r) in vec_results.iter().enumerate() {
+            let rrf = 1.0 / (rrf_k as f32 + rank0 as f32 + 1.0);
+            *scores.entry(r.id).or_insert(0.0) += rrf;
+        }
+
+        for (rank0, r) in fts_results.iter().enumerate() {
+            let rrf = 1.0 / (rrf_k as f32 + rank0 as f32 + 1.0);
+            *scores.entry(r.id).or_insert(0.0) += rrf;
+        }
+
+        let mut ranked: Vec<(VecId, f32)> = scores.into_iter().collect();
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranked.truncate(k);
+
+        let mut results: Vec<ScoredResult> = ranked
+            .into_iter()
+            .map(|(id, score)| ScoredResult {
+                id,
+                score,
+                payload: None,
+            })
+            .collect();
+
+        if include_payload {
+            for r in &mut results {
+                r.payload = self.meta.get(r.id).cloned();
+            }
+        }
+
+        Ok(results)
+    }
+
     pub fn insert(&mut self, id: VecId, vec: Vector, payload: Option<Value>) -> Result<()> {
         self.index.insert(id, vec)?;
         if let Some(p) = payload {
@@ -354,6 +413,109 @@ mod tests {
             let results = c.fts_search("xylophone", 5).unwrap();
             assert!(!results.is_empty(), "should find the unique doc");
             assert_eq!(results[0].id, 42, "best match should be id 42");
+        }
+
+        // ── hybrid_search tests ───────────────────────────────────────────────
+
+        #[test]
+        fn hybrid_rrf_scores_are_positive_and_top_k_respected() {
+            let mut c = make_fts_collection();
+            for i in 0..10u64 {
+                c.insert(
+                    i,
+                    vec![i as f32, 0.0, 0.0],
+                    Some(json!({"body": format!("doc {i} content")})),
+                )
+                .unwrap();
+            }
+            let results = c
+                .hybrid_search(&[0.0, 0.0, 0.0], "doc", 3, 60, None, false)
+                .unwrap();
+            assert_eq!(results.len(), 3);
+            for r in &results {
+                assert!(r.score > 0.0, "RRF score must be positive");
+            }
+            // sorted descending
+            for w in results.windows(2) {
+                assert!(w[0].score >= w[1].score, "results must be sorted by score descending");
+            }
+        }
+
+        #[test]
+        fn hybrid_include_payload_returns_payload() {
+            let mut c = make_fts_collection();
+            c.insert(1, vec![1.0, 0.0, 0.0], Some(json!({"body": "hello world", "tag": "a"})))
+                .unwrap();
+            c.insert(2, vec![2.0, 0.0, 0.0], Some(json!({"body": "foo bar", "tag": "b"})))
+                .unwrap();
+
+            let with_payload = c
+                .hybrid_search(&[1.0, 0.0, 0.0], "hello", 2, 60, None, true)
+                .unwrap();
+            assert!(with_payload.iter().all(|r| r.payload.is_some()));
+
+            let without_payload = c
+                .hybrid_search(&[1.0, 0.0, 0.0], "hello", 2, 60, None, false)
+                .unwrap();
+            assert!(without_payload.iter().all(|r| r.payload.is_none()));
+        }
+
+        #[test]
+        fn hybrid_beats_each_modality_alone_on_mixed_dataset() {
+            // Success criterion from BIZ.md:
+            // TARGET (id=99) wins hybrid top-1 even though:
+            //   - vector alone puts id=0 at top-1  (id=99 is vec rank 2)
+            //   - fts alone puts id=1 at top-1     (id=99 is fts rank 3)
+            //
+            // Dataset layout (6 docs):
+            //   id=0  (VEC CHAMP):   vec=[0.001], text="animals birds"   → vec rank 1, no FTS match
+            //   id=99 (TARGET):      vec=[0.1],   text="special word"    → vec rank 2, fts rank 3
+            //   id=3  (FILLER VEC):  vec=[1.0],   text="generic noise"   → vec rank 3, no FTS match
+            //   id=4  (FILLER VEC):  vec=[5.0],   text="generic noise"   → vec rank 4, no FTS match
+            //   id=1  (TEXT CHAMP):  vec=[100.0], text="special special special" → vec rank 5, fts rank 1
+            //   id=2  (NOISE TEXT):  vec=[101.0], text="special special mention" → vec rank 6, fts rank 2
+            //
+            // RRF scores (rrf_k=60, 0-based ranks):
+            //   id=0:  1/61            ≈ 0.01639
+            //   id=99: 1/62 + 1/63    ≈ 0.03200  ← WINS
+            //   id=1:  1/65 + 1/61    ≈ 0.03178
+            //   id=2:  1/66 + 1/62    ≈ 0.03128
+            let mut c = make_fts_collection();
+
+            c.insert(0, vec![0.001, 0.0, 0.0], Some(json!({"body": "animals birds completely unrelated"})))
+                .unwrap();
+            c.insert(99, vec![0.1, 0.0, 0.0], Some(json!({"body": "special word"})))
+                .unwrap();
+            c.insert(3, vec![1.0, 0.0, 0.0], Some(json!({"body": "generic noise text"})))
+                .unwrap();
+            c.insert(4, vec![5.0, 0.0, 0.0], Some(json!({"body": "generic noise content"})))
+                .unwrap();
+            c.insert(1, vec![100.0, 0.0, 0.0], Some(json!({"body": "special special special highlight"})))
+                .unwrap();
+            c.insert(2, vec![101.0, 0.0, 0.0], Some(json!({"body": "special special mention"})))
+                .unwrap();
+
+            let query_vec = [0.0_f32, 0.0, 0.0];
+            let query_text = "special";
+
+            // vector alone: id=0 is closest → top-1; id=99 is rank 2, not top-1
+            let vec_only = c.search(&query_vec, 6, None, false).unwrap();
+            assert_eq!(vec_only[0].id, 0, "vector alone: id=0 should be top-1");
+
+            // fts alone: id=1 has highest TF → top-1; id=99 is rank 3, not top-1
+            let fts_only = c.fts_search(query_text, 6).unwrap();
+            assert_eq!(fts_only[0].id, 1, "fts alone: id=1 should be top-1");
+            assert_ne!(fts_only[0].id, 99, "fts alone: id=99 must not be top-1");
+
+            // hybrid: id=99 accumulates from vec rank 2 + fts rank 3 → beats both champions
+            let hybrid = c
+                .hybrid_search(&query_vec, query_text, 6, 60, None, false)
+                .unwrap();
+            assert_eq!(
+                hybrid[0].id, 99,
+                "hybrid top-1 should be id=99; got {:?}",
+                hybrid.iter().map(|r| r.id).collect::<Vec<_>>()
+            );
         }
     }
 }

--- a/crates/likhadb-store/src/manager.rs
+++ b/crates/likhadb-store/src/manager.rs
@@ -133,6 +133,11 @@ impl CollectionManager {
         Ok(())
     }
 
+    #[cfg(feature = "fts")]
+    pub fn enable_fts(&mut self, name: &str) -> likhadb_core::Result<()> {
+        self.get_mut(name)?.enable_fts()
+    }
+
     #[cfg(feature = "persist")]
     pub(crate) fn insert_collection(&mut self, col: Collection) {
         self.collections.insert(col.name.clone(), col);

--- a/crates/likhadb-store/src/snapshot.rs
+++ b/crates/likhadb-store/src/snapshot.rs
@@ -12,6 +12,8 @@ pub struct CollectionSnapshot {
     pub metric: Metric,
     pub index: IndexSnapshot,
     pub meta: MetaStore,
+    #[serde(default)]
+    pub fts_enabled: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -29,12 +31,33 @@ impl Collection {
             metric: self.metric,
             index: self.index.to_snapshot(),
             meta: self.meta.clone(),
+            fts_enabled: self.is_fts_enabled(),
+        }
+    }
+
+    fn is_fts_enabled(&self) -> bool {
+        #[cfg(feature = "fts")]
+        {
+            self.fts_index.is_some()
+        }
+        #[cfg(not(feature = "fts"))]
+        {
+            false
         }
     }
 
     pub fn from_snapshot(snap: CollectionSnapshot) -> Self {
-        Self::with_index(snap.name, snap.dim, snap.metric, snap.index.into_box())
-            .with_meta(snap.meta)
+        let col = Self::with_index(snap.name, snap.dim, snap.metric, snap.index.into_box())
+            .with_meta(snap.meta);
+        #[cfg(feature = "fts")]
+        let col = {
+            let mut c = col;
+            if snap.fts_enabled {
+                let _ = c.enable_fts();
+            }
+            c
+        };
+        col
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `Collection::hybrid_search()` in `likhadb-store` using Reciprocal Rank Fusion: `rrf_score(id) = 1/(rrf_k + rank_vec) + 1/(rrf_k + rank_fts)` (default `rrf_k = 60`)
- New `HybridQuery` type in `likhadb-core` (vector + text + rrf_k + filter + include_payload)
- `enable_fts: bool` flag on collection creation (REST + gRPC) — durable via `WalOp::EnableFts` WAL entry and `CollectionSnapshot.fts_enabled` (backward-compatible with `#[serde(default)]`)
- `POST /collections/:name/hybrid-query` REST endpoint
- `HybridQuery` RPC + messages in the gRPC proto schema
- `likhadb-persist` gains an optional `fts` feature; `likhadb-server` enables it unconditionally

## Test plan

- [x] `cargo test --workspace` — all 181 tests pass, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Unit tests in `likhadb-store`: RRF scores positive, top-k respected, payload flag, BIZ.md success criterion (target doc wins hybrid when it's neither vec top-1 nor FTS top-1)
- [x] REST integration tests in `crates/likhadb-server/tests/hybrid_integration.rs`: hybrid query returns results, collection without FTS still returns vector results, `enable_fts` defaults to false

🤖 Generated with [Claude Code](https://claude.com/claude-code)