### PR TITLE
feat: implement L1 — Parquet import/export (likhadb-lakehouse)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/likhadb-server",
     "crates/likhadb-bench",
     "crates/likhadb-fts",
+    "crates/likhadb-lakehouse",
 ]
 resolver = "2"
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ the next begins.
 | Prometheus metrics | Done | `crates/likhadb-server/` |
 | Structured tracing | Done | `crates/likhadb-server/` |
 | Full-text search (`FtsIndex`, `TantivyFtsIndex`, `enable_fts`, `fts_search`) | Done (F1) | `crates/likhadb-fts/` |
-| Lakehouse I/O (Parquet) | **None** | — |
+| Lakehouse I/O (Parquet) | Done (L1) | `crates/likhadb-lakehouse/` |
 | Vector transforms | **None** | — |
 | Hybrid search (vec + FTS) | Done (F2) | `crates/likhadb-store/src/collection.rs`, `crates/likhadb-server/` |
 
@@ -162,7 +162,7 @@ pub struct HybridQuery {
 
 New crate: `crates/likhadb-lakehouse/` (depends on `arrow-rs`, `parquet`, `delta-rs`, `object_store`)
 
-### L1 — Parquet import / export
+### L1 — Parquet import / export ✅ Done
 
 **Goal:** Load vectors + metadata from Parquet files; export collections back to Parquet.
 

--- a/crates/likhadb-index/src/flat.rs
+++ b/crates/likhadb-index/src/flat.rs
@@ -200,6 +200,10 @@ impl VectorIndex for FlatIndex {
         self.dim
     }
 
+    fn list_ids(&self) -> Vec<VecId> {
+        self.ids.clone()
+    }
+
     fn index_type(&self) -> &'static str {
         "FlatIndex"
     }

--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -449,6 +449,14 @@ impl VectorIndex for HnswIndex {
         self.dim
     }
 
+    fn list_ids(&self) -> Vec<VecId> {
+        self.id_to_node
+            .keys()
+            .filter(|id| !self.deleted.contains(id))
+            .copied()
+            .collect()
+    }
+
     fn index_type(&self) -> &'static str {
         "HnswIndex"
     }

--- a/crates/likhadb-index/src/ivf.rs
+++ b/crates/likhadb-index/src/ivf.rs
@@ -666,6 +666,14 @@ impl VectorIndex for IvfIndex {
         self.dim
     }
 
+    fn list_ids(&self) -> Vec<VecId> {
+        if self.trained {
+            self.id_to_list.keys().copied().collect()
+        } else {
+            self.staging_ids.clone()
+        }
+    }
+
     fn index_type(&self) -> &'static str {
         "IvfIndex"
     }

--- a/crates/likhadb-index/src/traits.rs
+++ b/crates/likhadb-index/src/traits.rs
@@ -29,6 +29,9 @@ pub trait VectorIndex: Send + Sync {
         self.len() == 0
     }
 
+    /// Return all live vector IDs stored in this index.
+    fn list_ids(&self) -> Vec<VecId>;
+
     /// Index type name — used for observability/logging only.
     fn index_type(&self) -> &'static str;
 

