### PR TITLE
feat: scaffold likhadb-query crate — Tier Q Step 1 (config + error type)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/likhadb-fts",
     "crates/likhadb-lakehouse",
     "crates/likhadb-stress",
+    "crates/likhadb-query",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,8 @@ Rayon uses the default thread pool (all available cores).
 | **F — Observability** | Done | Prometheus metrics (`/metrics`) + structured JSON tracing |
 | **F1 — Full-text search** | Done | Tantivy BM25 index per collection, opt-in via `fts` feature |
 | **F2 — Hybrid search** | Done | RRF fusion of vector similarity + BM25 scores |
-| **L — Lakehouse I/O** | Planned | Parquet import/export, object storage (S3/GCS), Delta Lake |
+| **L — Lakehouse I/O** | Planned | Parquet import/export, object storage (S3/GCS), Iceberg |
+| **Q — DataFusion pipeline** | In Progress | Post-ANN enrichment, ACL enforcement, multi-signal score fusion, reranking (`likhadb-query` crate) |
 | **T — Vector transforms** | Planned | Insert-time L2 normalisation, scalar scaling |
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,201 +51,69 @@ cargo clippy -p likhadb-store --features fts -- -D warnings
 
 ---
 
-## Quick usage
+## Query flow
 
-### Exact search (FlatIndex)
+End-to-end path from client request to ranked response, covering both the current ANN+RRF path and the planned DataFusion enrichment tier (Tier Q):
 
-```rust
-use likhadb_core::Metric;
-use likhadb_store::CollectionManager;
-use serde_json::json;
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Server as likhadb-server<br/>(axum / tonic)
+    participant WAL as WalManager<br/>(likhadb-persist)
+    participant Store as Collection<br/>(likhadb-store)
+    participant ANN as VectorIndex<br/>(HNSW / IVF / Flat)
+    participant FTS as FtsIndex<br/>(Tantivy / BM25)
+    participant Pipeline as QueryPipeline<br/>(likhadb-query · Tier Q)
+    participant DF as DataFusion<br/>SessionContext
+    participant Parquet as Parquet tables<br/>(documents · authors · acl)
 
-let mut mgr = CollectionManager::new();
-mgr.create_collection("documents", 384, Metric::Cosine).unwrap();
+    Client->>Server: POST /collections/:name/query<br/>{ vector, text?, k, filter? }
+    Server->>WAL: acquire read lock
 
-let col = mgr.get_mut("documents").unwrap();
-col.insert(1, vec![0.1; 384], Some(json!({"category": "news"}))).unwrap();
-col.insert(2, vec![0.9; 384], Some(json!({"category": "sports"}))).unwrap();
-col.insert(3, vec![0.5; 384], Some(json!({"category": "news"}))).unwrap();
+    alt vector-only query
+        WAL->>Store: search(vector, top_n, filter)
+        Store->>ANN: knn(vector, top_n)
+        ANN-->>Store: [(id, distance, rank)]
+        Store-->>WAL: Vec<ScoredResult>
+    else hybrid query (vector + text)
+        WAL->>Store: hybrid_search(vector, text, 2k)
+        Store->>ANN: knn(vector, 2k)
+        ANN-->>Store: [(id, distance, rank_vec)]
+        Store->>FTS: fts_search(text, 2k)
+        FTS-->>Store: [(id, bm25_score, rank_fts)]
+        Store->>Store: RRF fusion<br/>score = 1/(60+rank_vec) + 1/(60+rank_fts)
+        Store-->>WAL: Vec<ScoredResult> top-k
+    end
 
-let predicate = json!({"field": "category", "op": "eq", "value": "news"});
-let results = col.search(&vec![0.15; 384], 5, Some(&predicate), false).unwrap();
+    WAL-->>Server: candidates (id, distance, rank)
+    Server->>Server: drop read lock
+
+    rect rgb(230, 245, 255)
+        note over Pipeline,Parquet: Tier Q — DataFusion enrichment (planned, likhadb-query)
+        Server->>Pipeline: run(candidates, k)
+        Pipeline->>DF: register candidates MemTable<br/>(id, ann_distance, ann_rank)
+        Pipeline->>DF: Stage 3 — enrichment SQL<br/>JOIN documents, authors<br/>WHERE acl allows + sensitivity != restricted
+        DF->>Parquet: predicate-pushdown reads
+        Parquet-->>DF: filtered row groups
+        DF-->>Pipeline: enriched RecordBatch
+
+        Pipeline->>DF: Stage 4a — score fusion SQL<br/>fusion = w_vec×norm(ann_dist) + w_rec×recency_decay
+        DF-->>Pipeline: top-M ranked by fusion_score
+
+        Pipeline->>Pipeline: Stage 4b — bi-encoder<br/>materialize top-M → batched model call → zip bi_scores
+        Pipeline->>Pipeline: Stage 4c — cross-encoder<br/>materialize top-P → batched model call → zip scores
+        Pipeline-->>Server: Vec<ScoredResult> top-K
+    end
+
+    Server-->>Client: { results: [{ id, score, payload }] }
 ```
 
