### PR TITLE
perf: eliminate per-search HashSet allocation in HNSW search_layer

### DIFF
--- a/crates/likhadb-bench/benches/search_bench.rs
+++ b/crates/likhadb-bench/benches/search_bench.rs
@@ -4,6 +4,7 @@ use likhadb_index::HnswIndex;
 use likhadb_index::{IvfIndex, VectorIndex};
 use likhadb_store::CollectionManager;
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::time::Duration;
 
 fn random_vec(rng: &mut StdRng, dim: usize) -> Vec<f32> {
     (0..dim).map(|_| rng.gen::<f32>()).collect()
@@ -240,7 +241,7 @@ fn bench_hnsw_build(
                 }
                 black_box(idx);
             },
-            BatchSize::SmallInput,
+            BatchSize::LargeInput,
         );
     });
 }
@@ -317,15 +318,7 @@ fn benchmarks(c: &mut Criterion) {
         bench_ivf_sq8_search(c, label, n, dim, nlist, nprobe);
     }
 
-    // HNSW build cost (one-time construction)
-    for &(label, n, dim) in &[
-        ("10k_d384", 10_000usize, 384usize),
-        ("100k_d384", 100_000, 384),
-    ] {
-        bench_hnsw_build(c, label, n, dim, 16, 200);
-    }
-
-    // HNSW search at varying ef_search
+    // HNSW search at varying ef_search (index pre-built outside the timing loop)
     for &(label, n, dim, ef_search) in &[
         ("10k_d384", 10_000usize, 384usize, 50usize),
         ("10k_d384", 10_000, 384, 100),
@@ -336,5 +329,23 @@ fn benchmarks(c: &mut Criterion) {
     }
 }
 
+/// HNSW build benchmarks in a separate group with tight time limits.
+/// Each iteration rebuilds the full index, so 100k vectors at d=384 takes
+/// several seconds — Criterion's default 100-sample target would take hours.
+fn hnsw_build_benchmarks(c: &mut Criterion) {
+    // Only 10k: a 100k build takes 5-10s per iteration; even sample_size=10
+    // at that cost would run for minutes. The 100k *search* bench (pre-built)
+    // already covers scale for query-time measurements.
+    bench_hnsw_build(c, "10k_d384", 10_000, 384, 16, 200);
+}
+
 criterion_group!(benches, benchmarks);
-criterion_main!(benches);
+criterion_group! {
+    name    = slow_benches;
+    config  = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(15));
+    targets = hnsw_build_benchmarks
+}
+criterion_main!(benches, slow_benches);

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -6,8 +6,8 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 // stamp array so concurrent `search` calls on different threads never interfere.
 // Epoch wraps at u64::MAX (18 quintillion searches per thread before collision).
 thread_local! {
-    static SEARCH_EPOCH: Cell<u64> = Cell::new(0);
-    static VISIT_STAMPS: RefCell<Vec<u64>> = RefCell::new(Vec::new());
+    static SEARCH_EPOCH: Cell<u64> = const { Cell::new(0) };
+    static VISIT_STAMPS: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
 }
 
 use ordered_float::OrderedFloat;

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -1,5 +1,14 @@
+use std::cell::{Cell, RefCell};
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashMap, HashSet};
+
+// Per-thread visited tracking: each thread maintains its own epoch counter and
+// stamp array so concurrent `search` calls on different threads never interfere.
+// Epoch wraps at u64::MAX (18 quintillion searches per thread before collision).
+thread_local! {
+    static SEARCH_EPOCH: Cell<u64> = Cell::new(0);
+    static VISIT_STAMPS: RefCell<Vec<u64>> = RefCell::new(Vec::new());
+}
 
 use ordered_float::OrderedFloat;
 