--- a/crates/likhadb-lakehouse/Cargo.toml
+++ b/crates/likhadb-lakehouse/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name    = "likhadb-lakehouse"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+persist = ["dep:likhadb-persist"]
+
+[dependencies]
+likhadb-core    = { path = "../likhadb-core" }
+likhadb-store   = { path = "../likhadb-store" }
+likhadb-persist = { path = "../likhadb-persist", optional = true, features = ["fts"] }
+arrow           = "53"
+parquet         = { version = "53", features = ["arrow"] }
+serde_json      = { workspace = true }
+thiserror       = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/likhadb-lakehouse/src/error.rs
+++ b/crates/likhadb-lakehouse/src/error.rs
@@ -1,0 +1,35 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LakehouseError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Arrow error: {0}")]
+    Arrow(#[from] arrow::error::ArrowError),
+
+    #[error("Parquet error: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+
+    #[error("collection not found: {0}")]
+    CollectionNotFound(String),
+
+    #[error("column not found: '{0}'")]
+    ColumnNotFound(String),
+
+    #[error("schema error: {0}")]
+    Schema(String),
+
+    #[error("dimension mismatch: collection expects {expected}, Parquet vector has {got}")]
+    DimMismatch { expected: usize, got: usize },
+
+    #[error("type mismatch for column '{col}': expected {expected}, got {got}")]
+    TypeMismatch {
+        col: String,
+        expected: String,
+        got: String,
+    },
+
+    #[error("store error: {0}")]
+    Store(#[from] likhadb_core::LikhaDbError),
+}

--- a/crates/likhadb-lakehouse/src/lib.rs
+++ b/crates/likhadb-lakehouse/src/lib.rs
@@ -1,0 +1,8 @@
+mod error;
+pub mod parquet_io;
+
+#[cfg(feature = "persist")]
+mod wal_io;
+
+pub use error::LakehouseError;
+pub use parquet_io::LakehouseExt;

--- a/crates/likhadb-lakehouse/src/parquet_io.rs
+++ b/crates/likhadb-lakehouse/src/parquet_io.rs
@@ -1,0 +1,500 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, FixedSizeListArray, Int32Array,
+    Int64Array, StringArray, UInt32Array, UInt64Array, UInt64Builder,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use likhadb_store::manager::CollectionManager;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use serde_json::{Map, Value};
+
+use crate::error::LakehouseError;
+
+const ROW_GROUP_SIZE: usize = 65_536;
+
+pub trait LakehouseExt {
+    /// Export a collection to a Parquet file.
+    ///
+    /// Output schema: `id: UInt64`, `vector: FixedSizeList<Float32>[dim]`,
+    /// `payload: Utf8` (nullable, JSON-serialised payload).
+    fn export_parquet(
+        &self,
+        collection_name: &str,
+        path: &Path,
+    ) -> Result<(), LakehouseError>;
+
+    /// Import vectors from a Parquet file into an existing collection.
+    ///
+    /// - `id_col`: column for vector IDs (UInt64 or auto-castable integer).
+    /// - `vector_col`: column for vectors (`FixedSizeList<Float32>`).
+    /// - `payload_cols`: columns to merge into the vector payload JSON. A single
+    ///   column named `"payload"` whose values are JSON strings is parsed directly
+    ///   as the payload `Value` (enables lossless export→import round-trips).
+    ///
+    /// Returns the number of vectors imported.
+    fn import_parquet(
+        &mut self,
+        collection_name: &str,
+        path: &Path,
+        id_col: &str,
+        vector_col: &str,
+        payload_cols: &[&str],
+    ) -> Result<usize, LakehouseError>;
+}
+
+impl LakehouseExt for CollectionManager {
+    fn export_parquet(
+        &self,
+        collection_name: &str,
+        path: &Path,
+    ) -> Result<(), LakehouseError> {
+        let collection = self
+            .get(collection_name)
+            .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
+
+        let dim = collection.dim;
+        let ids = collection.list_ids();
+
+        let vector_item_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_item_field.clone(), dim as i32),
+                false,
+            ),
+            Field::new("payload", DataType::Utf8, true),
+        ]));
+
+        let file = std::fs::File::create(path)?;
+        let props = parquet::file::properties::WriterProperties::builder()
+            .set_max_row_group_size(ROW_GROUP_SIZE)
+            .build();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
+
+        for chunk in ids.chunks(ROW_GROUP_SIZE) {
+            let mut id_builder = UInt64Builder::with_capacity(chunk.len());
+            let mut float_values: Vec<f32> = Vec::with_capacity(chunk.len() * dim);
+            let mut payload_strings: Vec<Option<String>> = Vec::with_capacity(chunk.len());
+
+            for &id in chunk {
+                if let Ok(Some((vec, payload_opt))) = collection.get(id) {
+                    id_builder.append_value(id);
+                    float_values.extend_from_slice(&vec);
+                    payload_strings.push(payload_opt.as_ref().map(Value::to_string));
+                }
+            }
+
+            let id_array: ArrayRef = Arc::new(id_builder.finish());
+            let float_array = Arc::new(Float32Array::from(float_values));
+            let vector_array: ArrayRef = Arc::new(FixedSizeListArray::try_new(
+                vector_item_field.clone(),
+                dim as i32,
+                float_array,
+                None,
+            )?);
+            let payload_array: ArrayRef = Arc::new(StringArray::from(payload_strings));
+
+            let batch =
+                RecordBatch::try_new(schema.clone(), vec![id_array, vector_array, payload_array])?;
+            writer.write(&batch)?;
+        }
+
+        writer.close()?;
+        Ok(())
+    }
+
+    fn import_parquet(
+        &mut self,
+        collection_name: &str,
+        path: &Path,
+        id_col: &str,
+        vector_col: &str,
+        payload_cols: &[&str],
+    ) -> Result<usize, LakehouseError> {
+        // Scope the immutable borrow so we can borrow mutably per batch later.
+        let collection_dim = {
+            let col = self
+                .get(collection_name)
+                .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
+            col.dim
+        };
+
+        let file = std::fs::File::open(path)?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let schema = builder.schema().clone();
+
+        if schema.field_with_name(id_col).is_err() {
+            return Err(LakehouseError::ColumnNotFound(id_col.to_string()));
+        }
+        if schema.field_with_name(vector_col).is_err() {
+            return Err(LakehouseError::ColumnNotFound(vector_col.to_string()));
+        }
+
+        // Validate vector column type and extract embedded dim.
+        let vec_field = schema.field_with_name(vector_col).unwrap();
+        let parquet_dim = match vec_field.data_type() {
+            DataType::FixedSizeList(inner, size) => {
+                if !matches!(inner.data_type(), DataType::Float32) {
+                    return Err(LakehouseError::TypeMismatch {
+                        col: vector_col.to_string(),
+                        expected: "FixedSizeList<Float32>".to_string(),
+                        got: vec_field.data_type().to_string(),
+                    });
+                }
+                *size as usize
+            }
+            other => {
+                return Err(LakehouseError::TypeMismatch {
+                    col: vector_col.to_string(),
+                    expected: "FixedSizeList<Float32>".to_string(),
+                    got: other.to_string(),
+                });
+            }
+        };
+
+        if parquet_dim != collection_dim {
+            return Err(LakehouseError::DimMismatch {
+                expected: collection_dim,
+                got: parquet_dim,
+            });
+        }
+
+        let reader = builder.build()?;
+        let mut total: usize = 0;
+
+        for batch_result in reader {
+            let batch = batch_result?;
+            let num_rows = batch.num_rows();
+
+            let id_col_idx = batch
+                .schema()
+                .index_of(id_col)
+                .map_err(|_| LakehouseError::ColumnNotFound(id_col.to_string()))?;
+            let id_array_raw = batch.column(id_col_idx);
+            let id_array_cast: Arc<dyn Array> =
+                if id_array_raw.data_type() == &DataType::UInt64 {
+                    id_array_raw.clone()
+                } else {
+                    arrow::compute::cast(id_array_raw, &DataType::UInt64)?
+                };
+            let id_array = id_array_cast
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema("id column could not be cast to UInt64".to_string())
+                })?;
+
+            let vec_col_idx = batch
+                .schema()
+                .index_of(vector_col)
+                .map_err(|_| LakehouseError::ColumnNotFound(vector_col.to_string()))?;
+            let vec_array = batch
+                .column(vec_col_idx)
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema("vector column is not FixedSizeListArray".to_string())
+                })?;
+            let float_values = vec_array
+                .values()
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema("vector values are not Float32".to_string())
+                })?;
+
+            // Resolve payload column indices once per batch.
+            let payload_col_indices: Vec<(usize, &str)> = payload_cols
+                .iter()
+                .map(|&name| {
+                    batch
+                        .schema()
+                        .index_of(name)
+                        .map(|idx| (idx, name))
+                        .map_err(|_| LakehouseError::ColumnNotFound(name.to_string()))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let collection = self
+                .get_mut(collection_name)
+                .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
+
+            for row in 0..num_rows {
+                let id = id_array.value(row);
+                let start = row * collection_dim;
+                let end = start + collection_dim;
+                let vec: Vec<f32> = float_values.values()[start..end].to_vec();
+                let payload = build_payload(&batch, &payload_col_indices, row);
+                collection.insert(id, vec, payload)?;
+            }
+
+            total += num_rows;
+        }
+
+        Ok(total)
+    }
+}
+
+pub(crate) fn build_payload(
+    batch: &RecordBatch,
+    payload_col_indices: &[(usize, &str)],
+    row: usize,
+) -> Option<Value> {
+    if payload_col_indices.is_empty() {
+        return None;
+    }
+
+    // Single column named "payload" containing a JSON string → parse directly for round-trip.
+    if payload_col_indices.len() == 1 {
+        let (idx, name) = payload_col_indices[0];
+        if name == "payload" {
+            if let Some(arr) = batch.column(idx).as_any().downcast_ref::<StringArray>() {
+                if !arr.is_null(row) {
+                    let s = arr.value(row);
+                    if let Ok(v) = serde_json::from_str::<Value>(s) {
+                        return Some(v);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut map = Map::new();
+    for &(idx, name) in payload_col_indices {
+        let col = batch.column(idx);
+        if col.is_null(row) {
+            continue;
+        }
+        if let Some(v) = col_value_at(col.as_ref(), row) {
+            map.insert(name.to_string(), v);
+        }
+    }
+
+    if map.is_empty() {
+        None
+    } else {
+        Some(Value::Object(map))
+    }
+}
+
+fn col_value_at(col: &dyn Array, row: usize) -> Option<Value> {
+    let any = col.as_any();
+    if let Some(a) = any.downcast_ref::<StringArray>() {
+        return Some(Value::String(a.value(row).to_string()));
+    }
+    if let Some(a) = any.downcast_ref::<Int64Array>() {
+        return Some(Value::Number(a.value(row).into()));
+    }
+    if let Some(a) = any.downcast_ref::<Int32Array>() {
+        return Some(Value::Number(a.value(row).into()));
+    }
+    if let Some(a) = any.downcast_ref::<UInt64Array>() {
+        return Some(Value::Number(a.value(row).into()));
+    }
+    if let Some(a) = any.downcast_ref::<UInt32Array>() {
+        return Some(Value::Number(a.value(row).into()));
+    }
+    if let Some(a) = any.downcast_ref::<Float32Array>() {
+        let v = a.value(row) as f64;
+        return serde_json::Number::from_f64(v).map(Value::Number);
+    }
+    if let Some(a) = any.downcast_ref::<Float64Array>() {
+        let v = a.value(row);
+        return serde_json::Number::from_f64(v).map(Value::Number);
+    }
+    if let Some(a) = any.downcast_ref::<BooleanArray>() {
+        return Some(Value::Bool(a.value(row)));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use likhadb_core::Metric;
+    use tempfile::tempdir;
+
+    fn make_manager_with_collection(name: &str, dim: usize) -> CollectionManager {
+        let mut m = CollectionManager::new();
+        m.create_collection(name, dim, Metric::L2).unwrap();
+        m
+    }
+
+    #[test]
+    fn test_export_schema() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.parquet");
+
+        let mut m = make_manager_with_collection("c", 4);
+        let col = m.get_mut("c").unwrap();
+        col.insert(1, vec![1.0, 2.0, 3.0, 4.0], Some(serde_json::json!({"tag": "a"}))).unwrap();
+        col.insert(2, vec![5.0, 6.0, 7.0, 8.0], None).unwrap();
+
+        m.export_parquet("c", &path).unwrap();
+        assert!(path.exists());
+
+        let file = std::fs::File::open(&path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let schema = builder.schema();
+
+        assert_eq!(schema.field_with_name("id").unwrap().data_type(), &DataType::UInt64);
+        assert_eq!(
+            schema.field_with_name("payload").unwrap().data_type(),
+            &DataType::Utf8
+        );
+        let vec_field = schema.field_with_name("vector").unwrap();
+        assert!(matches!(vec_field.data_type(), DataType::FixedSizeList(_, 4)));
+    }
+
+    #[test]
+    fn test_export_null_payload() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.parquet");
+
+        let mut m = make_manager_with_collection("c", 2);
+        let col = m.get_mut("c").unwrap();
+        col.insert(1, vec![1.0, 2.0], None).unwrap();
+        col.insert(2, vec![3.0, 4.0], Some(serde_json::json!({"x": 1}))).unwrap();
+
+        m.export_parquet("c", &path).unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+        let batch = reader.into_iter().next().unwrap().unwrap();
+        let payload_col = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+
+        let null_count = (0..payload_col.len()).filter(|&i| payload_col.is_null(i)).count();
+        assert_eq!(null_count, 1);
+    }
+
+    #[test]
+    fn test_import_basic() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("import.parquet");
+
+        let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 3), false),
+            Field::new("payload", DataType::Utf8, true),
+        ]));
+
+        let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![10u64, 20, 30]));
+        let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]));
+        let vec_array: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap()
+        );
+        let payload_array: ArrayRef = Arc::new(StringArray::from(vec![
+            Some(r#"{"label":"a"}"#),
+            None,
+            Some(r#"{"label":"c"}"#),
+        ]));
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array, payload_array]).unwrap();
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut m = make_manager_with_collection("dst", 3);
+        let count = m.import_parquet("dst", &path, "id", "vector", &["payload"]).unwrap();
+        assert_eq!(count, 3);
+
+        let col = m.get("dst").unwrap();
+        assert_eq!(col.len(), 3);
+        let (vec, payload) = col.get(10).unwrap().unwrap();
+        assert_eq!(vec, vec![1.0, 2.0, 3.0]);
+        assert_eq!(payload.unwrap()["label"], "a");
+    }
+
+    #[test]
+    fn test_import_type_coercion() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("coerce.parquet");
+
+        let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 2), false),
+        ]));
+
+        let id_array: ArrayRef = Arc::new(Int64Array::from(vec![100i64, 200]));
+        let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0, 4.0]));
+        let vec_array: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap()
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
+
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut m = make_manager_with_collection("dst", 2);
+        let count = m.import_parquet("dst", &path, "id", "vector", &[]).unwrap();
+        assert_eq!(count, 2);
+        assert!(m.get("dst").unwrap().get(100).unwrap().is_some());
+        assert!(m.get("dst").unwrap().get(200).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_import_missing_column_errors() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.parquet");
+
+        let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 2), false),
+        ]));
+
+        let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![1u64]));
+        let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0]));
+        let vec_array: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap()
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
+
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut m = make_manager_with_collection("dst", 2);
+        let err = m.import_parquet("dst", &path, "id", "no_such_col", &[]).unwrap_err();
+        assert!(matches!(err, LakehouseError::ColumnNotFound(_)));
+    }
+
+    #[test]
+    fn test_import_dim_mismatch_errors() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("dim.parquet");
+
+        let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 3), false),
+        ]));
+
+        let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![1u64]));
+        let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0]));
+        let vec_array: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap()
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
+
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut m = make_manager_with_collection("dst", 4); // dim=4, file has dim=3
+        let err = m.import_parquet("dst", &path, "id", "vector", &[]).unwrap_err();
+        assert!(matches!(err, LakehouseError::DimMismatch { expected: 4, got: 3 }));
+    }
+}

