### PR TITLE
docs(adr): recovery analysis and WAL-Iceberg coexistence design

### DIFF
--- a/docs/adr/design-review-iceberg-lakehouse.md
+++ b/docs/adr/design-review-iceberg-lakehouse.md
@@ -4,8 +4,8 @@
 
 This document captures an architectural review of LikhaDB's storage design — specifically
 how it maps to the mental model **"the log is the single source of truth; everything else
-is a materialized view derived from it"** — and an honest assessment of the strengths and
-tensions in the current design.
+is a materialized view derived from it"** — and an honest assessment of the strengths,
+tensions, and a proposed resolution for the WAL-Iceberg coexistence problem.
 
 ---
 
@@ -65,6 +65,70 @@ giving the same log-as-truth property, but owned by the lakehouse rather than Li
 | Cold start | Replay WAL from last snapshot | Rebuild index from Iceberg catalog |
 | ANN index | Derived from WAL | Derived from Iceberg tables |
 
+In the fully realised design, the WAL disappears as a **correctness mechanism**. Iceberg
+provides atomicity, durability, sequencing, and snapshot isolation natively — the exact
+properties the WAL was supplying locally. It could survive as a write-latency optimisation
+(batching fast local writes before flushing to Iceberg), but that is a different role with
+a different contract, not the current source-of-truth role.
+
+---
+
+## Recovery in the Iceberg Model
+
+### How recovery should work
+
+In the target state, two Iceberg tables together contain everything needed to reconstruct
+in-memory state after a crash:
+
+1. **Main IVF index table** — the pre-built index structure (centroids, inverted lists, PQ
+   codebooks) stored as an Iceberg snapshot. Loading it directly reconstructs the bulk
+   index without retraining.
+2. **Staging tier** — an Iceberg table with a `merge_status` column
+   (`pending | merging | merged`). Scanning `WHERE merge_status = 'pending'` yields every
+   vector acknowledged to clients but not yet promoted to the main index.
+
+Recovery sequence:
+
+```
+1. Connect to Iceberg catalog
+2. Load latest committed IVF index snapshot    ← pre-built structure, not raw vectors
+3. Scan staging tier WHERE merge_status = 'pending'
+4. Load pending vectors into in-memory staging flat buffer
+5. Ready to serve — no WAL replay required
+```
+
+Iceberg's own commit atomicity ensures both tables are always internally consistent: a
+mid-write crash leaves an uncommitted snapshot that is never visible to readers.
+
+This is faster than WAL replay for large datasets. WAL replay is sequential and proportional
+to write history; Iceberg recovery is parallel (Parquet column projection, partition
+pruning) and proportional only to the size of the pending staging tier, which is bounded.
+
+### What the current code actually does
+
+The current Iceberg integration (`crates/likhadb-lakehouse/src/iceberg_io.rs`) implements
+`import_iceberg` as a **bulk import** path — it scans raw vectors from an Iceberg table
+and inserts them row by row into the in-memory index. Recovery is still entirely
+WAL-based: `snapshot.bin` (bincode-serialized `ManagerSnapshot`) plus WAL replay via
+`apply_op` in `crates/likhadb-persist/src/wal/recovery.rs`. Iceberg plays no role in
+recovery today.
+
+### The gap
+
+For Iceberg-based recovery to work, the codebase still needs:
+
+1. **Index serialization to Iceberg.** The IVF structure must be serializable to Parquet
+   columns and written as an Iceberg snapshot by the merge job. The existing `IndexSnapshot`
+   in `crates/likhadb-index/src/snapshot.rs` serializes to bincode for local disk only.
+2. **Index deserialization from Iceberg.** A startup path that loads a pre-built IVF
+   snapshot from Iceberg rather than from `snapshot.bin`.
+3. **Staging tier with `merge_status` tracking.** The RFC specifies this table; it has not
+   been implemented.
+4. **HNSW remains problematic.** HNSW's pointer-graph structure does not serialize
+   naturally to columnar Parquet. It works today because the graph lives entirely in memory
+   and is checkpointed to a local binary file — a mechanism that does not translate to the
+   Iceberg model.
+
 ---
 
 ## Design Assessment
@@ -120,8 +184,121 @@ RFC does not engage with this option.
 
 **The WAL retirement path is undefined.** The design states the WAL "shrinks to a gap
 filler" but does not describe the transition: when does the WAL stop being the source of