@@ -156,51 +165,64 @@ impl HnswIndex {
         ef: usize,
         level: usize,
     ) -> BinaryHeap<(OrderedFloat<f32>, usize)> {
-        // W: result set (max-heap, worst/farthest at top, size ≤ ef)
-        let mut w: BinaryHeap<(OrderedFloat<f32>, usize)> = BinaryHeap::new();
-        // C: candidates to expand (min-heap, nearest at top)
-        // We use Reverse to turn BinaryHeap into a min-heap.
-        let mut c: BinaryHeap<Reverse<(OrderedFloat<f32>, usize)>> = BinaryHeap::new();
-        let mut visited: HashSet<usize> = HashSet::new();
+        // Bump the per-thread epoch so every node looks unvisited at the start.
+        // No allocation: we reuse the thread-local stamps Vec across calls.
+        let epoch = SEARCH_EPOCH.with(|e| {
+            let next = e.get().wrapping_add(1);
+            e.set(next);
+            next
+        });
 
-        for &ep in entry_points {
-            let d = OrderedFloat(self.dist(query, ep));
-            w.push((d, ep));
-            c.push(std::cmp::Reverse((d, ep)));
-            visited.insert(ep);
-        }
-
-        while let Some(std::cmp::Reverse((c_dist, c_idx))) = c.pop() {
-            let f_dist = w.peek().map(|&(d, _)| d).unwrap_or(OrderedFloat(f32::MAX));
-            if c_dist > f_dist {
-                break; // every remaining candidate is farther than the worst result
+        VISIT_STAMPS.with(|cell| {
+            let mut stamps = cell.borrow_mut();
+            if stamps.len() < self.nodes.len() {
+                stamps.resize(self.nodes.len(), 0);
             }
 
-            // Expand neighbours of c_idx at this level
-            let neighbours = if level < self.nodes[c_idx].layers.len() {
-                self.nodes[c_idx].layers[level].clone()
-            } else {
-                vec![]
-            };
+            // W: result set (max-heap, worst/farthest at top, size ≤ ef)
+            let mut w: BinaryHeap<(OrderedFloat<f32>, usize)> = BinaryHeap::new();
+            // C: candidates to expand (min-heap, nearest at top)
+            let mut c: BinaryHeap<Reverse<(OrderedFloat<f32>, usize)>> = BinaryHeap::new();
 
-            for nbr in neighbours {
-                if visited.contains(&nbr) {
-                    continue;
-                }
-                visited.insert(nbr);
-                let d = OrderedFloat(self.dist(query, nbr));
+            for &ep in entry_points {
+                let d = OrderedFloat(self.dist(query, ep));
+                w.push((d, ep));
+                c.push(Reverse((d, ep)));
+                stamps[ep] = epoch;
+            }
+
+            while let Some(Reverse((c_dist, c_idx))) = c.pop() {
                 let f_dist = w.peek().map(|&(d, _)| d).unwrap_or(OrderedFloat(f32::MAX));
-                if d < f_dist || w.len() < ef {
-                    c.push(std::cmp::Reverse((d, nbr)));
-                    w.push((d, nbr));
-                    if w.len() > ef {
-                        w.pop(); // evict worst
+                if c_dist > f_dist {
+                    break; // every remaining candidate is farther than the worst result
+                }
+
+                // Borrow neighbours as a slice to avoid a Vec allocation per hop.
+                let neighbours: &[usize] = self.nodes[c_idx]
+                    .layers
+                    .get(level)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+
+                for &nbr in neighbours {
+                    if stamps[nbr] == epoch {
+                        continue;
+                    }
+                    stamps[nbr] = epoch;
+                    let d = OrderedFloat(self.dist(query, nbr));
+                    let f_dist = w.peek().map(|&(d, _)| d).unwrap_or(OrderedFloat(f32::MAX));
+                    if d < f_dist || w.len() < ef {
+                        c.push(Reverse((d, nbr)));
+                        w.push((d, nbr));
+                        if w.len() > ef {
+                            w.pop(); // evict worst
+                        }
                     }
                 }
             }
-        }
 
-        w
+            w
+        })
     }
 
     /// Select the `m_max` closest candidates from a max-heap, returning their node indices.


### PR DESCRIPTION
## Summary

- **Root cause of regressions**: `HashSet::with_capacity(ef * 4)` pre-allocated ~9 KB hash tables on every `search_layer` call (millions of times during a 100k build), costing more to allocate and blowing cache vs the default grow-on-demand approach.
- **Root cause of slow bench**: `measurement_time(60s)` in the `slow_benches` Criterion group made the build bench take 60s per benchmark (×2 = 120s) vs Criterion's natural ~8–15s handling.

## Changes

### `hnsw.rs` — thread-local generation stamps
Replace the per-`search_layer` `HashSet<usize>` with a zero-allocation generation-stamp scheme:
- Two `thread_local!` statics: `SEARCH_EPOCH: Cell<u64>` and `VISIT_STAMPS: RefCell<Vec<u64>>`
- Each `search_layer` call bumps the epoch; a node is "visited" iff `stamps[idx] == epoch`
- The stamps `Vec` grows once per thread as the index grows, then is reused indefinitely — no per-call allocation
- Thread-local isolation means concurrent `&self` searches on different threads are safe with zero synchronization

Also borrows the neighbour list as `&[usize]` instead of cloning a `Vec` per hop.

### `search_bench.rs` — bench config fixes
- Move HNSW build into its own `slow_benches` Criterion group with `sample_size(10)`, `warm_up_time(1s)`, `measurement_time(15s)` — bench finishes in ~17s instead of 60s+
- Drop the `100k_d384` build variant — a 100k build takes 5–10s per iteration; the 100k *search* bench (pre-built outside the timing loop) already covers query-time scale

## Test plan

- [ ] `cargo test -p likhadb-index --lib hnsw` — all 20 tests pass (including `high_recall`)
- [ ] `cargo build -p likhadb-bench --benches` — compiles clean
- [ ] `cargo bench -p likhadb-bench -- hnsw` — build bench finishes in ~17s; search benches show no regressions vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)