--- a/crates/likhadb-lakehouse/src/parquet_io.rs
+++ b/crates/likhadb-lakehouse/src/parquet_io.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, FixedSizeListArray, Int32Array,
+    Array, ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, Float64Array, Int32Array,
     Int64Array, StringArray, UInt32Array, UInt64Array, UInt64Builder,
 };
 use arrow::datatypes::{DataType, Field, Schema};
@@ -21,11 +21,7 @@ pub trait LakehouseExt {
     ///
     /// Output schema: `id: UInt64`, `vector: FixedSizeList<Float32>[dim]`,
     /// `payload: Utf8` (nullable, JSON-serialised payload).
-    fn export_parquet(
-        &self,
-        collection_name: &str,
-        path: &Path,
-    ) -> Result<(), LakehouseError>;
+    fn export_parquet(&self, collection_name: &str, path: &Path) -> Result<(), LakehouseError>;
 
     /// Import vectors from a Parquet file into an existing collection.
     ///
@@ -47,11 +43,7 @@ pub trait LakehouseExt {
 }
 
 impl LakehouseExt for CollectionManager {
-    fn export_parquet(
-        &self,
-        collection_name: &str,
-        path: &Path,
-    ) -> Result<(), LakehouseError> {
+    fn export_parquet(&self, collection_name: &str, path: &Path) -> Result<(), LakehouseError> {
         let collection = self
             .get(collection_name)
             .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
@@ -176,12 +168,11 @@ impl LakehouseExt for CollectionManager {
                 .index_of(id_col)
                 .map_err(|_| LakehouseError::ColumnNotFound(id_col.to_string()))?;
             let id_array_raw = batch.column(id_col_idx);
-            let id_array_cast: Arc<dyn Array> =
-                if id_array_raw.data_type() == &DataType::UInt64 {
-                    id_array_raw.clone()
-                } else {
-                    arrow::compute::cast(id_array_raw, &DataType::UInt64)?
-                };
+            let id_array_cast: Arc<dyn Array> = if id_array_raw.data_type() == &DataType::UInt64 {
+                id_array_raw.clone()
+            } else {
+                arrow::compute::cast(id_array_raw, &DataType::UInt64)?
+            };
             let id_array = id_array_cast
                 .as_any()
                 .downcast_ref::<UInt64Array>()
@@ -332,7 +323,12 @@ mod tests {
 
         let mut m = make_manager_with_collection("c", 4);
         let col = m.get_mut("c").unwrap();
-        col.insert(1, vec![1.0, 2.0, 3.0, 4.0], Some(serde_json::json!({"tag": "a"}))).unwrap();
+        col.insert(
+            1,
+            vec![1.0, 2.0, 3.0, 4.0],
+            Some(serde_json::json!({"tag": "a"})),
+        )
+        .unwrap();
         col.insert(2, vec![5.0, 6.0, 7.0, 8.0], None).unwrap();
 
         m.export_parquet("c", &path).unwrap();
@@ -342,13 +338,19 @@ mod tests {
         let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
         let schema = builder.schema();
 
-        assert_eq!(schema.field_with_name("id").unwrap().data_type(), &DataType::UInt64);
+        assert_eq!(
+            schema.field_with_name("id").unwrap().data_type(),
+            &DataType::UInt64
+        );
         assert_eq!(
             schema.field_with_name("payload").unwrap().data_type(),
             &DataType::Utf8
         );
         let vec_field = schema.field_with_name("vector").unwrap();
-        assert!(matches!(vec_field.data_type(), DataType::FixedSizeList(_, 4)));
+        assert!(matches!(
+            vec_field.data_type(),
+            DataType::FixedSizeList(_, 4)
+        ));
     }
 
     #[test]
@@ -359,16 +361,26 @@ mod tests {
         let mut m = make_manager_with_collection("c", 2);
         let col = m.get_mut("c").unwrap();
         col.insert(1, vec![1.0, 2.0], None).unwrap();
-        col.insert(2, vec![3.0, 4.0], Some(serde_json::json!({"x": 1}))).unwrap();
+        col.insert(2, vec![3.0, 4.0], Some(serde_json::json!({"x": 1})))
+            .unwrap();
 
         m.export_parquet("c", &path).unwrap();
 
         let file = std::fs::File::open(&path).unwrap();
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
         let batch = reader.into_iter().next().unwrap().unwrap();
-        let payload_col = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+        let payload_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
 
-        let null_count = (0..payload_col.len()).filter(|&i| payload_col.is_null(i)).count();
+        let null_count = (0..payload_col.len())
+            .filter(|&i| payload_col.is_null(i))
+            .count();
         assert_eq!(null_count, 1);
     }
 
@@ -380,29 +392,37 @@ mod tests {
         let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::UInt64, false),
-            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 3), false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_field.clone(), 3),
+                false,
+            ),
             Field::new("payload", DataType::Utf8, true),
         ]));
 
         let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![10u64, 20, 30]));