-### Approximate search (IvfIndex)
+> **Tier Q note:** stages inside the blue box are implemented by the `likhadb-query` crate (currently in progress — Q0 config/error done; Q1–Q4 planned). Without Tier Q the server returns the ANN/RRF result directly.
 
-```rust
-use likhadb_core::Metric;
-use likhadb_store::CollectionManager;
+For a deeper walkthrough of each stage see [`docs/rfc_datafusion_integration.md`](docs/rfc_datafusion_integration.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
-let mut mgr = CollectionManager::new();
-// nlist=1024: k-means clusters (also the training trigger threshold)
-// nprobe=16:  clusters searched per query — higher = better recall, slower queries
-mgr.create_ivf_collection("docs", 384, Metric::L2, 1024, 16).unwrap();
-
-let col = mgr.get_mut("docs").unwrap();
-for i in 0..100_000u64 {
-    col.insert(i, vec![i as f32 / 100_000.0; 384], None).unwrap();
-}
-let results = col.search(&vec![0.5; 384], 10, None, false).unwrap();
-```
-
-**nlist / nprobe guidance:**
-- `nlist`: typically `sqrt(N)` to `4 * sqrt(N)`. For 100 k vectors, 256–1024 is a good range.
-- `nprobe`: start at `nlist / 64` for speed, increase toward `nlist / 8` for higher recall.
-- `nprobe == nlist` gives exact recall identical to `FlatIndex`.
-
-### Approximate search + 4× memory reduction (IvfIndex + SQ8)
-
-```rust
-// Same parameters as IvfIndex — just swap the constructor.
-// After training, each vector is stored as dim × u8 instead of dim × f32.
-mgr.create_ivf_sq8_collection("docs_sq8", 384, Metric::L2, 1024, 16).unwrap();
-```
-
-Memory: 100 k × d384 goes from ~146 MB (f32) to ~36 MB (u8). Distance computation
-uses asymmetric evaluation — the query stays in f32 while stored codes are decoded
-on-the-fly.
-
-### Graph-based approximate search (HnswIndex)
-
-```rust
-use likhadb_core::Metric;
-use likhadb_store::CollectionManager;
-
-let mut mgr = CollectionManager::new();
-// m=16: graph density · ef_construction=200: build quality · ef_search=50: query recall
-mgr.create_hnsw_collection("docs", 384, Metric::Cosine, 16, 200, 50).unwrap();
-
-let col = mgr.get_mut("docs").unwrap();
-for i in 0..100_000u64 {
-    col.insert(i, vec![i as f32 / 100_000.0; 384], None).unwrap();
-}
-let results = col.search(&vec![0.5; 384], 10, None, false).unwrap();
-```
-
-**m / ef_construction / ef_search guidance:**
-- `m`: typically 8–32. Higher `m` increases memory and improves recall. 16 is a good default.
-- `ef_construction`: must be ≥ `m`. 200 is a good default.
-- `ef_search`: must be ≥ 1. Increase to trade latency for recall. Start at 50.
-
-### Full-text search (FtsIndex)
-
-Enable per-collection with the `fts` Cargo feature. All string values in the JSON payload
-(including nested objects and arrays) are indexed automatically. Scores are BM25.
-
-```toml
-# Cargo.toml
-likhadb-store = { path = "crates/likhadb-store", features = ["fts"] }
-```
-
-```rust
-use likhadb_core::Metric;
-use likhadb_store::CollectionManager;
-use serde_json::json;
-
-let mut mgr = CollectionManager::new();
-mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
-
-let col = mgr.get_mut("articles").unwrap();
-col.enable_fts().unwrap();   // activates the Tantivy in-memory index
-
-col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio and async-std"}))).unwrap();
-col.insert(2, vec![0.2; 384], Some(json!({"title": "Python data science", "body": "numpy pandas sklearn"}))).unwrap();
-col.insert(3, vec![0.3; 384], Some(json!({"title": "Rust memory model", "body": "ownership borrowing lifetimes"}))).unwrap();
-
-// BM25 full-text search — returns top-k results ranked by relevance
-let results = col.fts_search("Rust ownership", 5).unwrap();
-// results[0].id == 3  (highest BM25 score for "ownership")
-// results[1].id == 1  (matches "Rust")
-```
-
-Deletions are propagated automatically: `col.delete(id)` removes the vector, the payload, and the FTS document in one call.
-
-### Hybrid search (vector + BM25 via RRF)
-
-Pass `enable_fts: true` at collection creation. Hybrid search fuses vector similarity ranks and BM25 text ranks using Reciprocal Rank Fusion:
-
-```
-rrf_score(id) = 1/(rrf_k + rank_vec) + 1/(rrf_k + rank_fts)    // default rrf_k = 60
-```
-
-A document that ranks 2nd by vector similarity and 3rd by keyword relevance beats a document that is top-1 in only one modality.
-
-```rust
-use likhadb_core::Metric;
-use likhadb_store::CollectionManager;
-use serde_json::json;
-
-let mut mgr = CollectionManager::new();
-mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
-
-let col = mgr.get_mut("articles").unwrap();
-col.enable_fts().unwrap();   // activates Tantivy BM25 index
-
-col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio"}))).unwrap();
-col.insert(2, vec![0.5; 384], Some(json!({"title": "Python ML", "body": "numpy sklearn"}))).unwrap();
-col.insert(3, vec![0.2; 384], Some(json!({"title": "Rust memory model", "body": "ownership lifetimes"}))).unwrap();
-
-// Returns top-5 fusing semantic + keyword signals
-let results = col.hybrid_search(
-    &vec![0.15; 384],  // query embedding
-    "Rust ownership",  // keyword query
-    5,                 // k
-    60,                // rrf_k
-    None,              // metadata filter
-    true,              // include_payload
-).unwrap();
-```
-
-**REST API:**
-```sh
-# Create collection with FTS enabled
-curl -X POST localhost:8080/collections \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"articles","dim":384,"metric":"cosine","enable_fts":true}'
-
-# Hybrid query
-curl -X POST localhost:8080/collections/articles/hybrid-query \
-  -H 'Content-Type: application/json' \
-  -d '{"vector":[...],"text":"Rust ownership","k":5,"include_payload":true}'
-```
-
----
-
-### Snapshot persistence
-
-```rust
-use std::path::Path;
-use likhadb_persist::PersistExt;
-use likhadb_store::CollectionManager;
-
-mgr.save(Path::new("snapshot.bin")).unwrap();
-
-// On next startup — all collections, index state, and payloads are restored.
-let mgr = CollectionManager::load(Path::new("snapshot.bin")).unwrap();
-```
-
-### Write-Ahead Log
-
-```rust
-use std::path::Path;
-use likhadb_core::Metric;
-use likhadb_persist::WalManager;
-
-// On restart after a crash: loads last snapshot then replays uncommitted WAL entries.
-let mut wal = WalManager::open(Path::new("/data/mydb")).unwrap();
-
-wal.create_collection("docs", 384, Metric::Cosine).unwrap();
-wal.insert("docs", 1, vec![0.1; 384], Some(serde_json::json!({"title": "hello"}))).unwrap();
-wal.delete("docs", 1).unwrap();
-
-let results = wal.get("docs").unwrap()
-    .search(&[0.5; 384], 10, None, false).unwrap();
-
-// Collapse WAL into a fresh snapshot and truncate wal.log.
-wal.checkpoint().unwrap();
-```
+See [`docs/quick-usages.md`](docs/quick-usages.md) for Rust API and REST usage examples.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,6 +268,25 @@ DataFusion           →   enrichment + filtering + scoring + reranking
 Iceberg (object store) → source of truth for embeddings, metadata, business tables
 ```
 
+### Q0 — Config + error type ✅ Done
+
+**Goal:** Scaffold the `likhadb-query` crate with typed configuration and a structured error
+type. All invariants are validated at construction time so the service can refuse to start
+on misconfiguration rather than silently using invalid parameters.
+
+**Structs implemented:**
+- `QueryConfig` — top-level config (parquet dir, DataFusion runtime, ANN params, scoring, top-M)
+- `DataFusionRuntimeConfig` — batch size, target_partitions, `SessionStrategy` (Child / Pool)
+- `AnnConfig` — `top_n` candidates retrieved per query
+- `ScoringConfig` → `ScoringWeights` (vector + recency, validated sum = 1.0 ± 1e-5) + `RecencyConfig` (grace period + decay lambda)
+- `QueryError` — `thiserror`-derived; `Config(String)` variant now; Arrow / DataFusion / IO variants added per step
+
+**No DataFusion dependency yet** — only `thiserror`. DataFusion/Arrow added in Q1.
+
+**16 unit tests** covering all validation paths (negative weights, sum-out-of-tolerance, negative grace period, zero/negative lambda, session strategy equality).
+
+---
+
 ### Q1 — SessionContext + Iceberg catalog registration
 
 **Goal:** Register an Iceberg catalog with a shared `SessionContext` at application startup.
@@ -359,7 +378,7 @@ likhadb/
 │   ├── likhadb-server/    # axum REST + tonic gRPC + Prometheus + tracing    ✅
 │   ├── likhadb-fts/       # Tantivy-backed FTS + hybrid query                ✅ (F1 done)
 │   ├── likhadb-lakehouse/ # Parquet / Iceberg import-export                  [ Tier L ]
-│   ├── likhadb-query/     # DataFusion query layer (enrichment + scoring)    [ Tier Q ]
+│   ├── likhadb-query/     # DataFusion query layer (enrichment + scoring)    [ Q0 ✅ config/error ]
 │   ├── likhadb-transform/ # Insert-time vector transforms                    [ Tier T ]
 │   └── likhadb-bench/     # Criterion benchmarks                             ✅
 ```