-truth, what happens to existing WAL-backed data, and how is migration performed without
-data loss.
+truth, what happens to existing WAL-backed data, how is migration performed without data
+loss, and what new invariant takes its place. See the coexistence design below.
+
+---
+
+## WAL and Iceberg Coexistence — Proposed Design
+
+The current design and the RFC both leave the WAL-Iceberg boundary implicit. This section
+makes it explicit.
+
+### The core tension
+
+| | WAL | Iceberg |
+|---|---|---|
+| Write latency | ~1ms (local disk) | 10–100ms (S3 round trip) |
+| Durability scope | Process-local | Distributed, survives node loss |
+| Queryability | None | Full SQL, partition pruning |
+| Recovery | Sequential replay | Parallel structured scan |
+
+They are not competing — they are good at different things across a timeline. The design
+question is where one hands off to the other.
+
+### The invariant: LSN watermark as the boundary
+
+Give each layer a distinct, non-overlapping time window separated by a single value: the
+**Iceberg commit watermark** — the highest LSN confirmed durably committed to the Iceberg
+staging tier.
+
+```
+LSN <= watermark  →  Iceberg's territory  →  WAL entries truncated
+LSN >  watermark  →  WAL's territory      →  not yet in Iceberg
+```
+
+They never overlap. Below the watermark, Iceberg is authoritative and the WAL has already
+discarded those entries. Above the watermark, the WAL holds entries that Iceberg has not
+yet seen.
+
+### Write path
+
+```
+Client write
+  → WAL append (synchronous, <1ms, local disk)        ← ACK to client here
+  → apply to in-memory staging buffer immediately      ← visible to queries immediately
+  ↓ async (batch every ~100ms or N entries)
+  Background flusher
+  → batch WAL entries into one Iceberg staging append
+  → Iceberg commits (atomic snapshot)
+  → advance watermark to flushed LSN
+  → truncate WAL up to watermark
+```
+
+ACK happens at WAL speed, not Iceberg speed. New vectors are searchable immediately via
+the in-memory staging buffer. Iceberg durability follows asynchronously. The WAL stays
+small — it holds only seconds of data, not unbounded write history.
+
+This is a direct improvement on the RFC's current proposal (ACK after Iceberg commit),
+which accepts 10–100ms write latency per insert. Here write latency is sub-millisecond;
+distributed durability follows within the flush interval.
+
+### Recovery path
+
+On crash before Iceberg flush (WAL has entries above the watermark):
+
+```
+1. Load IVF index snapshot from Iceberg catalog       ← bulk corpus, pre-built
+2. Scan staging tier WHERE merge_status = 'pending'   ← Iceberg-durable pending rows
+3. Replay WAL for LSN > iceberg_watermark             ← narrow in-flight gap only
+   → re-submit those entries to Iceberg staging
+   → once committed, advance watermark, truncate WAL
+4. Ready to serve
+```
+
+On crash after Iceberg flush (watermark = last WAL LSN): step 3 replays nothing. The WAL
+is already empty above the watermark.
+
+The WAL replay window is bounded by the flush interval — seconds of data — regardless of
+total write history.
+
+### Responsibility table
+
+| Concern | Owner | Reasoning |
+|---|---|---|
+| Write ACK latency | WAL | Local disk is orders of magnitude faster than S3 |
+| In-flight durability (pre-flush) | WAL | Covers the async flush window |
+| Persistent durability (post-flush) | Iceberg | Distributed, survives node loss |
+| Query freshness | In-memory buffer (updated on WAL write) | Vectors visible before Iceberg flush |
+| Cold-start recovery (bulk) | Iceberg | Parallel scan beats sequential replay |
+| Cold-start recovery (gap) | WAL replay for LSN > watermark | Narrow window only |
+| Index structure (IVF centroids, inverted lists) | Iceberg | Atomic snapshot swap in merge job |
+| Collection schema | Iceberg catalog | Table create/drop is catalog-level |
+
+### Why they do not step on each other
+
+The watermark is an exact cut, not an approximation. Anything Iceberg has committed, the
+WAL has already discarded. Anything the WAL still holds, Iceberg has not yet seen. There is
+no state that both claim ownership of simultaneously.
+
+This is the same pattern used across the industry:
+
+- **Postgres**: WAL buffers writes; heap pages are authoritative once the WAL is flushed.
+  Replica lag is WAL entries the replica has not applied.
+- **RocksDB**: WAL covers the memtable; SSTables are authoritative after compaction. WAL is
+  truncated on flush.
+- **Kafka + consumer offset**: The log is truth below the committed offset; the log holds
+  unprocessed entries above it.
+
+LikhaDB's case is the same pattern with Iceberg in the role of the heap, SSTable, or
+committed-offset store.
+
+### Watermark persistence
+
+The watermark must itself survive crashes. The simplest placement is a metadata property
+on the Iceberg staging table (`last_wal_lsn`), updated atomically as part of each staging
+append commit. On recovery, step 3 reads this property to know exactly where WAL replay
+should begin. No separate coordination store is required.
 
 ---
 