-        let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]));
-        let vec_array: ArrayRef = Arc::new(
-            FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap()
-        );
+        let float_array = Arc::new(Float32Array::from(vec![
+            1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+        ]));
+        let vec_array: ArrayRef =
+            Arc::new(FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap());
         let payload_array: ArrayRef = Arc::new(StringArray::from(vec![
             Some(r#"{"label":"a"}"#),
             None,
             Some(r#"{"label":"c"}"#),
         ]));
 
-        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array, payload_array]).unwrap();
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![id_array, vec_array, payload_array]).unwrap();
         let file = std::fs::File::create(&path).unwrap();
         let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
         let mut m = make_manager_with_collection("dst", 3);
-        let count = m.import_parquet("dst", &path, "id", "vector", &["payload"]).unwrap();
+        let count = m
+            .import_parquet("dst", &path, "id", "vector", &["payload"])
+            .unwrap();
         assert_eq!(count, 3);
 
         let col = m.get("dst").unwrap();
@@ -420,14 +440,17 @@ mod tests {
         let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
-            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 2), false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_field.clone(), 2),
+                false,
+            ),
         ]));
 
         let id_array: ArrayRef = Arc::new(Int64Array::from(vec![100i64, 200]));
         let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0, 4.0]));
-        let vec_array: ArrayRef = Arc::new(
-            FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap()
-        );
+        let vec_array: ArrayRef =
+            Arc::new(FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
 
         let file = std::fs::File::create(&path).unwrap();
@@ -450,14 +473,17 @@ mod tests {
         let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::UInt64, false),
-            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 2), false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_field.clone(), 2),
+                false,
+            ),
         ]));
 
         let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![1u64]));
         let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0]));