@@ -383,7 +402,7 @@ A1 → A2 → A3           ✅ done
          ↓
     L1 → L2 → L3        ← next (parquet → object store → iceberg)
          ↓
-    Q1 → Q2 → Q3 → Q4  (DataFusion query layer: enrichment → scoring → reranking)
+    Q0 ✅ → Q1 → Q2 → Q3 → Q4  (DataFusion query layer: config → SessionContext → enrichment → scoring → reranking)
          ↓
     T1 → T2             (vector transforms)
 ```

--- a/crates/likhadb-query/Cargo.toml
+++ b/crates/likhadb-query/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name    = "likhadb-query"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = { workspace = true }
+
+[dev-dependencies]

--- a/crates/likhadb-query/src/config.rs
+++ b/crates/likhadb-query/src/config.rs
@@ -1,0 +1,359 @@
+use std::path::PathBuf;
+
+use crate::{QueryError, Result};
+
+/// Tolerance for floating-point weight sum validation.
+const WEIGHT_SUM_TOLERANCE: f32 = 1e-5;
+
+// ---------------------------------------------------------------------------
+// Top-level config
+// ---------------------------------------------------------------------------
+
+/// Top-level configuration for the DataFusion post-ANN query pipeline.
+///
+/// Constructed once at service startup. Individual sub-configs validate their
+/// own invariants at construction time; the service must refuse to start if
+/// any sub-config constructor returns an error.
+pub struct QueryConfig {
+    /// Root directory containing the enrichment Parquet tables.
+    ///
+    /// Expected files: `embeddings.parquet`, `documents.parquet`, `authors.parquet`.
+    /// File existence is verified by [`crate::session::DataFusionSession`] at startup,
+    /// not here — this struct is pure configuration, not I/O.
+    pub parquet_dir: PathBuf,
+
+    /// DataFusion runtime tuning (batch size, parallelism, session strategy).
+    pub datafusion: DataFusionRuntimeConfig,
+
+    /// ANN retrieval parameters.
+    pub ann: AnnConfig,
+
+    /// Score fusion signal weights and recency decay parameters.
+    pub scoring: ScoringConfig,
+
+    /// Number of candidates emitted by Stage 4a (score fusion).
+    /// Must be ≤ `ann.top_n`. Passed to Stage 4b (bi-encoder) when implemented.
+    pub top_m: usize,
+}
+
+// ---------------------------------------------------------------------------
+// DataFusion runtime
+// ---------------------------------------------------------------------------
+
+/// DataFusion `SessionContext` runtime parameters.
+pub struct DataFusionRuntimeConfig {
+    /// `RecordBatch` row count. Tune for candidate set cardinality.
+    ///
+    /// The candidate set is typically 100–500 rows. A `batch_size` equal to
+    /// `ann.top_n` ensures each stage processes a single batch.
+    pub batch_size: usize,
+
+    /// Number of executor threads (DataFusion `target_partitions`).
+    ///
+    /// Defaults to the number of logical CPUs. For a candidate-set workload
+    /// (hundreds of rows) a single partition is often sufficient; increase only
+    /// if profiling shows executor parallelism is a bottleneck.
+    pub target_partitions: usize,
+
+    /// How per-request `SessionContext` isolation is achieved.
+    pub session_strategy: SessionStrategy,
+}
+
+/// Per-request `SessionContext` isolation strategy.
+///
+/// The shared `SessionContext` holds the catalog and UDF registrations and must
+/// not be mutated after startup. Per-request `candidates` MemTable registration
+/// requires an isolated context — this enum controls how that isolation is achieved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStrategy {
+    /// Clone the shared context for each request (Strategy B from the RFC).
+    ///
+    /// The clone is shallow: catalog references and UDF registrations are shared;
+    /// only the table registry is isolated. This is the recommended starting point.
+    /// Switch to `Pool` if clone latency is measurable under production load.
+    Child,
+
+    /// Pre-allocate a fixed pool of `SessionContext` instances (Strategy C from the RFC).
+    ///
+    /// Eliminates per-request clone cost at the expense of higher idle memory.
+    /// Each pool slot is acquired exclusively for the duration of one request.
+    Pool { size: usize },
+}
+
+impl Default for DataFusionRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: 512,
+            target_partitions: std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4),
+            session_strategy: SessionStrategy::Child,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ANN retrieval
+// ---------------------------------------------------------------------------
+
+/// ANN retrieval parameters.
+pub struct AnnConfig {
+    /// Number of ANN candidates retrieved from the index per query.
+    ///
+    /// These candidates form the input to the DataFusion enrichment pipeline.
+    /// After ACL filtering (Stage 3) and score fusion (Stage 4a), the candidate
+    /// count is reduced to `top_m`. Setting `top_n` ≥ 5 × final top-K is a
+    /// safe starting point; tune against a recall evaluation set.
+    pub top_n: usize,
+}
+
+impl Default for AnnConfig {
+    fn default() -> Self {
+        Self { top_n: 500 }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/// Score fusion configuration (Stage 4a).
+pub struct ScoringConfig {
+    /// Signal weights. Must sum to 1.0 — validated at construction.
+    pub weights: ScoringWeights,
+
+    /// Recency decay parameters for the temporal scoring signal.
+    pub recency: RecencyConfig,
+}
+
+/// Per-signal weights for Stage 4a score fusion.
+///
+/// The MVP pipeline uses two signals: vector distance and document recency.
+/// Additional signals (author reputation, content quality, etc.) are added by
+/// introducing new weight fields and extending the fusion SQL in Stage 4a.
+///
+/// # Invariants
+///
+/// - All weights are non-negative.
+/// - `vector_score + recency_score` must equal `1.0` within [`WEIGHT_SUM_TOLERANCE`].
+///
+/// The service must refuse to start if these invariants are violated.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoringWeights {
+    /// Weight for the ANN distance signal (inverted and normalised: lower distance → higher score).
+    pub vector_score: f32,
+
+    /// Weight for the recency decay signal (exponential decay from `created_at`).
+    pub recency_score: f32,
+}
+
+impl ScoringWeights {
+    /// Construct and validate scoring weights.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::Config`] if:
+    /// - Any weight is negative.
+    /// - The sum of all weights does not equal `1.0` within [`WEIGHT_SUM_TOLERANCE`] (`1e-5`).
+    pub fn new(vector_score: f32, recency_score: f32) -> Result<Self> {
+        if vector_score < 0.0 {
+            return Err(QueryError::Config(format!(
+                "vector_score must be non-negative, got {vector_score}"
+            )));
+        }
+        if recency_score < 0.0 {
+            return Err(QueryError::Config(format!(
+                "recency_score must be non-negative, got {recency_score}"
+            )));
+        }
+        let sum = vector_score + recency_score;
+        if (sum - 1.0_f32).abs() > WEIGHT_SUM_TOLERANCE {
+            return Err(QueryError::Config(format!(
+                "scoring weights must sum to 1.0, got {sum:.6} \
+                 (vector_score={vector_score}, recency_score={recency_score})"
+            )));
+        }
+        Ok(Self {
+            vector_score,
+            recency_score,
+        })
+    }
+}
+
+/// Recency decay parameters for the temporal scoring signal.
+///
+/// The recency score for a document of age `d` days is:
+///
+/// ```text
+/// recency_score = exp(-decay_lambda × max(0, d - grace_period_days))
+/// ```
+///
+/// Within `grace_period_days` the score is `1.0` (no penalty).
+/// Beyond `grace_period_days` the score decays exponentially at rate `decay_lambda`.
+#[derive(Debug)]
+pub struct RecencyConfig {
+    /// Flat scoring window in days before exponential decay begins.
+    ///
+    /// Documents newer than `grace_period_days` receive a recency score of `1.0`.
+    /// Must be non-negative.
+    pub grace_period_days: i64,
+
+    /// Exponential decay rate `λ`. Higher values cause faster score decay.
+    ///
+    /// Example: `λ = 0.01` decays to `~0.37` after 100 days beyond the grace period.
+    /// Must be strictly positive.
+    pub decay_lambda: f64,
+}
+
+impl RecencyConfig {
+    /// Construct and validate recency decay parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::Config`] if:
+    /// - `grace_period_days` is negative.
+    /// - `decay_lambda` is not strictly positive.
+    pub fn new(grace_period_days: i64, decay_lambda: f64) -> Result<Self> {
+        if grace_period_days < 0 {
+            return Err(QueryError::Config(format!(
+                "grace_period_days must be non-negative, got {grace_period_days}"
+            )));
+        }
+        if decay_lambda <= 0.0 {
+            return Err(QueryError::Config(format!(
+                "decay_lambda must be strictly positive, got {decay_lambda}"
+            )));
+        }
+        Ok(Self {
+            grace_period_days,
+            decay_lambda,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- ScoringWeights ---
+
+    #[test]
+    fn weights_valid_sum_to_one() {
+        let w = ScoringWeights::new(0.6, 0.4).unwrap();
+        assert_eq!(w.vector_score, 0.6);
+        assert_eq!(w.recency_score, 0.4);
+    }
+
+    #[test]
+    fn weights_valid_extreme_cases() {
+        // All weight on one signal is allowed.
+        assert!(ScoringWeights::new(1.0, 0.0).is_ok());
+        assert!(ScoringWeights::new(0.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn weights_sum_below_one_errors() {
+        let err = ScoringWeights::new(0.6, 0.3).unwrap_err();
+        assert!(err.to_string().contains("sum to 1.0"));
+        assert!(err.to_string().contains("0.900000"));
+    }
+
+    #[test]
+    fn weights_sum_above_one_errors() {
+        let err = ScoringWeights::new(0.6, 0.5).unwrap_err();
+        assert!(err.to_string().contains("sum to 1.0"));
+    }
+
+    #[test]
+    fn weights_negative_vector_score_errors() {
+        let err = ScoringWeights::new(-0.1, 1.1).unwrap_err();
+        assert!(err.to_string().contains("vector_score"));
+        assert!(err.to_string().contains("non-negative"));
+    }
+
+    #[test]
+    fn weights_negative_recency_score_errors() {
+        let err = ScoringWeights::new(1.1, -0.1).unwrap_err();
+        assert!(err.to_string().contains("recency_score"));
+        assert!(err.to_string().contains("non-negative"));
+    }
+
+    #[test]
+    fn weights_within_tolerance_accepted() {
+        // 0.6 + 0.4000001 = 1.0000001, within 1e-5 tolerance.
+        assert!(ScoringWeights::new(0.6, 0.400_000_1).is_ok());
+    }
+
+    #[test]
+    fn weights_outside_tolerance_rejected() {
+        // 0.6 + 0.401 = 1.001, exceeds 1e-5 tolerance.
+        assert!(ScoringWeights::new(0.6, 0.401).is_err());
+    }
+
+    // --- RecencyConfig ---
+
+    #[test]
+    fn recency_valid() {
+        let r = RecencyConfig::new(30, 0.01).unwrap();
+        assert_eq!(r.grace_period_days, 30);
+        assert_eq!(r.decay_lambda, 0.01);
+    }
+
+    #[test]
+    fn recency_zero_grace_period_valid() {
+        assert!(RecencyConfig::new(0, 0.01).is_ok());
+    }
+
+    #[test]
+    fn recency_negative_grace_period_errors() {
+        let err = RecencyConfig::new(-1, 0.01).unwrap_err();
+        assert!(err.to_string().contains("grace_period_days"));
+        assert!(err.to_string().contains("non-negative"));
+    }
+
+    #[test]
+    fn recency_zero_lambda_errors() {
+        let err = RecencyConfig::new(30, 0.0).unwrap_err();
+        assert!(err.to_string().contains("decay_lambda"));
+        assert!(err.to_string().contains("strictly positive"));
+    }
+
+    #[test]
+    fn recency_negative_lambda_errors() {
+        let err = RecencyConfig::new(30, -0.01).unwrap_err();
+        assert!(err.to_string().contains("decay_lambda"));
+        assert!(err.to_string().contains("strictly positive"));
+    }
+
+    // --- SessionStrategy ---
+
+    #[test]
+    fn session_strategy_variants_are_distinct() {
+        assert_ne!(SessionStrategy::Child, SessionStrategy::Pool { size: 4 });
+        assert_eq!(
+            SessionStrategy::Pool { size: 4 },
+            SessionStrategy::Pool { size: 4 }
+        );
+    }
+
+    // --- DataFusionRuntimeConfig default ---
+
+    #[test]
+    fn runtime_config_default_is_sane() {
+        let cfg = DataFusionRuntimeConfig::default();
+        assert!(cfg.batch_size > 0);
+        assert!(cfg.target_partitions > 0);
+        assert_eq!(cfg.session_strategy, SessionStrategy::Child);
+    }
+
+    // --- AnnConfig default ---
+
+    #[test]
+    fn ann_config_default_top_n() {
+        assert_eq!(AnnConfig::default().top_n, 500);
+    }
+}

--- a/crates/likhadb-query/src/error.rs
+++ b/crates/likhadb-query/src/error.rs
@@ -1,0 +1,14 @@
+/// Errors produced by the DataFusion post-ANN query pipeline.
+///
+/// Variants are added as pipeline stages are implemented:
+/// - `Config` — config validation (Step 1, this file)
+/// - Arrow / DataFusion / IO variants will be added in Steps 3-4
+///   when those dependencies are introduced.
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    /// A configuration invariant was violated.
+    ///
+    /// The service must refuse to start when this error is returned.
+    #[error("configuration error: {0}")]
+    Config(String),
+}

--- a/crates/likhadb-query/src/lib.rs
+++ b/crates/likhadb-query/src/lib.rs
@@ -1,0 +1,28 @@
+//! DataFusion post-ANN query pipeline for LikhaDB.
+//!
+//! This crate implements the Tier Q (DataFusion Query Layer) described in
+//! `docs/rfc_datafusion_integration.md`. It takes the small candidate set
+//! returned by the ANN index and runs it through a sequence of DataFusion
+//! stages: metadata enrichment, access control enforcement, multi-signal
+//! score fusion, and (in future steps) model-based reranking.
+//!
+//! ## Implementation status
+//!
+//! | Step | Stage | Status |
+//! |------|-------|--------|
+//! | 1 | Config + error type | ✅ Done |
+//! | 2 | Candidate MemTable | Planned |
+//! | 3 | Sync distance UDFs | Planned |
+//! | 4 | SessionContext + Parquet tables | Planned |
+//! | 5 | Enrichment SQL (Stage 3) | Planned |
+//! | 6 | Score fusion SQL (Stage 4a) | Planned |
+//! | 7 | Pipeline orchestration | Planned |
+//! | 8 | Server integration | Planned |
+
+pub mod config;
+mod error;
+
+pub use error::QueryError;
+
+/// Convenience alias — all fallible operations in this crate return this type.
+pub type Result<T> = std::result::Result<T, QueryError>;

--- a/docs/quick-usages.md
+++ b/docs/quick-usages.md
@@ -1,0 +1,193 @@
+# Quick usage
+
+## Exact search (FlatIndex)
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+use serde_json::json;
+
+let mut mgr = CollectionManager::new();
+mgr.create_collection("documents", 384, Metric::Cosine).unwrap();
+
+let col = mgr.get_mut("documents").unwrap();
+col.insert(1, vec![0.1; 384], Some(json!({"category": "news"}))).unwrap();
+col.insert(2, vec![0.9; 384], Some(json!({"category": "sports"}))).unwrap();
+col.insert(3, vec![0.5; 384], Some(json!({"category": "news"}))).unwrap();
+
+let predicate = json!({"field": "category", "op": "eq", "value": "news"});
+let results = col.search(&vec![0.15; 384], 5, Some(&predicate), false).unwrap();
+```
+
+## Approximate search (IvfIndex)
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+
+let mut mgr = CollectionManager::new();
+// nlist=1024: k-means clusters (also the training trigger threshold)
+// nprobe=16:  clusters searched per query — higher = better recall, slower queries
+mgr.create_ivf_collection("docs", 384, Metric::L2, 1024, 16).unwrap();
+
+let col = mgr.get_mut("docs").unwrap();
+for i in 0..100_000u64 {
+    col.insert(i, vec![i as f32 / 100_000.0; 384], None).unwrap();
+}
+let results = col.search(&vec![0.5; 384], 10, None, false).unwrap();
+```
+
+**nlist / nprobe guidance:**
+- `nlist`: typically `sqrt(N)` to `4 * sqrt(N)`. For 100 k vectors, 256–1024 is a good range.
+- `nprobe`: start at `nlist / 64` for speed, increase toward `nlist / 8` for higher recall.
+- `nprobe == nlist` gives exact recall identical to `FlatIndex`.
+
+## Approximate search + 4× memory reduction (IvfIndex + SQ8)
+
+```rust
+// Same parameters as IvfIndex — just swap the constructor.
+// After training, each vector is stored as dim × u8 instead of dim × f32.
+mgr.create_ivf_sq8_collection("docs_sq8", 384, Metric::L2, 1024, 16).unwrap();
+```
+
+Memory: 100 k × d384 goes from ~146 MB (f32) to ~36 MB (u8). Distance computation
+uses asymmetric evaluation — the query stays in f32 while stored codes are decoded
+on-the-fly.
+
+## Graph-based approximate search (HnswIndex)
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+
+let mut mgr = CollectionManager::new();
+// m=16: graph density · ef_construction=200: build quality · ef_search=50: query recall
+mgr.create_hnsw_collection("docs", 384, Metric::Cosine, 16, 200, 50).unwrap();
+
+let col = mgr.get_mut("docs").unwrap();
+for i in 0..100_000u64 {
+    col.insert(i, vec![i as f32 / 100_000.0; 384], None).unwrap();
+}
+let results = col.search(&vec![0.5; 384], 10, None, false).unwrap();
+```
+
+**m / ef_construction / ef_search guidance:**
+- `m`: typically 8–32. Higher `m` increases memory and improves recall. 16 is a good default.
+- `ef_construction`: must be ≥ `m`. 200 is a good default.
+- `ef_search`: must be ≥ 1. Increase to trade latency for recall. Start at 50.
+
+## Full-text search (FtsIndex)
+
+Enable per-collection with the `fts` Cargo feature. All string values in the JSON payload
+(including nested objects and arrays) are indexed automatically. Scores are BM25.
+
+```toml
+# Cargo.toml
+likhadb-store = { path = "crates/likhadb-store", features = ["fts"] }
+```
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+use serde_json::json;
+
+let mut mgr = CollectionManager::new();
+mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
+
+let col = mgr.get_mut("articles").unwrap();
+col.enable_fts().unwrap();   // activates the Tantivy in-memory index
+
+col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio and async-std"}))).unwrap();
+col.insert(2, vec![0.2; 384], Some(json!({"title": "Python data science", "body": "numpy pandas sklearn"}))).unwrap();
+col.insert(3, vec![0.3; 384], Some(json!({"title": "Rust memory model", "body": "ownership borrowing lifetimes"}))).unwrap();
+
+// BM25 full-text search — returns top-k results ranked by relevance
+let results = col.fts_search("Rust ownership", 5).unwrap();
+// results[0].id == 3  (highest BM25 score for "ownership")
+// results[1].id == 1  (matches "Rust")
+```
+
+Deletions are propagated automatically: `col.delete(id)` removes the vector, the payload, and the FTS document in one call.
+
+## Hybrid search (vector + BM25 via RRF)
+
+Pass `enable_fts: true` at collection creation. Hybrid search fuses vector similarity ranks and BM25 text ranks using Reciprocal Rank Fusion:
+
+```
+rrf_score(id) = 1/(rrf_k + rank_vec) + 1/(rrf_k + rank_fts)    // default rrf_k = 60
+```
+
+A document that ranks 2nd by vector similarity and 3rd by keyword relevance beats a document that is top-1 in only one modality.
+
+```rust
+use likhadb_core::Metric;
+use likhadb_store::CollectionManager;
+use serde_json::json;
+
+let mut mgr = CollectionManager::new();
+mgr.create_collection("articles", 384, Metric::Cosine).unwrap();
+
+let col = mgr.get_mut("articles").unwrap();
+col.enable_fts().unwrap();   // activates Tantivy BM25 index
+
+col.insert(1, vec![0.1; 384], Some(json!({"title": "Rust async runtime", "body": "tokio"}))).unwrap();
+col.insert(2, vec![0.5; 384], Some(json!({"title": "Python ML", "body": "numpy sklearn"}))).unwrap();
+col.insert(3, vec![0.2; 384], Some(json!({"title": "Rust memory model", "body": "ownership lifetimes"}))).unwrap();
+
+// Returns top-5 fusing semantic + keyword signals
+let results = col.hybrid_search(
+    &vec![0.15; 384],  // query embedding
+    "Rust ownership",  // keyword query
+    5,                 // k
+    60,                // rrf_k
+    None,              // metadata filter
+    true,              // include_payload
+).unwrap();
+```
+
+**REST API:**
+```sh
+# Create collection with FTS enabled
+curl -X POST localhost:8080/collections \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"articles","dim":384,"metric":"cosine","enable_fts":true}'
+
+# Hybrid query
+curl -X POST localhost:8080/collections/articles/hybrid-query \
+  -H 'Content-Type: application/json' \
+  -d '{"vector":[...],"text":"Rust ownership","k":5,"include_payload":true}'
+```
+
+## Snapshot persistence
+
+```rust
+use std::path::Path;
+use likhadb_persist::PersistExt;
+use likhadb_store::CollectionManager;
+
+mgr.save(Path::new("snapshot.bin")).unwrap();
+
+// On next startup — all collections, index state, and payloads are restored.
+let mgr = CollectionManager::load(Path::new("snapshot.bin")).unwrap();
+```
+
+## Write-Ahead Log
+
+```rust
+use std::path::Path;
+use likhadb_core::Metric;
+use likhadb_persist::WalManager;
+
+// On restart after a crash: loads last snapshot then replays uncommitted WAL entries.
+let mut wal = WalManager::open(Path::new("/data/mydb")).unwrap();
+
+wal.create_collection("docs", 384, Metric::Cosine).unwrap();
+wal.insert("docs", 1, vec![0.1; 384], Some(serde_json::json!({"title": "hello"}))).unwrap();
+wal.delete("docs", 1).unwrap();
+
+let results = wal.get("docs").unwrap()
+    .search(&[0.5; 384], 10, None, false).unwrap();
+
+// Collapse WAL into a fresh snapshot and truncate wal.log.
+wal.checkpoint().unwrap();
+```

--- a/docs/rfc_datafusion_integration.md
+++ b/docs/rfc_datafusion_integration.md
@@ -168,7 +168,7 @@ ANN Store output
         │
         ▼
 ┌───────────────────────────────────────────────────────────────┐
-│                    DataFusion SessionContext                   │
+│                    DataFusion SessionContext                  │
 │                                                               │
 │  Stage 2: Candidate Registration  →  MemTable                 │
 │                │                                              │
@@ -178,7 +178,7 @@ ANN Store output
 │                │                                              │
 │  Stage 4b: Bi-encoder Reranking   →  AsyncUDF, top-M → top-P  │
 │                │                                              │
-│  Stage 4c: Cross-encoder Reranking → materialize-then-call   │
+│  Stage 4c: Cross-encoder Reranking → materialize-then-call    │
 └───────────────────────────────────────────────────────────────┘
         │
         ▼


### PR DESCRIPTION
## Summary

- Introduces the `likhadb-query` crate skeleton — the DataFusion post-ANN query pipeline described in `docs/rfc_datafusion_integration.md`
- Implements Step 1: typed configuration structs (`QueryConfig`, `ScoringWeights`, `RecencyConfig`, `SessionStrategy`) and a structured `QueryError` type
- All invariants validated at construction time so the service refuses to start on misconfiguration rather than silently corrupting query results
- No DataFusion/Arrow dependencies yet — only `thiserror`; heavier deps deferred to Step 4 (SessionContext)
- Updates README roadmap table and ROADMAP.md to mark Q0 done

## Key design choices

**`ScoringWeights::new` validates at construction.** The weights must sum to 1.0 within a 1e-5 floating-point tolerance. Validation at startup (not query time) means an operator misconfiguration crashes the process before it serves a single request — a hard-to-miss failure rather than a subtle score distortion.

**`SessionStrategy` is a typed enum, not a bool.** `Child` (clone shared context per request) vs `Pool { size }` (pre-allocated pool) have meaningfully different memory/latency tradeoffs. An enum makes those tradeoffs explicit and allows adding a third strategy later without a breaking API change.

**`RecencyConfig` validates `decay_lambda > 0` eagerly.** The recency formula is `exp(-λ × age)`. A zero or negative lambda is a logic error — either a divide-by-zero or an "age improves score" inversion. Catching it at startup eliminates a class of runtime surprises.

## Test plan

- [x] `cargo test -p likhadb-query` — 16 unit tests, all passing
- [x] `cargo clippy -p likhadb-query -- -D warnings` — clean
- [x] `cargo fmt --all` — formatted
- [x] `cargo test --workspace` — full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)