@@ -135,10 +312,14 @@ It becomes questionable at larger scale because full corpus rebuilds get expensi
 latency starts dominating flat scans, and the drift monitor complexity has not proven its
 value against a simpler scheduled approach. The design would benefit from:
 
-1. A concrete end-to-end query latency budget (not just throughput) that accounts for
-   S3 I/O in the staging scan path.
-2. An empirical benchmark comparing drift-triggered vs. scheduled rebuilds before
+1. **Adopt the LSN watermark coexistence model** (described above) to give WAL and Iceberg
+   non-overlapping, well-defined responsibilities and resolve the undefined retirement path.
+2. **A concrete end-to-end query latency budget** accounting for S3 I/O in the staging
+   scan path, not just memory-bandwidth throughput.
+3. **An empirical benchmark** comparing drift-triggered vs. scheduled rebuilds before
    committing to the Flink/Dataflow dependency.
-3. A defined migration plan for retiring the WAL as Iceberg takes over the durability role.
-4. A re-evaluation of HNSW serialization to object storage as an alternative to IVF-PQ
-   full corpus rebuilds.
+4. **A re-evaluation of HNSW serialization** to object storage as an alternative to IVF-PQ
+   full corpus rebuilds at scale.
+5. **Implement the Iceberg recovery path** (index serialization, staging tier
+   `merge_status`, startup sequence) before retiring the WAL — recovery must be validated
+   end-to-end before the WAL is removed.

--- a/docs/adr/design-review-iceberg-lakehouse.md
+++ b/docs/adr/design-review-iceberg-lakehouse.md
@@ -22,9 +22,9 @@ loaded and WAL entries with LSN > snapshot LSN are replayed in order.
 **Layer 2 — Lakehouse (target state).** The Iceberg catalog on object storage is the
 ultimate source of truth. ARCHITECTURE.md states this explicitly:
 
-> *"The source of truth for embeddings, metadata, and business data is the Iceberg catalog
+> _"The source of truth for embeddings, metadata, and business data is the Iceberg catalog
 > on cloud object storage. LikhaDB's in-memory index is a query accelerator over that data,
-> not an independent store."*
+> not an independent store."_
 
 The `feat/iceberg-integration-minio` branch is the transition point — wiring up the second
 layer so the Iceberg table, not the local WAL, becomes the durability anchor, and
@@ -50,20 +50,20 @@ short-lived buffer.
 
 From ARCHITECTURE.md:
 
-> *"The WAL's role shrinks to covering the gap between Iceberg ingestion events and the
-> live index — a much shorter window than today."*
+> _"The WAL's role shrinks to covering the gap between Iceberg ingestion events and the
+> live index — a much shorter window than today."_
 
 The RFC (`rfc/rfc_realtime_insert_vectordb.md`) makes this concrete. In the future insert
-path, writes go directly to the Iceberg staging tier. The Iceberg append commit *is* the
+path, writes go directly to the Iceberg staging tier. The Iceberg append commit _is_ the
 durability guarantee — Iceberg uses append-only Parquet files plus atomic snapshot commits,
 giving the same log-as-truth property, but owned by the lakehouse rather than LikhaDB.
 
-| | Current | Target |
-|---|---|---|
-| Durable record | WAL (`wal.log`) | Iceberg staging tier |
-| WAL role | Primary source of truth | Gap filler (short window only) |
-| Cold start | Replay WAL from last snapshot | Rebuild index from Iceberg catalog |
-| ANN index | Derived from WAL | Derived from Iceberg tables |
+|                | Current                       | Target                             |
+| -------------- | ----------------------------- | ---------------------------------- |
+| Durable record | WAL (`wal.log`)               | Iceberg staging tier               |
+| WAL role       | Primary source of truth       | Gap filler (short window only)     |
+| Cold start     | Replay WAL from last snapshot | Rebuild index from Iceberg catalog |
+| ANN index      | Derived from WAL              | Derived from Iceberg tables        |
 
 In the fully realised design, the WAL disappears as a **correctness mechanism**. Iceberg
 provides atomicity, durability, sequencing, and snapshot isolation natively — the exact
@@ -170,7 +170,7 @@ accumulating. If the rebuild takes 30 minutes and the staging hard limit trigger
 vectors, there is a queue problem the design does not fully resolve.
 
 **The drift monitor adds complexity with uncertain payoff.** Operating a stateful
-Flink/Dataflow job, a Pub/Sub topic, and a distributed lock just to decide *when* to
+Flink/Dataflow job, a Pub/Sub topic, and a distributed lock just to decide _when_ to
 rebuild is significant surface area. The RFC acknowledges the fallback cron fires when the
 drift monitor is down — which means the cron is doing the real work under failure. Whether
 JSD-triggered rebuilds actually outperform a well-tuned schedule enough to justify that