-        let vec_array: ArrayRef = Arc::new(
-            FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap()
-        );
+        let vec_array: ArrayRef =
+            Arc::new(FixedSizeListArray::try_new(vector_field, 2, float_array, None).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
 
         let file = std::fs::File::create(&path).unwrap();
@@ -466,7 +492,9 @@ mod tests {
         writer.close().unwrap();
 
         let mut m = make_manager_with_collection("dst", 2);
-        let err = m.import_parquet("dst", &path, "id", "no_such_col", &[]).unwrap_err();
+        let err = m
+            .import_parquet("dst", &path, "id", "no_such_col", &[])
+            .unwrap_err();
         assert!(matches!(err, LakehouseError::ColumnNotFound(_)));
     }
 
@@ -478,14 +506,17 @@ mod tests {
         let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::UInt64, false),
-            Field::new("vector", DataType::FixedSizeList(vector_field.clone(), 3), false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_field.clone(), 3),
+                false,
+            ),
         ]));
 
         let id_array: ArrayRef = Arc::new(UInt64Array::from(vec![1u64]));
         let float_array = Arc::new(Float32Array::from(vec![1.0f32, 2.0, 3.0]));
-        let vec_array: ArrayRef = Arc::new(
-            FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap()
-        );
+        let vec_array: ArrayRef =
+            Arc::new(FixedSizeListArray::try_new(vector_field, 3, float_array, None).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![id_array, vec_array]).unwrap();
 
         let file = std::fs::File::create(&path).unwrap();
@@ -494,7 +525,15 @@ mod tests {
         writer.close().unwrap();
 
         let mut m = make_manager_with_collection("dst", 4); // dim=4, file has dim=3
-        let err = m.import_parquet("dst", &path, "id", "vector", &[]).unwrap_err();
-        assert!(matches!(err, LakehouseError::DimMismatch { expected: 4, got: 3 }));
+        let err = m
+            .import_parquet("dst", &path, "id", "vector", &[])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LakehouseError::DimMismatch {
+                expected: 4,
+                got: 3
+            }
+        ));
     }
 }

--- a/crates/likhadb-lakehouse/src/wal_io.rs
+++ b/crates/likhadb-lakehouse/src/wal_io.rs
@@ -1,0 +1,209 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, Float32Array, FixedSizeListArray, StringArray, UInt64Array, UInt64Builder,
+};
+use arrow::compute;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use likhadb_persist::WalManager;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use serde_json::Value;
+
+use crate::error::LakehouseError;
+use crate::parquet_io::{build_payload, LakehouseExt};
+
+const ROW_GROUP_SIZE: usize = 65_536;
+
+impl LakehouseExt for WalManager {
+    fn export_parquet(
+        &self,
+        collection_name: &str,
+        path: &Path,
+    ) -> Result<(), LakehouseError> {
+        let collection = self
+            .get(collection_name)
+            .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
+
+        let dim = collection.dim;
+        let ids = collection.list_ids();
+
+        let vector_item_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(vector_item_field.clone(), dim as i32),
+                false,
+            ),
+            Field::new("payload", DataType::Utf8, true),
+        ]));
+
+        let file = std::fs::File::create(path)?;
+        let props = parquet::file::properties::WriterProperties::builder()
+            .set_max_row_group_size(ROW_GROUP_SIZE)
+            .build();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
+
+        for chunk in ids.chunks(ROW_GROUP_SIZE) {
+            let mut id_builder = UInt64Builder::with_capacity(chunk.len());
+            let mut float_values: Vec<f32> = Vec::with_capacity(chunk.len() * dim);
+            let mut payload_strings: Vec<Option<String>> = Vec::with_capacity(chunk.len());
+
+            for &id in chunk {
+                if let Ok(Some((vec, payload_opt))) = collection.get(id) {
+                    id_builder.append_value(id);
+                    float_values.extend_from_slice(&vec);
+                    payload_strings.push(payload_opt.as_ref().map(Value::to_string));
+                }
+            }
+
+            let id_array: ArrayRef = Arc::new(id_builder.finish());
+            let float_array = Arc::new(Float32Array::from(float_values));
+            let vector_array: ArrayRef = Arc::new(FixedSizeListArray::try_new(
+                vector_item_field.clone(),
+                dim as i32,
+                float_array,
+                None,
+            )?);
+            let payload_array: ArrayRef = Arc::new(StringArray::from(payload_strings));
+
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![id_array, vector_array, payload_array],
+            )?;
+            writer.write(&batch)?;
+        }
+
+        writer.close()?;
+        Ok(())
+    }
+
+    fn import_parquet(
+        &mut self,
+        collection_name: &str,
+        path: &Path,
+        id_col: &str,
+        vector_col: &str,
+        payload_cols: &[&str],
+    ) -> Result<usize, LakehouseError> {
+        let collection_dim = {
+            let col = self
+                .get(collection_name)
+                .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
+            col.dim
+        };
+
+        let file = std::fs::File::open(path)?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let schema = builder.schema().clone();
+
+        if schema.field_with_name(id_col).is_err() {
+            return Err(LakehouseError::ColumnNotFound(id_col.to_string()));
+        }
+        if schema.field_with_name(vector_col).is_err() {
+            return Err(LakehouseError::ColumnNotFound(vector_col.to_string()));
+        }
+
+        let vec_field = schema.field_with_name(vector_col).unwrap();
+        let parquet_dim = match vec_field.data_type() {
+            DataType::FixedSizeList(inner, size) => {
+                if !matches!(inner.data_type(), DataType::Float32) {
+                    return Err(LakehouseError::TypeMismatch {
+                        col: vector_col.to_string(),
+                        expected: "FixedSizeList<Float32>".to_string(),
+                        got: vec_field.data_type().to_string(),
+                    });
+                }
+                *size as usize
+            }
+            other => {
+                return Err(LakehouseError::TypeMismatch {
+                    col: vector_col.to_string(),
+                    expected: "FixedSizeList<Float32>".to_string(),
+                    got: other.to_string(),
+                });
+            }
+        };
+
+        if parquet_dim != collection_dim {
+            return Err(LakehouseError::DimMismatch {
+                expected: collection_dim,
+                got: parquet_dim,
+            });
+        }
+
+        let reader = builder.build()?;
+        let mut total: usize = 0;
+
+        for batch_result in reader {
+            let batch = batch_result?;
+            let num_rows = batch.num_rows();
+
+            let id_col_idx = batch
+                .schema()
+                .index_of(id_col)
+                .map_err(|_| LakehouseError::ColumnNotFound(id_col.to_string()))?;
+            let id_array_raw = batch.column(id_col_idx);
+            let id_array_cast = if id_array_raw.data_type() == &DataType::UInt64 {
+                id_array_raw.clone()
+            } else {
+                compute::cast(id_array_raw, &DataType::UInt64)?
+            };
+            let id_array = id_array_cast
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema("id column could not be cast to UInt64".to_string())
+                })?;
+
+            let vec_col_idx = batch
+                .schema()
+                .index_of(vector_col)
+                .map_err(|_| LakehouseError::ColumnNotFound(vector_col.to_string()))?;
+            let vec_array = batch
+                .column(vec_col_idx)
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema(
+                        "vector column is not FixedSizeListArray".to_string(),
+                    )
+                })?;
+            let float_values = vec_array
+                .values()
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    LakehouseError::Schema("vector values are not Float32".to_string())
+                })?;
+
+            let payload_col_indices: Vec<(usize, &str)> = payload_cols
+                .iter()
+                .map(|&name| {
+                    batch
+                        .schema()
+                        .index_of(name)
+                        .map(|idx| (idx, name))
+                        .map_err(|_| LakehouseError::ColumnNotFound(name.to_string()))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for row in 0..num_rows {
+                let id = id_array.value(row);
+                let start = row * collection_dim;
+                let end = start + collection_dim;
+                let vec: Vec<f32> = float_values.values()[start..end].to_vec();
+                let payload = build_payload(&batch, &payload_col_indices, row);
+                self.insert(collection_name, id, vec, payload)
+                    .map_err(|e| LakehouseError::Schema(e.to_string()))?;
+            }
+
+            total += num_rows;
+        }
+
+        Ok(total)
+    }
+}

--- a/crates/likhadb-lakehouse/src/wal_io.rs
+++ b/crates/likhadb-lakehouse/src/wal_io.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, Float32Array, FixedSizeListArray, StringArray, UInt64Array, UInt64Builder,
+    ArrayRef, FixedSizeListArray, Float32Array, StringArray, UInt64Array, UInt64Builder,
 };
 use arrow::compute;
 use arrow::datatypes::{DataType, Field, Schema};