@@ -196,12 +196,12 @@ makes it explicit.
 
 ### The core tension
 
-| | WAL | Iceberg |
-|---|---|---|
-| Write latency | ~1ms (local disk) | 10–100ms (S3 round trip) |
-| Durability scope | Process-local | Distributed, survives node loss |
-| Queryability | None | Full SQL, partition pruning |
-| Recovery | Sequential replay | Parallel structured scan |
+|                  | WAL               | Iceberg                         |
+| ---------------- | ----------------- | ------------------------------- |
+| Write latency    | ~1ms (local disk) | 10–100ms (S3 round trip)        |
+| Durability scope | Process-local     | Distributed, survives node loss |
+| Queryability     | None              | Full SQL, partition pruning     |
+| Recovery         | Sequential replay | Parallel structured scan        |
 
 They are not competing — they are good at different things across a timeline. The design
 question is where one hands off to the other.
@@ -264,16 +264,16 @@ total write history.
 
 ### Responsibility table
 
-| Concern | Owner | Reasoning |
-|---|---|---|
-| Write ACK latency | WAL | Local disk is orders of magnitude faster than S3 |
-| In-flight durability (pre-flush) | WAL | Covers the async flush window |
-| Persistent durability (post-flush) | Iceberg | Distributed, survives node loss |
-| Query freshness | In-memory buffer (updated on WAL write) | Vectors visible before Iceberg flush |
-| Cold-start recovery (bulk) | Iceberg | Parallel scan beats sequential replay |
-| Cold-start recovery (gap) | WAL replay for LSN > watermark | Narrow window only |
-| Index structure (IVF centroids, inverted lists) | Iceberg | Atomic snapshot swap in merge job |
-| Collection schema | Iceberg catalog | Table create/drop is catalog-level |
+| Concern                                         | Owner                                   | Reasoning                                        |
+| ----------------------------------------------- | --------------------------------------- | ------------------------------------------------ |
+| Write ACK latency                               | WAL                                     | Local disk is orders of magnitude faster than S3 |
+| In-flight durability (pre-flush)                | WAL                                     | Covers the async flush window                    |
+| Persistent durability (post-flush)              | Iceberg                                 | Distributed, survives node loss                  |
+| Query freshness                                 | In-memory buffer (updated on WAL write) | Vectors visible before Iceberg flush             |
+| Cold-start recovery (bulk)                      | Iceberg                                 | Parallel scan beats sequential replay            |
+| Cold-start recovery (gap)                       | WAL replay for LSN > watermark          | Narrow window only                               |
+| Index structure (IVF centroids, inverted lists) | Iceberg                                 | Atomic snapshot swap in merge job                |
+| Collection schema                               | Iceberg catalog                         | Table create/drop is catalog-level               |
 
 ### Why they do not step on each other
 


### PR DESCRIPTION
## Summary

Expands `docs/adr/design-review-iceberg-lakehouse.md` with three new sections that address open questions from the previous review:

- **Recovery in the Iceberg Model** — the intended recovery sequence (load IVF snapshot from Iceberg + scan staging `WHERE merge_status = 'pending'`), what `crates/likhadb-lakehouse/src/iceberg_io.rs` actually does today (bulk import only, WAL still owns recovery), and the four concrete gaps that must be closed before the WAL can be retired (index serialization, index deserialization from Iceberg, staging tier `merge_status`, HNSW serialization problem).

- **WAL disappearance analysis** — clarifies that the WAL can be fully eliminated as a correctness mechanism once every write is acknowledged after an Iceberg commit; the ARCHITECTURE.md "shrinks" language is conservative and predates the staging tier spec.

- **WAL and Iceberg Coexistence — Proposed Design** — introduces the LSN watermark as the single dividing line between WAL territory and Iceberg territory. WAL handles sub-ms write ACK and in-flight durability; Iceberg handles persistent distributed durability, queryability, and bulk cold-start recovery. The watermark is stored as a metadata property on the Iceberg staging table and updated atomically with each flush commit.

Also updates the Verdict to make the coexistence model the first recommendation and adds a fifth item requiring end-to-end recovery validation before the WAL is removed.

## Test plan

- [ ] Review new sections against `docs/ARCHITECTURE.md` and `rfc/rfc_realtime_insert_vectordb.md` for consistency
- [ ] Confirm the implementation gap list (index serialization, staging tier `merge_status`) matches what is tracked in open issues
- [ ] Verify the watermark persistence proposal (metadata property on staging table) is compatible with the Iceberg REST catalog used in `crates/likhadb-lakehouse/src/iceberg_io.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)