@@ -18,11 +18,7 @@ use crate::parquet_io::{build_payload, LakehouseExt};
 const ROW_GROUP_SIZE: usize = 65_536;
 
 impl LakehouseExt for WalManager {
-    fn export_parquet(
-        &self,
-        collection_name: &str,
-        path: &Path,
-    ) -> Result<(), LakehouseError> {
+    fn export_parquet(&self, collection_name: &str, path: &Path) -> Result<(), LakehouseError> {
         let collection = self
             .get(collection_name)
             .map_err(|_| LakehouseError::CollectionNotFound(collection_name.to_string()))?;
@@ -70,10 +66,8 @@ impl LakehouseExt for WalManager {
             )?);
             let payload_array: ArrayRef = Arc::new(StringArray::from(payload_strings));
 
-            let batch = RecordBatch::try_new(
-                schema.clone(),
-                vec![id_array, vector_array, payload_array],
-            )?;
+            let batch =
+                RecordBatch::try_new(schema.clone(), vec![id_array, vector_array, payload_array])?;
             writer.write(&batch)?;
         }
 
@@ -168,9 +162,7 @@ impl LakehouseExt for WalManager {
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
                 .ok_or_else(|| {
-                    LakehouseError::Schema(
-                        "vector column is not FixedSizeListArray".to_string(),
-                    )
+                    LakehouseError::Schema("vector column is not FixedSizeListArray".to_string())
                 })?;
             let float_values = vec_array
                 .values()

--- a/crates/likhadb-lakehouse/tests/round_trip.rs
+++ b/crates/likhadb-lakehouse/tests/round_trip.rs
@@ -1,0 +1,48 @@
+use likhadb_core::Metric;
+use likhadb_lakehouse::LakehouseExt;
+use likhadb_store::manager::CollectionManager;
+use tempfile::tempdir;
+
+#[test]
+fn parquet_round_trip_10k_vectors() {
+    let dir = tempdir().unwrap();
+    let parquet_path = dir.path().join("test.parquet");
+
+    // 1. Build source collection with 10k vectors (dim=16, L2)
+    let mut src = CollectionManager::new();
+    src.create_collection("src", 16, Metric::L2).unwrap();
+    {
+        let col = src.get_mut("src").unwrap();
+        for i in 0u64..10_000 {
+            let vec: Vec<f32> = (0..16).map(|d| (i * 16 + d) as f32 / 1000.0).collect();
+            let payload = Some(serde_json::json!({"idx": i, "label": format!("item_{i}")}));
+            col.insert(i, vec, payload).unwrap();
+        }
+    }
+
+    // 2. Export
+    src.export_parquet("src", &parquet_path).unwrap();
+    assert!(parquet_path.exists());
+
+    // 3. Import into a new collection
+    let mut dst = CollectionManager::new();
+    dst.create_collection("dst", 16, Metric::L2).unwrap();
+    let count = dst
+        .import_parquet("dst", &parquet_path, "id", "vector", &["payload"])
+        .unwrap();
+    assert_eq!(count, 10_000);
+    assert_eq!(dst.get("dst").unwrap().len(), 10_000);
+
+    // 4. Verify search results are identical
+    let query: Vec<f32> = (0..16).map(|d| d as f32 / 1000.0).collect();
+    let src_results = src.get("src").unwrap().search(&query, 10, None, false).unwrap();
+    let dst_results = dst.get("dst").unwrap().search(&query, 10, None, false).unwrap();
+
+    assert_eq!(src_results.len(), dst_results.len());
+
+    let mut src_ids: Vec<u64> = src_results.iter().map(|r| r.id).collect();
+    let mut dst_ids: Vec<u64> = dst_results.iter().map(|r| r.id).collect();
+    src_ids.sort_unstable();
+    dst_ids.sort_unstable();
+    assert_eq!(src_ids, dst_ids, "top-10 result IDs must match after round-trip");
+}

--- a/crates/likhadb-lakehouse/tests/round_trip.rs
+++ b/crates/likhadb-lakehouse/tests/round_trip.rs
@@ -35,8 +35,16 @@ fn parquet_round_trip_10k_vectors() {
 
     // 4. Verify search results are identical
     let query: Vec<f32> = (0..16).map(|d| d as f32 / 1000.0).collect();
-    let src_results = src.get("src").unwrap().search(&query, 10, None, false).unwrap();
-    let dst_results = dst.get("dst").unwrap().search(&query, 10, None, false).unwrap();
+    let src_results = src
+        .get("src")
+        .unwrap()
+        .search(&query, 10, None, false)
+        .unwrap();
+    let dst_results = dst
+        .get("dst")
+        .unwrap()
+        .search(&query, 10, None, false)
+        .unwrap();
 
     assert_eq!(src_results.len(), dst_results.len());
 
@@ -44,5 +52,8 @@ fn parquet_round_trip_10k_vectors() {
     let mut dst_ids: Vec<u64> = dst_results.iter().map(|r| r.id).collect();
     src_ids.sort_unstable();
     dst_ids.sort_unstable();
-    assert_eq!(src_ids, dst_ids, "top-10 result IDs must match after round-trip");
+    assert_eq!(
+        src_ids, dst_ids,
+        "top-10 result IDs must match after round-trip"
+    );
 }

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 likhadb-core                 = { path = "../likhadb-core" }
 likhadb-store                = { path = "../likhadb-store", features = ["fts"] }
 likhadb-persist              = { path = "../likhadb-persist", features = ["fts"] }
+likhadb-lakehouse            = { path = "../likhadb-lakehouse", features = ["persist"] }
 axum                         = "0.7"
 tokio                        = { version = "1", features = ["full"] }
 serde                        = { workspace = true }

--- a/crates/likhadb-server/src/error.rs
+++ b/crates/likhadb-server/src/error.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use likhadb_core::LikhaDbError;
+use likhadb_lakehouse::LakehouseError;
 use likhadb_persist::PersistError;
 use serde_json::json;
 
@@ -43,6 +44,19 @@ impl From<LikhaDbError> for ApiError {
                 ApiError::BadRequest(e.to_string())
             }
             LikhaDbError::Fts(_) => ApiError::Internal(e.to_string()),
+        }
+    }
+}
+
+impl From<LakehouseError> for ApiError {
+    fn from(e: LakehouseError) -> Self {
+        match e {
+            LakehouseError::CollectionNotFound(_) => ApiError::NotFound(e.to_string()),
+            LakehouseError::DimMismatch { .. }
+            | LakehouseError::TypeMismatch { .. }
+            | LakehouseError::Schema(_)
+            | LakehouseError::ColumnNotFound(_) => ApiError::BadRequest(e.to_string()),
+            _ => ApiError::Internal(e.to_string()),
         }
     }
 }

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -10,13 +10,15 @@ use axum::{
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde_json::json;
 
+use likhadb_lakehouse::LakehouseExt;
+
 use crate::{
     error::ApiError,
     state::AppState,
     types::{
-        metric_str, parse_metric, CollectionInfo, CreateCollectionRequest, HybridQueryRequest,
-        HybridQueryResponse, IndexConfig, InsertRequest, QueryRequest, QueryResponse,
-        VectorResponse,
+        metric_str, parse_metric, CollectionInfo, CreateCollectionRequest, ExportParquetRequest,
+        HybridQueryRequest, HybridQueryResponse, ImportParquetRequest, ImportParquetResponse,
+        IndexConfig, InsertRequest, QueryRequest, QueryResponse, VectorResponse,
     },
 };
 
@@ -41,6 +43,14 @@ pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
         .route(
             "/collections/:name/hybrid-query",
             post(hybrid_query_vectors),
+        )
+        .route(
+            "/collections/:name/import-parquet",
+            post(import_parquet),
+        )
+        .route(
+            "/collections/:name/export-parquet",
+            post(export_parquet),
         )
         .layer(Extension(prometheus))
         .with_state(state)
@@ -240,4 +250,31 @@ async fn hybrid_query_vectors(
     )
     .record(start.elapsed().as_secs_f64());
     Ok(Json(HybridQueryResponse { results }))
+}
+
+async fn import_parquet(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<ImportParquetRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let path = std::path::Path::new(&req.path);
+    let payload_cols: Vec<&str> = req.payload_cols.iter().map(String::as_str).collect();
+    let imported = {
+        let mut guard = state.write().await;
+        guard.import_parquet(&name, path, &req.id_col, &req.vector_col, &payload_cols)?
+    };
+    Ok((StatusCode::OK, Json(ImportParquetResponse { imported })))
+}
+
+async fn export_parquet(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<ExportParquetRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let path = std::path::Path::new(&req.path);
+    {
+        let guard = state.read().await;
+        guard.export_parquet(&name, path)?;
+    }
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -44,14 +44,8 @@ pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
             "/collections/:name/hybrid-query",
             post(hybrid_query_vectors),
         )
-        .route(
-            "/collections/:name/import-parquet",
-            post(import_parquet),
-        )
-        .route(
-            "/collections/:name/export-parquet",
-            post(export_parquet),
-        )
+        .route("/collections/:name/import-parquet", post(import_parquet))
+        .route("/collections/:name/export-parquet", post(export_parquet))
         .layer(Extension(prometheus))
         .with_state(state)
 }

--- a/crates/likhadb-server/src/types.rs
+++ b/crates/likhadb-server/src/types.rs
@@ -102,6 +102,27 @@ pub struct HybridQueryResponse {
     pub results: Vec<ScoredResult>,
 }
 
+// ── Lakehouse I/O ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ImportParquetRequest {
+    pub path: String,
+    pub id_col: String,
+    pub vector_col: String,
+    #[serde(default)]
+    pub payload_cols: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct ImportParquetResponse {
+    pub imported: usize,
+}
+
+#[derive(Deserialize)]
+pub struct ExportParquetRequest {
+    pub path: String,
+}
+
 // ── Metric helpers ────────────────────────────────────────────────────────────
 
 pub fn parse_metric(s: &str) -> Result<Metric, ApiError> {

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -204,6 +204,10 @@ impl Collection {
         ids.iter().map(|&id| self.get(id)).collect()
     }
 
+    pub fn list_ids(&self) -> Vec<likhadb_core::VecId> {
+        self.index.list_ids()
+    }
+
     pub fn len(&self) -> usize {
         self.index.len()
     }


### PR DESCRIPTION
## Summary

- Adds new `crates/likhadb-lakehouse` crate with `LakehouseExt` extension trait providing `import_parquet` and `export_parquet` on both `CollectionManager` (library use) and `WalManager` (server use, WAL-durable inserts)
- Adds `list_ids()` to `VectorIndex` trait and all three index implementations (`FlatIndex`, `IvfIndex`, `HnswIndex`) plus `Collection::list_ids()` — needed for export iteration
- Adds two new REST endpoints to `likhadb-server`: `POST /collections/:name/import-parquet` and `POST /collections/:name/export-parquet`

**Export schema** (always fixed): `id: UInt64`, `vector: FixedSizeList<Float32>[dim]`, `payload: Utf8` (nullable, JSON-serialised)

**Import**: validates schema, detects dim mismatches, coerces `Int64`→`u64` IDs, special-cases a `"payload"` Utf8 column for lossless round-trips

## Test plan

- [ ] 6 unit tests in `likhadb-lakehouse`: export schema, null payload export, basic import, Int64 coercion, missing column error, dim mismatch error
- [ ] Round-trip integration test: insert 10k vectors (dim=16) → `export_parquet` → `import_parquet` into new collection → assert top-10 search results are identical
- [ ] Full workspace: `cargo test --workspace` — 165 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)