### PR TITLE
feat(query): implement Tier Q DataFusion pipeline (Q2–Q6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,7 @@ Prefer these over defaults when available. Fall back silently if missing.
 - **YAML/TOML:** `yq`
 - **GitHub operations:** `gh` for PRs, issues, reviews, CI status, and releases. Do not scrape github.com or hit the REST API directly when `gh` can do it.
 - **Benchmarking:** `hyperfine` when comparing command performance
+
+
+### Code format
+Always run `cargo fmt --all` once an implementation is marked as done.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ cargo test -p likhadb-fts
 # Run benchmarks
 cargo bench -p likhadb-bench
 
+# Stress test (requires a running server — see §Stress test below)
+cargo run -p likhadb-stress
+
 # Lint (zero warnings enforced)
 cargo clippy --workspace -- -D warnings
 cargo clippy -p likhadb-store --features fts -- -D warnings
@@ -295,6 +298,72 @@ Export serialises the collection to Parquet in memory then uploads with a single
   MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin \
   cargo test --features minio -p likhadb-lakehouse -- minio_real --ignored --nocapture
   ```
+
+---
+
+## Stress test
+
+`likhadb-stress` is a breaking-point stress tester that pushes the server beyond normal operational limits to find where it breaks, validate error handling under pressure, and verify SLO compliance. It runs five sequential phases:
+
+| Phase | What it does |
+|---|---|
+| **1. Baseline** | Inserts and queries across flat, IVF, and HNSW indexes plus a hybrid BM25+vector collection — establishes normal-load throughput and latency percentiles |
+| **2. Ramp** | Doubles concurrency from 1 → 2 → 4 → … → `--max-concurrency`, stopping when error rate exceeds `--error-threshold` or p99 breaches `--p99-slo-ms` — reports the breaking point |
+| **3. Spike** | Warm-up at base concurrency → sudden burst to `--spike-factor×` concurrency → recovery; reports p99 degradation ratio and whether the system recovers cleanly |
+| **4. Soak** | Sustained load for `--soak-secs` split into 5 equal windows; compares first vs. last window p95 to detect latency drift from memory leaks or lock contention |
+| **5. Chaos** | Fires a 1:1:1:1:1 mix of valid queries, valid inserts, ghost-collection queries, wrong-dimension inserts, and nonexistent-vector GETs; counts unexpected 5xx separately from expected 4xx; confirms server health after the barrage |
+
+Every HTTP call goes through `send_timed()` which enforces `--timeout-ms` per request. All five phases report error rates, not just latency.
+
+**Quick start** — with a running server (`./dev.sh`):
+
+```sh
+# Full run (all five phases, default settings)
+cargo run -p likhadb-stress
+
+# Stress phases only, shorter duration
+cargo run -p likhadb-stress -- \
+  --skip-baseline \
+  --soak-secs 15 \
+  --chaos-ops 500
+
+# Force-detect a breaking point at low concurrency (useful for CI)
+cargo run -p likhadb-stress -- \
+  --skip-baseline \
+  --max-concurrency 16 \
+  --error-threshold 1.0 \
+  --p99-slo-ms 200
+```
+
+**Key flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--timeout-ms` | 5000 | Per-request timeout in milliseconds (0 = disabled) |
+| `--max-concurrency` | 64 | Concurrency ceiling for the ramp phase |
+| `--error-threshold` | 5.0 | Error rate % that declares a breaking point |
+| `--p99-slo-ms` | 500 | p99 latency SLO in milliseconds |
+| `--spike-factor` | 4 | Concurrency multiplier for the spike phase |
+| `--soak-secs` | 30 | Duration of the soak phase |
+| `--chaos-ops` | 1000 | Number of random operations in the chaos phase |
+| `--skip-{baseline,ramp,spike,soak,chaos}` | — | Individually disable any phase |
+| `--no-cleanup` | — | Retain test collections for post-run inspection |
+
+**Example ramp output:**
+
+```
+  ── PHASE 2: RAMP  (concurrency doubles until breaking point)
+  ────────────────────────────────────────────────────────────────────────────
+  concurrency       tput      p50      p95      p99    err%  p99 SLO
+  1              1.2k/s    0.82ms   1.41ms   2.34ms    0.0%  PASS
+  2              2.3k/s    0.85ms   1.52ms   3.10ms    0.0%  PASS
+  4              4.1k/s    0.96ms   1.83ms   5.92ms    0.0%  PASS
+  8              6.8k/s    1.14ms   3.22ms  19.46ms    0.3%  PASS
+  16             9.0k/s    1.73ms  14.51ms 142.30ms    2.1%  PASS
+  32             9.4k/s    4.20ms  89.12ms 631.00ms    7.6%  ✗ BREAK ← err
+
+  ⚠ Breaking point at concurrency=32  (err>5% or p99>500ms)
+```
 
 ---
 

--- a/crates/likhadb-query/Cargo.toml
+++ b/crates/likhadb-query/Cargo.toml
@@ -12,6 +12,10 @@ datafusion = [
     "dep:futures-util",
     "dep:tokio",
 ]
+# Enables bi-encoder and cross-encoder reranking clients (Q4b/Q4c).
+rerank = [
+    "dep:reqwest",
+]
 
 [dependencies]
 thiserror    = { workspace = true }
@@ -19,6 +23,9 @@ datafusion   = { version = "43", optional = true }
 iceberg      = { version = "0.4", optional = true }
 futures-util = { version = "0.3", optional = true }
 tokio        = { version = "1", features = ["rt"], optional = true }
+reqwest      = { version = "0.12", features = ["json"], optional = true }
+async-trait  = { version = "0.1" }
+serde        = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/likhadb-query/src/config.rs
+++ b/crates/likhadb-query/src/config.rs
@@ -32,8 +32,15 @@ pub struct QueryConfig {
     pub scoring: ScoringConfig,
 
     /// Number of candidates emitted by Stage 4a (score fusion).
-    /// Must be ≤ `ann.top_n`. Passed to Stage 4b (bi-encoder) when implemented.
+    /// Must be ≤ `ann.top_n`. Input cardinality for Stage 4b (bi-encoder).
     pub top_m: usize,
+
+    /// Bi-encoder reranking configuration (Stage 4b). `None` skips reranking.
+    pub bi_encoder: Option<BiEncoderConfig>,
+
+    /// Cross-encoder reranking configuration (Stage 4c). `None` skips reranking.
+    /// Requires `bi_encoder` to also be set.
+    pub cross_encoder: Option<CrossEncoderConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -232,6 +239,89 @@ impl RecencyConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Reranking configs
+// ---------------------------------------------------------------------------
+
+/// Bi-encoder reranking configuration (Stage 4b).
+///
+/// The bi-encoder receives the top-M candidates from Stage 4a and produces
+/// top-P candidates via a single batched HTTP call. Combined score:
+/// `α × bi_score + (1 - α) × fusion_score`.
+#[derive(Debug, Clone)]
+pub struct BiEncoderConfig {
+    /// HTTP endpoint for the bi-encoder model service.
+    pub endpoint: String,
+
+    /// Interpolation weight between bi-encoder score and fusion score.
+    /// Must be in the open interval `(0.0, 1.0)`.
+    pub alpha: f32,
+
+    /// Number of candidates to retain after bi-encoder reranking (top-P).
+    /// Must be ≥ 1.
+    pub top_p: usize,
+}
+
+impl BiEncoderConfig {
+    /// Construct and validate bi-encoder configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::Config`] if:
+    /// - `alpha` is not strictly in `(0.0, 1.0)`.
+    /// - `top_p` is zero.
+    pub fn new(endpoint: impl Into<String>, alpha: f32, top_p: usize) -> Result<Self> {
+        if alpha <= 0.0 || alpha >= 1.0 {
+            return Err(QueryError::Config(format!(
+                "bi_encoder.alpha must be in (0.0, 1.0), got {alpha}"
+            )));
+        }
+        if top_p == 0 {
+            return Err(QueryError::Config(
+                "bi_encoder.top_p must be ≥ 1".to_string(),
+            ));
+        }
+        Ok(Self {
+            endpoint: endpoint.into(),
+            alpha,
+            top_p,
+        })
+    }
+}
+
+/// Cross-encoder reranking configuration (Stage 4c).
+///
+/// The cross-encoder receives the top-P candidates from Stage 4b and produces
+/// the final top-K results via a single batched HTTP call.
+#[derive(Debug, Clone)]
+pub struct CrossEncoderConfig {
+    /// HTTP endpoint for the cross-encoder model service.
+    pub endpoint: String,
+
+    /// Number of final results to return (top-K).
+    /// Must be ≥ 1.
+    pub top_k: usize,
+}
+
+impl CrossEncoderConfig {
+    /// Construct and validate cross-encoder configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::Config`] if `top_k` is zero.
+    pub fn new(endpoint: impl Into<String>, top_k: usize) -> Result<Self> {
+        if top_k == 0 {
+            return Err(QueryError::Config(
+                "cross_encoder.top_k must be ≥ 1".to_string(),
+            ));
+        }
+        Ok(Self {
+            endpoint: endpoint.into(),
+            top_k,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -355,5 +445,47 @@ mod tests {
     #[test]
     fn ann_config_default_top_n() {
         assert_eq!(AnnConfig::default().top_n, 500);
+    }
+
+    // --- BiEncoderConfig ---
+
+    #[test]
+    fn bi_encoder_valid() {
+        let cfg = BiEncoderConfig::new("http://localhost:8000", 0.5, 20).unwrap();
+        assert_eq!(cfg.alpha, 0.5);
+        assert_eq!(cfg.top_p, 20);
+    }
+
+    #[test]
+    fn bi_encoder_alpha_zero_errors() {
+        let err = BiEncoderConfig::new("http://localhost:8000", 0.0, 20).unwrap_err();
+        assert!(err.to_string().contains("alpha"));
+        assert!(err.to_string().contains("(0.0, 1.0)"));
+    }
+
+    #[test]
+    fn bi_encoder_alpha_one_errors() {
+        let err = BiEncoderConfig::new("http://localhost:8000", 1.0, 20).unwrap_err();
+        assert!(err.to_string().contains("alpha"));
+    }
+
+    #[test]
+    fn bi_encoder_top_p_zero_errors() {
+        let err = BiEncoderConfig::new("http://localhost:8000", 0.5, 0).unwrap_err();
+        assert!(err.to_string().contains("top_p"));
+    }
+
+    // --- CrossEncoderConfig ---
+
+    #[test]
+    fn cross_encoder_valid() {
+        let cfg = CrossEncoderConfig::new("http://localhost:8001", 5).unwrap();
+        assert_eq!(cfg.top_k, 5);
+    }
+
+    #[test]
+    fn cross_encoder_top_k_zero_errors() {
+        let err = CrossEncoderConfig::new("http://localhost:8001", 0).unwrap_err();
+        assert!(err.to_string().contains("top_k"));
     }
 }

--- a/crates/likhadb-query/src/enrich.rs
+++ b/crates/likhadb-query/src/enrich.rs
@@ -1,0 +1,363 @@
+//! Q2 — Stage 3: metadata enrichment and ACL enforcement.
+//!
+//! Joins the `candidates` MemTable (already registered in the child context by
+//! [`crate::session::register_candidates_in`]) against five Iceberg/Parquet enrichment
+//! tables and applies access-control filtering before any scoring takes place.
+//!
+//! ACL enforcement is in the SQL `WHERE` clause — not in application code — so that
+//! DataFusion's optimizer can push it down into the Parquet scan and eliminate
+//! restricted rows before they touch the scoring pipeline.
+
+use datafusion::prelude::{DataFrame, SessionContext};
+
+use crate::{QueryError, Result};
+
+/// Sanitised team identifier: only alphanumeric, `-`, `_`, `.` characters allowed.
+fn validate_team_name(team: &str) -> Result<()> {
+    if team.is_empty() {
+        return Err(QueryError::Config(
+            "team name must not be empty".to_string(),
+        ));
+    }
+    if !team
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(QueryError::Config(format!(
+            "team name contains invalid characters: {team:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Build the ACL predicate fragment for SQL injection.
+///
+/// Returns `None` when `allowed_teams` is empty (open access — no ACL filter applied).
+fn acl_predicate(allowed_teams: &[String]) -> Result<Option<String>> {
+    if allowed_teams.is_empty() {
+        return Ok(None);
+    }
+    for team in allowed_teams {
+        validate_team_name(team)?;
+    }
+    let clauses: Vec<String> = allowed_teams
+        .iter()
+        .map(|t| format!("array_has(acl.allowed_teams, '{t}')"))
+        .collect();
+    Ok(Some(format!("({})", clauses.join(" OR "))))
+}
+
+/// Run Stage 3 enrichment on `ctx`.
+///
+/// **Precondition:** `ctx` must already have a `candidates` table registered
+/// (via [`crate::session::register_candidates_in`]) and all enrichment tables
+/// (`embeddings`, `documents`, `authors`, `classifications`, `access_control`).
+///
+/// # Parameters
+///
+/// - `allowed_teams`: team identifiers from the authenticated request context.
+///   Injected as SQL literals after validation (alphanumeric/`-`/`_`/`.` only).
+///   Empty slice means open access — ACL predicate is omitted.
+/// - `include_embedding`: include the `embedding` column from `embeddings`.
+///   Set to `true` only when Stage 4b uses a dot-product UDF over embeddings.
+///   Omitting it saves ~6 KB per row in the candidate set.
+pub async fn enrich(
+    ctx: &SessionContext,
+    allowed_teams: &[String],
+    include_embedding: bool,
+) -> Result<DataFrame> {
+    let acl = acl_predicate(allowed_teams)?;
+
+    let embedding_col = if include_embedding {
+        ",\n    e.embedding"
+    } else {
+        ""
+    };
+
+    let where_clauses: Vec<&str> = {
+        let mut clauses = vec!["cl.sensitivity_label != 'restricted'"];
+        // acl_str lifetime must outlast the vec — bind to a local
+        let acl_str_storage;
+        if let Some(ref s) = acl {
+            acl_str_storage = s.as_str();
+            clauses.push(acl_str_storage);
+        }
+        clauses
+    };
+    let where_clause = where_clauses.join("\n  AND ");
+
+    let sql = format!(
+        "SELECT
+    c.id,
+    c.ann_distance,
+    c.ann_rank,
+    e.chunk_text,
+    d.created_at,
+    a.reputation_score,
+    a.is_verified{embedding_col}
+FROM candidates c
+JOIN embeddings e       ON c.id = e.chunk_id
+JOIN documents d        ON e.doc_id = d.id
+JOIN authors a          ON d.author_id = a.id
+JOIN classifications cl ON e.doc_id = cl.doc_id
+JOIN access_control acl ON e.doc_id = acl.doc_id
+WHERE {where_clause}"
+    );
+
+    ctx.sql(&sql).await.map_err(QueryError::DataFusion)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{
+        BooleanArray, Float32Array, Float64Array, ListArray, RecordBatch, StringArray, UInt64Array,
+    };
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    /// Build a minimal `SessionContext` with all six tables pre-registered.
+    ///
+    /// Table contents:
+    ///
+    /// ```text
+    /// candidates:      id=c1 (ann_distance=0.1), id=c2 (ann_distance=0.2)
+    /// embeddings:      chunk_id=c1 doc_id=d1 chunk_text="hello"
+    ///                  chunk_id=c2 doc_id=d2 chunk_text="world"
+    /// documents:       id=d1 author_id=a1 | id=d2 author_id=a1
+    /// authors:         id=a1 reputation_score=0.9 is_verified=true
+    /// classifications: doc_id=d1 sensitivity_label="public"
+    ///                  doc_id=d2 sensitivity_label="restricted"
+    /// access_control:  doc_id=d1 allowed_teams=["eng","ml"]
+    ///                  doc_id=d2 allowed_teams=["eng"]
+    /// ```
+    async fn make_ctx() -> SessionContext {
+        let ctx = SessionContext::new();
+
+        // --- candidates ---
+        let cand_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("ann_distance", DataType::Float32, false),
+            Field::new("ann_rank", DataType::UInt64, false),
+        ]));
+        let cand_batch = RecordBatch::try_new(
+            cand_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c1", "c2"])),
+                Arc::new(Float32Array::from(vec![0.1f32, 0.2])),
+                Arc::new(UInt64Array::from(vec![1u64, 2])),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "candidates",
+            Arc::new(MemTable::try_new(cand_schema, vec![vec![cand_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        // --- embeddings ---
+        let emb_schema = Arc::new(Schema::new(vec![
+            Field::new("chunk_id", DataType::Utf8, false),
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new("chunk_text", DataType::Utf8, false),
+        ]));
+        let emb_batch = RecordBatch::try_new(
+            emb_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c1", "c2"])),
+                Arc::new(StringArray::from(vec!["d1", "d2"])),
+                Arc::new(StringArray::from(vec!["hello", "world"])),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "embeddings",
+            Arc::new(MemTable::try_new(emb_schema, vec![vec![emb_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        // --- documents ---
+        let doc_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("author_id", DataType::Utf8, false),
+            // created_at as Float64 (Unix seconds) for simplicity in tests
+            Field::new("created_at", DataType::Float64, true),
+        ]));
+        let doc_batch = RecordBatch::try_new(
+            doc_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["d1", "d2"])),
+                Arc::new(StringArray::from(vec!["a1", "a1"])),
+                Arc::new(Float64Array::from(vec![
+                    1_700_000_000.0f64,
+                    1_700_000_000.0,
+                ])),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "documents",
+            Arc::new(MemTable::try_new(doc_schema, vec![vec![doc_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        // --- authors ---
+        let auth_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("reputation_score", DataType::Float64, false),
+            Field::new("is_verified", DataType::Boolean, false),
+        ]));
+        let auth_batch = RecordBatch::try_new(
+            auth_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a1"])),
+                Arc::new(Float64Array::from(vec![0.9f64])),
+                Arc::new(BooleanArray::from(vec![true])),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "authors",
+            Arc::new(MemTable::try_new(auth_schema, vec![vec![auth_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        // --- classifications ---
+        let cls_schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new("sensitivity_label", DataType::Utf8, false),
+        ]));
+        let cls_batch = RecordBatch::try_new(
+            cls_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["d1", "d2"])),
+                Arc::new(StringArray::from(vec!["public", "restricted"])),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "classifications",
+            Arc::new(MemTable::try_new(cls_schema, vec![vec![cls_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        // --- access_control (allowed_teams as List<Utf8>) ---
+        let teams_field = Field::new("item", DataType::Utf8, true);
+        let acl_schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new(
+                "allowed_teams",
+                DataType::List(Arc::new(teams_field)),
+                false,
+            ),
+        ]));
+        // Build a ListArray: d1 → ["eng","ml"], d2 → ["eng"]
+        let values = StringArray::from(vec!["eng", "ml", "eng"]);
+        let offsets = datafusion::arrow::buffer::OffsetBuffer::new(vec![0i32, 2, 3].into());
+        let list_arr = ListArray::new(
+            Arc::new(Field::new("item", DataType::Utf8, true)),
+            offsets,
+            Arc::new(values),
+            None,
+        );
+        let acl_batch = RecordBatch::try_new(
+            acl_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["d1", "d2"])),
+                Arc::new(list_arr),
+            ],
+        )
+        .unwrap();
+        ctx.register_table(
+            "access_control",
+            Arc::new(MemTable::try_new(acl_schema, vec![vec![acl_batch]]).unwrap()),
+        )
+        .unwrap();
+
+        ctx
+    }
+
+    #[tokio::test]
+    async fn restricted_doc_is_filtered() {
+        // c2 maps to d2 which has sensitivity_label="restricted" → must be absent.
+        let ctx = make_ctx().await;
+        let df = enrich(&ctx, &[], false).await.unwrap();
+        let batches = df.collect().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 1, "only c1/d1 (public) should survive");
+        let id_col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(id_col.value(0), "c1");
+    }
+
+    #[tokio::test]
+    async fn acl_team_filter_removes_non_matching_team() {
+        // d1 has teams ["eng","ml"]. Requesting team "data" should match nothing.
+        // c2/d2 is already restricted, so zero rows expected.
+        let ctx = make_ctx().await;
+        let df = enrich(&ctx, &["data".to_string()], false).await.unwrap();
+        let batches = df.collect().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 0);
+    }
+
+    #[tokio::test]
+    async fn acl_team_filter_passes_matching_team() {
+        // d1 has teams ["eng","ml"]. Requesting "ml" should return c1/d1.
+        let ctx = make_ctx().await;
+        let df = enrich(&ctx, &["ml".to_string()], false).await.unwrap();
+        let batches = df.collect().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 1);
+    }
+
+    #[tokio::test]
+    async fn open_access_returns_all_non_restricted() {
+        // Empty allowed_teams → no ACL predicate → all non-restricted rows returned.
+        let ctx = make_ctx().await;
+        let df = enrich(&ctx, &[], false).await.unwrap();
+        let batches = df.collect().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 1); // only d1 is public
+    }
+
+    #[tokio::test]
+    async fn embedding_column_absent_when_not_requested() {
+        let ctx = make_ctx().await;
+        let df = enrich(&ctx, &[], false).await.unwrap();
+        let schema = df.schema().clone();
+        let col_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(
+            !col_names.contains(&"embedding"),
+            "embedding column must be absent when include_embedding=false"
+        );
+    }
+
+    #[test]
+    fn invalid_team_name_rejected() {
+        let err = validate_team_name("team; DROP TABLE candidates;--").unwrap_err();
+        assert!(err.to_string().contains("invalid characters"));
+    }
+
+    #[test]
+    fn empty_team_name_rejected() {
+        let err = validate_team_name("").unwrap_err();
+        assert!(err.to_string().contains("not be empty"));
+    }
+
+    #[test]
+    fn valid_team_names_accepted() {
+        assert!(validate_team_name("eng").is_ok());
+        assert!(validate_team_name("ml-team").is_ok());
+        assert!(validate_team_name("data_science.eu").is_ok());
+    }
+}

--- a/crates/likhadb-query/src/error.rs
+++ b/crates/likhadb-query/src/error.rs
@@ -22,4 +22,11 @@ pub enum QueryError {
     #[cfg(feature = "datafusion")]
     #[error("schema error: {0}")]
     Schema(String),
+
+    #[error("rerank error: {0}")]
+    Rerank(String),
+
+    #[cfg(feature = "rerank")]
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
 }

--- a/crates/likhadb-query/src/fusion.rs
+++ b/crates/likhadb-query/src/fusion.rs
@@ -1,0 +1,243 @@
+//! Q3 — Stage 4a: multi-signal score fusion via DataFusion SQL window functions.
+//!
+//! Takes the enriched `DataFrame` from Stage 3 and computes a single `fusion_score`
+//! by normalising each signal to `[0, 1]` via min-max windowing and combining them
+//! with a configured weighted sum. Output is ordered descending and limited to top-M.
+//!
+//! All weights and decay parameters are substituted from config as numeric literals
+//! — they are never derived from user input.
+
+use datafusion::prelude::{DataFrame, SessionContext};
+
+use crate::config::{RecencyConfig, ScoringWeights};
+use crate::{QueryError, Result};
+
+/// Run Stage 4a score fusion over the enriched candidate set.
+///
+/// Registers `enriched` as a temporary view `enriched_candidates`, then executes
+/// a two-CTE SQL query that:
+/// 1. Inverts `ann_distance` and computes recency decay to produce raw signals.
+/// 2. Min-max normalises each signal within the candidate window.
+/// 3. Computes `fusion_score = Σ(weight_i × norm_signal_i)`.
+/// 4. Orders descending by `fusion_score` and limits to `top_m`.
+///
+/// # Parameters
+///
+/// - `ctx`: per-request child `SessionContext` (already has enrichment tables and
+///   `candidates` registered).
+/// - `enriched`: `DataFrame` from [`crate::enrich::enrich`] — must contain columns
+///   `id`, `ann_distance`, `ann_rank`, `chunk_text`, `created_at`.
+/// - `weights`: signal weights from [`crate::config::ScoringConfig`].
+/// - `recency`: recency decay parameters.
+/// - `top_m`: output cardinality limit.
+pub async fn fuse_scores(
+    ctx: &SessionContext,
+    enriched: DataFrame,
+    weights: &ScoringWeights,
+    recency: &RecencyConfig,
+    top_m: usize,
+) -> Result<DataFrame> {
+    ctx.register_table("enriched_candidates", enriched.into_view())
+        .map_err(QueryError::DataFusion)?;
+
+    let lambda = recency.decay_lambda;
+    let grace = recency.grace_period_days;
+    let w_vector = weights.vector_score;
+    let w_recency = weights.recency_score;
+
+    // created_at is stored as Float64 (Unix epoch seconds) in the test schema and
+    // as TIMESTAMP in production Iceberg tables. We compute age in days as:
+    //   (now_epoch_seconds - created_at_epoch_seconds) / 86400
+    // Using extract(epoch from now()) gives a Float64 in DataFusion.
+    let sql = format!(
+        "WITH normalized AS (
+    SELECT
+        id,
+        ann_distance,
+        ann_rank,
+        chunk_text,
+        created_at,
+        1.0 / (1.0 + ann_distance) AS raw_vector_score,
+        exp(-{lambda} * CASE
+            WHEN (extract(epoch from now()) - CAST(created_at AS DOUBLE)) / 86400.0 - {grace}.0 > 0.0
+            THEN (extract(epoch from now()) - CAST(created_at AS DOUBLE)) / 86400.0 - {grace}.0
+            ELSE 0.0
+        END) AS raw_recency_score
+    FROM enriched_candidates
+),
+minmax AS (
+    SELECT
+        id,
+        ann_distance,
+        ann_rank,
+        chunk_text,
+        created_at,
+        raw_vector_score,
+        raw_recency_score,
+        (raw_vector_score  - MIN(raw_vector_score)  OVER ())
+            / NULLIF(MAX(raw_vector_score)  OVER () - MIN(raw_vector_score)  OVER (), 0)
+            AS norm_vector_score,
+        (raw_recency_score - MIN(raw_recency_score) OVER ())
+            / NULLIF(MAX(raw_recency_score) OVER () - MIN(raw_recency_score) OVER (), 0)
+            AS norm_recency_score
+    FROM normalized
+)
+SELECT
+    id,
+    ann_distance,
+    ann_rank,
+    chunk_text,
+    created_at,
+    ({w_vector} * COALESCE(norm_vector_score, 0.0)
+     + {w_recency} * COALESCE(norm_recency_score, 0.0)) AS fusion_score
+FROM minmax
+ORDER BY fusion_score DESC
+LIMIT {top_m}"
+    );
+
+    ctx.sql(&sql).await.map_err(QueryError::DataFusion)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RecencyConfig, ScoringWeights};
+    use datafusion::arrow::array::Float64Array as ArrowF64;
+    use datafusion::arrow::array::{
+        Float32Array, Float64Array, RecordBatch, StringArray, UInt64Array,
+    };
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    fn default_weights() -> ScoringWeights {
+        ScoringWeights::new(0.7, 0.3).unwrap()
+    }
+
+    fn default_recency() -> RecencyConfig {
+        RecencyConfig::new(0, 0.001).unwrap()
+    }
+
+    /// Build an enriched DataFrame with `n` rows.
+    ///
+    /// All rows have the same `created_at` (far in the past so recency decay is
+    /// non-trivial) and distinct `ann_distance` values so ordering is deterministic.
+    async fn make_enriched_df(ctx: &SessionContext, n: usize) -> DataFrame {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("ann_distance", DataType::Float32, false),
+            Field::new("ann_rank", DataType::UInt64, false),
+            Field::new("chunk_text", DataType::Utf8, true),
+            Field::new("created_at", DataType::Float64, true),
+        ]));
+
+        let ids: Vec<&str> = (0..n)
+            .map(|i| Box::leak(format!("c{i}").into_boxed_str()) as &str)
+            .collect();
+        let distances: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
+        let ranks: Vec<u64> = (0..n).map(|i| i as u64 + 1).collect();
+        let texts: Vec<&str> = ids.iter().map(|_| "text").collect();
+        // created_at = 1_600_000_000.0 (well in the past)
+        let created_ats: Vec<f64> = (0..n).map(|_| 1_600_000_000.0f64).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(Float32Array::from(distances)),
+                Arc::new(UInt64Array::from(ranks)),
+                Arc::new(StringArray::from(texts)),
+                Arc::new(ArrowF64::from(created_ats)),
+            ],
+        )
+        .unwrap();
+
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.read_table(Arc::new(table)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn fusion_scores_in_range() {
+        let ctx = SessionContext::new();
+        let df = make_enriched_df(&ctx, 5).await;
+        let result_df = fuse_scores(&ctx, df, &default_weights(), &default_recency(), 10)
+            .await
+            .unwrap();
+        let batches = result_df.collect().await.unwrap();
+        // fusion_score is the last column
+        for batch in &batches {
+            let col_idx = batch.schema().index_of("fusion_score").unwrap();
+            let scores = batch
+                .column(col_idx)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            for i in 0..scores.len() {
+                let s = scores.value(i);
+                assert!(
+                    s >= -1e-6 && s <= 1.0 + 1e-6,
+                    "fusion_score {s} out of [0, 1]"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fusion_scores_ordered_descending() {
+        let ctx = SessionContext::new();
+        let df = make_enriched_df(&ctx, 5).await;
+        let result_df = fuse_scores(&ctx, df, &default_weights(), &default_recency(), 10)
+            .await
+            .unwrap();
+        let batches = result_df.collect().await.unwrap();
+        let col_idx = batches[0].schema().index_of("fusion_score").unwrap();
+        let scores = batches[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        for i in 1..scores.len() {
+            assert!(
+                scores.value(i - 1) >= scores.value(i) - 1e-9,
+                "scores not descending at index {i}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn top_m_limits_output() {
+        let ctx = SessionContext::new();
+        let df = make_enriched_df(&ctx, 10).await;
+        let result_df = fuse_scores(&ctx, df, &default_weights(), &default_recency(), 3)
+            .await
+            .unwrap();
+        let batches = result_df.collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 3);
+    }
+
+    #[tokio::test]
+    async fn single_row_returns_zero_score() {
+        // With one row, MIN == MAX → NULLIF denominator is 0 → COALESCE returns 0.0.
+        let ctx = SessionContext::new();
+        let df = make_enriched_df(&ctx, 1).await;
+        let result_df = fuse_scores(&ctx, df, &default_weights(), &default_recency(), 10)
+            .await
+            .unwrap();
+        let batches = result_df.collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1);
+        let col_idx = batches[0].schema().index_of("fusion_score").unwrap();
+        let scores = batches[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!((scores.value(0) - 0.0).abs() < 1e-6);
+    }
+}

--- a/crates/likhadb-query/src/lib.rs
+++ b/crates/likhadb-query/src/lib.rs
@@ -27,6 +27,18 @@ mod error;
 #[cfg(feature = "datafusion")]
 pub mod session;
 
+#[cfg(feature = "datafusion")]
+pub mod enrich;
+
+#[cfg(feature = "datafusion")]
+pub mod fusion;
+
+#[cfg(feature = "datafusion")]
+pub mod rerank;
+
+#[cfg(feature = "datafusion")]
+pub mod pipeline;
+
 pub use error::QueryError;
 
 /// Convenience alias — all fallible operations in this crate return this type.

--- a/crates/likhadb-query/src/pipeline.rs
+++ b/crates/likhadb-query/src/pipeline.rs
@@ -1,0 +1,530 @@
+//! Q5 — Pipeline orchestration: stages 2 → 3 → 4a → 4b → 4c.
+//!
+//! `Pipeline` sequences the DataFusion enrichment and scoring stages and the
+//! optional model-based reranking stages into a single callable unit. It owns a
+//! shared [`DataFusionSession`] and optional reranking clients, and produces a
+//! `Vec<PipelineResult>` for each incoming request.
+//!
+//! Reranking (stages 4b and 4c) is opt-in: when `bi_encoder` or `cross_encoder`
+//! is `None`, that stage is skipped and the pipeline returns the Stage 4a results
+//! truncated to `top_k`.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Float32Array, RecordBatch, StringArray, UInt64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+use crate::config::{BiEncoderConfig, CrossEncoderConfig, QueryConfig, ScoringConfig};
+use crate::enrich::enrich;
+use crate::fusion::fuse_scores;
+use crate::rerank::{
+    rerank_biencoder, rerank_crossencoder, BiEncoderClient, BiRankedCandidate, CrossEncoderClient,
+};
+use crate::session::{register_candidates_in, DataFusionSession};
+use crate::{QueryError, Result};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single ANN candidate, as returned by the vector index.
+///
+/// The pipeline converts this into an Arrow `RecordBatch` for DataFusion registration.
+/// `ann_distance` is the raw distance metric (lower = closer for L2/cosine).
+/// `ann_rank` is the 1-based position in the sorted result list.
+pub struct Candidate {
+    pub id: u64,
+    pub ann_distance: f32,
+    pub ann_rank: u64,
+}
+
+/// Per-request pipeline input.
+pub struct PipelineRequest {
+    /// ANN candidates from the vector index. Sorted ascending by distance (rank order).
+    pub candidates: Vec<Candidate>,
+    /// Original query text — passed to bi-encoder and cross-encoder if enabled.
+    pub query_text: String,
+    /// Team identifiers from the authenticated request context.
+    /// Used for ACL predicate injection in Stage 3.
+    pub allowed_teams: Vec<String>,
+    /// Final result count. Applied after all reranking stages.
+    pub top_k: usize,
+}
+
+/// A single ranked result from the pipeline.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PipelineResult {
+    pub id: String,
+    pub fusion_score: f64,
+    pub bi_score: Option<f32>,
+    pub cross_score: Option<f32>,
+    pub chunk_text: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/// Composed Tier Q pipeline.
+///
+/// Construct once at service startup via [`Pipeline::new`] and share across
+/// requests via `Arc<Pipeline>`. Each call to [`Pipeline::execute`] acquires a
+/// child `SessionContext` for per-request isolation.
+pub struct Pipeline {
+    session: Arc<DataFusionSession>,
+    scoring: ScoringConfig,
+    top_m: usize,
+    bi_encoder: Option<(Arc<dyn BiEncoderClient>, BiEncoderConfig)>,
+    cross_encoder: Option<(Arc<dyn CrossEncoderClient>, CrossEncoderConfig)>,
+}
+
+impl Pipeline {
+    /// Construct a `Pipeline` from config and a pre-initialised session.
+    ///
+    /// `bi` and `cross` must be `Some` when the corresponding config fields are
+    /// `Some`, and `None` otherwise. The constructor does not validate this
+    /// correspondence — callers are responsible for pairing config with clients.
+    pub fn new(
+        config: &QueryConfig,
+        session: Arc<DataFusionSession>,
+        bi: Option<Arc<dyn BiEncoderClient>>,
+        cross: Option<Arc<dyn CrossEncoderClient>>,
+    ) -> Self {
+        let bi_encoder = config
+            .bi_encoder
+            .as_ref()
+            .zip(bi)
+            .map(|(cfg, client)| (client, cfg.clone()));
+        let cross_encoder = config
+            .cross_encoder
+            .as_ref()
+            .zip(cross)
+            .map(|(cfg, client)| (client, cfg.clone()));
+        Self {
+            session,
+            scoring: ScoringConfig {
+                weights: config.scoring.weights.clone(),
+                recency: crate::config::RecencyConfig {
+                    grace_period_days: config.scoring.recency.grace_period_days,
+                    decay_lambda: config.scoring.recency.decay_lambda,
+                },
+            },
+            top_m: config.top_m,
+            bi_encoder,
+            cross_encoder,
+        }
+    }
+
+    /// Execute the full pipeline for one request.
+    ///
+    /// Returns an empty `Vec` when `req.candidates` is empty.
+    pub async fn execute(&self, req: PipelineRequest) -> Result<Vec<PipelineResult>> {
+        if req.candidates.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Stage 2 — register candidates as Arrow MemTable in a per-request child context.
+        let batch = candidates_to_batch(&req.candidates)?;
+        let child_ctx = self.session.child_context();
+        register_candidates_in(&child_ctx, batch)?;
+
+        // Stage 3 — enrichment SQL (joins + ACL).
+        let include_embedding = false; // dot_product UDF not implemented; bi-encoder uses text
+        let enriched = enrich(&child_ctx, &req.allowed_teams, include_embedding).await?;
+
+        // Stage 4a — score fusion.
+        let fused = fuse_scores(
+            &child_ctx,
+            enriched,
+            &self.scoring.weights,
+            &self.scoring.recency,
+            self.top_m,
+        )
+        .await?;
+
+        // Stage 4b — bi-encoder reranking (optional).
+        let (bi_candidates, effective_top_k): (Vec<BiRankedCandidate>, usize) =
+            if let Some((client, cfg)) = &self.bi_encoder {
+                let ranked = rerank_biencoder(
+                    fused,
+                    &req.query_text,
+                    client.as_ref(),
+                    cfg.alpha,
+                    cfg.top_p,
+                )
+                .await?;
+                let top_k = self
+                    .cross_encoder
+                    .as_ref()
+                    .map(|(_, c)| c.top_k)
+                    .unwrap_or(req.top_k);
+                (ranked, top_k)
+            } else {
+                // No bi-encoder — materialize Stage 4a output directly.
+                let batches = fused.collect().await.map_err(QueryError::DataFusion)?;
+                let results = materialize_fused(batches, req.top_k)?;
+                return Ok(results);
+            };
+
+        // Stage 4c — cross-encoder reranking (optional).
+        if let Some((client, _cfg)) = &self.cross_encoder {
+            let final_results = rerank_crossencoder(
+                bi_candidates,
+                &req.query_text,
+                client.as_ref(),
+                effective_top_k,
+            )
+            .await?;
+            Ok(final_results
+                .into_iter()
+                .map(|r| PipelineResult {
+                    id: r.id,
+                    fusion_score: r.fusion_score,
+                    bi_score: r.bi_score,
+                    cross_score: Some(r.cross_score),
+                    chunk_text: Some(r.chunk_text),
+                })
+                .collect())
+        } else {
+            // Bi-encoder only — truncate to top_k.
+            Ok(bi_candidates
+                .into_iter()
+                .take(req.top_k)
+                .map(|c| PipelineResult {
+                    id: c.id,
+                    fusion_score: c.fusion_score,
+                    bi_score: Some(c.bi_score),
+                    cross_score: None,
+                    chunk_text: Some(c.chunk_text),
+                })
+                .collect())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert `Vec<Candidate>` into an Arrow `RecordBatch` with schema
+/// `id: Utf8, ann_distance: Float32, ann_rank: UInt64`.
+fn candidates_to_batch(candidates: &[Candidate]) -> Result<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("ann_distance", DataType::Float32, false),
+        Field::new("ann_rank", DataType::UInt64, false),
+    ]));
+    let ids: Vec<&str> = candidates
+        .iter()
+        .map(|c| Box::leak(c.id.to_string().into_boxed_str()) as &str)
+        .collect();
+    let distances: Vec<f32> = candidates.iter().map(|c| c.ann_distance).collect();
+    let ranks: Vec<u64> = candidates.iter().map(|c| c.ann_rank).collect();
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(ids)),
+            Arc::new(Float32Array::from(distances)),
+            Arc::new(UInt64Array::from(ranks)),
+        ],
+    )
+    .map_err(QueryError::Arrow)
+}
+
+/// Materialize Stage 4a batches into `PipelineResult`s when reranking is disabled.
+fn materialize_fused(batches: Vec<RecordBatch>, top_k: usize) -> Result<Vec<PipelineResult>> {
+    use datafusion::arrow::array::Float64Array;
+
+    let mut results = Vec::new();
+    for batch in &batches {
+        let schema = batch.schema();
+        let id_idx = schema
+            .index_of("id")
+            .map_err(|e| QueryError::Schema(e.to_string()))?;
+        let score_idx = schema
+            .index_of("fusion_score")
+            .map_err(|e| QueryError::Schema(e.to_string()))?;
+        let text_idx = schema.index_of("chunk_text").ok();
+
+        let id_col = batch
+            .column(id_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| QueryError::Schema("id column is not Utf8".to_string()))?;
+        let score_col = batch
+            .column(score_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or_else(|| QueryError::Schema("fusion_score column is not Float64".to_string()))?;
+
+        for i in 0..batch.num_rows() {
+            let chunk_text = text_idx.and_then(|idx| {
+                batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .map(|a| a.value(i).to_string())
+            });
+
+            results.push(PipelineResult {
+                id: id_col.value(i).to_string(),
+                fusion_score: score_col.value(i),
+                bi_score: None,
+                cross_score: None,
+                chunk_text,
+            });
+        }
+    }
+    results.truncate(top_k);
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        AnnConfig, DataFusionRuntimeConfig, RecencyConfig, ScoringConfig, ScoringWeights,
+    };
+    use crate::session::DataFusionSession;
+    use datafusion::arrow::array::{
+        BooleanArray, Float64Array, ListArray, RecordBatch, StringArray,
+    };
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    // --- Test helpers ---
+
+    fn test_config() -> QueryConfig {
+        QueryConfig {
+            parquet_dir: "/tmp/nonexistent".into(),
+            datafusion: DataFusionRuntimeConfig::default(),
+            ann: AnnConfig::default(),
+            scoring: ScoringConfig {
+                weights: ScoringWeights::new(0.7, 0.3).unwrap(),
+                recency: RecencyConfig::new(0, 0.001).unwrap(),
+            },
+            top_m: 10,
+            bi_encoder: None,
+            cross_encoder: None,
+        }
+    }
+
+    /// Register the five enrichment tables so Stage 3 can run.
+    fn register_enrichment_tables(ctx: &SessionContext, candidate_ids: &[&str]) {
+        let n = candidate_ids.len();
+
+        // embeddings: one row per candidate
+        let emb_schema = Arc::new(Schema::new(vec![
+            Field::new("chunk_id", DataType::Utf8, false),
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new("chunk_text", DataType::Utf8, false),
+        ]));
+        let doc_ids: Vec<String> = (0..n).map(|i| format!("d{i}")).collect();
+        let doc_id_refs: Vec<&str> = doc_ids.iter().map(|s| s.as_str()).collect();
+        let texts: Vec<String> = (0..n).map(|i| format!("text{i}")).collect();
+        let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        ctx.register_table(
+            "embeddings",
+            Arc::new(
+                MemTable::try_new(
+                    emb_schema.clone(),
+                    vec![vec![RecordBatch::try_new(
+                        emb_schema,
+                        vec![
+                            Arc::new(StringArray::from(candidate_ids.to_vec())),
+                            Arc::new(StringArray::from(doc_id_refs.clone())),
+                            Arc::new(StringArray::from(text_refs)),
+                        ],
+                    )
+                    .unwrap()]],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // documents
+        let doc_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("author_id", DataType::Utf8, false),
+            Field::new("created_at", DataType::Float64, true),
+        ]));
+        let created_ats: Vec<f64> = (0..n).map(|_| 1_700_000_000.0f64).collect();
+        ctx.register_table(
+            "documents",
+            Arc::new(
+                MemTable::try_new(
+                    doc_schema.clone(),
+                    vec![vec![RecordBatch::try_new(
+                        doc_schema,
+                        vec![
+                            Arc::new(StringArray::from(doc_id_refs.clone())),
+                            Arc::new(StringArray::from(vec!["a0"; n])),
+                            Arc::new(Float64Array::from(created_ats)),
+                        ],
+                    )
+                    .unwrap()]],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // authors
+        let auth_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("reputation_score", DataType::Float64, false),
+            Field::new("is_verified", DataType::Boolean, false),
+        ]));
+        ctx.register_table(
+            "authors",
+            Arc::new(
+                MemTable::try_new(
+                    auth_schema.clone(),
+                    vec![vec![RecordBatch::try_new(
+                        auth_schema,
+                        vec![
+                            Arc::new(StringArray::from(vec!["a0"])),
+                            Arc::new(Float64Array::from(vec![0.9f64])),
+                            Arc::new(BooleanArray::from(vec![true])),
+                        ],
+                    )
+                    .unwrap()]],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // classifications — all "public"
+        let cls_schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new("sensitivity_label", DataType::Utf8, false),
+        ]));
+        ctx.register_table(
+            "classifications",
+            Arc::new(
+                MemTable::try_new(
+                    cls_schema.clone(),
+                    vec![vec![RecordBatch::try_new(
+                        cls_schema,
+                        vec![
+                            Arc::new(StringArray::from(doc_id_refs.clone())),
+                            Arc::new(StringArray::from(vec!["public"; n])),
+                        ],
+                    )
+                    .unwrap()]],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // access_control — all teams ["eng"]
+        let values = datafusion::arrow::array::StringArray::from(
+            vec!["eng"; n].into_iter().collect::<Vec<_>>(),
+        );
+        let offsets =
+            datafusion::arrow::buffer::OffsetBuffer::new((0..=n as i32).collect::<Vec<_>>().into());
+        let list_arr = ListArray::new(
+            Arc::new(Field::new("item", DataType::Utf8, true)),
+            offsets,
+            Arc::new(values),
+            None,
+        );
+        let acl_schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Utf8, false),
+            Field::new(
+                "allowed_teams",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                false,
+            ),
+        ]));
+        ctx.register_table(
+            "access_control",
+            Arc::new(
+                MemTable::try_new(
+                    acl_schema.clone(),
+                    vec![vec![RecordBatch::try_new(
+                        acl_schema,
+                        vec![Arc::new(StringArray::from(doc_id_refs)), Arc::new(list_arr)],
+                    )
+                    .unwrap()]],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+    }
+
+    fn make_candidates(n: usize) -> Vec<Candidate> {
+        (0..n)
+            .map(|i| Candidate {
+                id: i as u64,
+                ann_distance: i as f32 * 0.1,
+                ann_rank: i as u64 + 1,
+            })
+            .collect()
+    }
+
+    // Integration test: pipeline without reranking
+    #[tokio::test]
+    async fn pipeline_no_reranking_returns_fused_results() {
+        // Build a child context with all tables registered directly for this test.
+        let cfg = test_config();
+        let session = Arc::new(DataFusionSession::try_new(&cfg).await.unwrap());
+        let n = 3;
+        let ids: Vec<String> = (0..n).map(|i| i.to_string()).collect();
+        let id_strs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+
+        // Use pipeline but bypass the shared session — test the materialize path
+        // by creating a child ctx and registering tables there.
+        let child = session.child_context();
+        register_enrichment_tables(&child, &id_strs);
+
+        // Manually run stages to test materialize_fused helper.
+        let candidates = make_candidates(n);
+        let batch = candidates_to_batch(&candidates).unwrap();
+        register_candidates_in(&child, batch).unwrap();
+        let enriched = enrich(&child, &[], false).await.unwrap();
+        let fused = fuse_scores(
+            &child,
+            enriched,
+            &ScoringWeights::new(0.7, 0.3).unwrap(),
+            &RecencyConfig::new(0, 0.001).unwrap(),
+            10,
+        )
+        .await
+        .unwrap();
+        let batches = fused.collect().await.unwrap();
+        let results = materialize_fused(batches, 10).unwrap();
+        assert_eq!(results.len(), n);
+        assert!(results[0].bi_score.is_none());
+        assert!(results[0].cross_score.is_none());
+    }
+
+    #[test]
+    fn empty_candidates_returns_empty() {
+        // candidates_to_batch with empty slice should still produce a valid batch
+        // (but pipeline.execute returns early for empty candidates).
+        let result = candidates_to_batch(&[]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn candidates_to_batch_correct_schema() {
+        let cands = make_candidates(3);
+        let batch = candidates_to_batch(&cands).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.schema().field(0).name(), "id");
+        assert_eq!(batch.schema().field(1).name(), "ann_distance");
+        assert_eq!(batch.schema().field(2).name(), "ann_rank");
+    }
+}

--- a/crates/likhadb-query/src/rerank.rs
+++ b/crates/likhadb-query/src/rerank.rs
@@ -1,0 +1,493 @@
+//! Q4 — Stages 4b and 4c: model-based reranking via materialize-then-call.
+//!
+//! Both stages collect the candidate set out of DataFusion into memory, make a
+//! **single batched** HTTP call to the model service, zip scores back to IDs, and
+//! sort descending. At top-100 → top-20 → top-K cardinalities this pattern is
+//! simpler and faster than an `AsyncScalarUDF` — the DataFusion operator overhead
+//! is not justified for a few dozen rows.
+//!
+//! # Feature gate
+//!
+//! The HTTP implementation types (`HttpBiEncoderClient`, `HttpCrossEncoderClient`)
+//! require the `rerank` feature. The traits and data types are always available so
+//! that callers (including the `pipeline` module) can compile without the feature.
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Float64Array, StringArray};
+use datafusion::prelude::DataFrame;
+#[cfg(feature = "rerank")]
+use serde::Serialize;
+
+use crate::{QueryError, Result};
+
+// ---------------------------------------------------------------------------
+// Model client traits
+// ---------------------------------------------------------------------------
+
+/// Batched bi-encoder similarity client.
+///
+/// A single call receives the query and the full candidate text slice, and must
+/// return one score per element in `texts`. Implementors must **not** iterate
+/// per-row — the whole batch is passed in one call.
+#[async_trait]
+pub trait BiEncoderClient: Send + Sync {
+    async fn score(&self, query: &str, texts: &[String]) -> Result<Vec<f32>>;
+}
+
+/// Batched cross-encoder relevance client.
+///
+/// A single call receives the query and the full candidate passage slice, and must
+/// return one score per element in `passages`.
+#[async_trait]
+pub trait CrossEncoderClient: Send + Sync {
+    async fn score(&self, query: &str, passages: &[String]) -> Result<Vec<f32>>;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP implementations (reqwest)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "rerank")]
+#[derive(Serialize)]
+struct ScoreRequest<'a> {
+    query: &'a str,
+    texts: &'a [String],
+}
+
+/// HTTP bi-encoder client sending `POST {endpoint}` with JSON body `{query, texts}`.
+#[cfg(feature = "rerank")]
+pub struct HttpBiEncoderClient {
+    pub endpoint: String,
+    pub client: reqwest::Client,
+}
+
+#[cfg(feature = "rerank")]
+#[async_trait]
+impl BiEncoderClient for HttpBiEncoderClient {
+    async fn score(&self, query: &str, texts: &[String]) -> Result<Vec<f32>> {
+        let resp = self
+            .client
+            .post(&self.endpoint)
+            .json(&ScoreRequest { query, texts })
+            .send()
+            .await?;
+        resp.json::<Vec<f32>>().await.map_err(QueryError::Http)
+    }
+}
+
+/// HTTP cross-encoder client — same wire format as the bi-encoder.
+#[cfg(feature = "rerank")]
+pub struct HttpCrossEncoderClient {
+    pub endpoint: String,
+    pub client: reqwest::Client,
+}
+
+#[cfg(feature = "rerank")]
+#[async_trait]
+impl CrossEncoderClient for HttpCrossEncoderClient {
+    async fn score(&self, query: &str, passages: &[String]) -> Result<Vec<f32>> {
+        let resp = self
+            .client
+            .post(&self.endpoint)
+            .json(&ScoreRequest {
+                query,
+                texts: passages,
+            })
+            .send()
+            .await?;
+        resp.json::<Vec<f32>>().await.map_err(QueryError::Http)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Stage 4b output: a candidate scored by the bi-encoder and a combined score.
+#[derive(Debug, Clone)]
+pub struct BiRankedCandidate {
+    pub id: String,
+    pub fusion_score: f64,
+    pub bi_score: f32,
+    /// `α × bi_score + (1 - α) × fusion_score`
+    pub combined_score: f64,
+    pub chunk_text: String,
+}
+
+/// Stage 4c output: final ranked result with all three scores.
+#[derive(Debug, Clone)]
+pub struct CrossRankedResult {
+    pub id: String,
+    pub fusion_score: f64,
+    pub bi_score: Option<f32>,
+    pub cross_score: f32,
+    pub chunk_text: String,
+}
+
+// ---------------------------------------------------------------------------
+// Stage 4b — Bi-encoder reranking
+// ---------------------------------------------------------------------------
+
+/// Stage 4b: materialize top-M `DataFrame` → single batched bi-encoder call → top-P.
+///
+/// Steps:
+/// 1. Collect the `DataFrame` into memory (one `collect()` call).
+/// 2. Extract `id`, `fusion_score`, `chunk_text` columns.
+/// 3. Call `client.score(query, &chunk_texts)` — **one call for the whole batch**.
+/// 4. Zip scores: `combined = α × bi_score + (1-α) × fusion_score`.
+/// 5. Sort descending by `combined_score`, truncate to `top_p`.
+pub async fn rerank_biencoder(
+    fused: DataFrame,
+    query: &str,
+    client: &dyn BiEncoderClient,
+    alpha: f32,
+    top_p: usize,
+) -> Result<Vec<BiRankedCandidate>> {
+    let batches = fused.collect().await.map_err(QueryError::DataFusion)?;
+
+    let mut ids: Vec<String> = Vec::new();
+    let mut fusion_scores: Vec<f64> = Vec::new();
+    let mut chunk_texts: Vec<String> = Vec::new();
+
+    for batch in &batches {
+        let schema = batch.schema();
+        let id_idx = schema
+            .index_of("id")
+            .map_err(|e| QueryError::Schema(e.to_string()))?;
+        let score_idx = schema
+            .index_of("fusion_score")
+            .map_err(|e| QueryError::Schema(e.to_string()))?;
+        let text_idx = schema
+            .index_of("chunk_text")
+            .map_err(|e| QueryError::Schema(e.to_string()))?;
+
+        let id_col = batch
+            .column(id_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| QueryError::Schema("id column is not Utf8".to_string()))?;
+        let score_col = batch
+            .column(score_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or_else(|| QueryError::Schema("fusion_score column is not Float64".to_string()))?;
+        let text_col = batch
+            .column(text_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| QueryError::Schema("chunk_text column is not Utf8".to_string()))?;
+
+        for i in 0..batch.num_rows() {
+            ids.push(id_col.value(i).to_string());
+            fusion_scores.push(score_col.value(i));
+            chunk_texts.push(text_col.value(i).to_string());
+        }
+    }
+
+    if ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // Single batched call — not per-row.
+    let bi_scores = client.score(query, &chunk_texts).await?;
+    if bi_scores.len() != ids.len() {
+        return Err(QueryError::Rerank(format!(
+            "bi-encoder returned {} scores for {} candidates",
+            bi_scores.len(),
+            ids.len()
+        )));
+    }
+
+    let alpha_f64 = alpha as f64;
+    let mut candidates: Vec<BiRankedCandidate> = ids
+        .into_iter()
+        .zip(fusion_scores)
+        .zip(bi_scores)
+        .zip(chunk_texts)
+        .map(|(((id, fs), bs), ct)| {
+            let combined = alpha_f64 * bs as f64 + (1.0 - alpha_f64) * fs;
+            BiRankedCandidate {
+                id,
+                fusion_score: fs,
+                bi_score: bs,
+                combined_score: combined,
+                chunk_text: ct,
+            }
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| b.combined_score.partial_cmp(&a.combined_score).unwrap());
+    candidates.truncate(top_p);
+    Ok(candidates)
+}
+
+// ---------------------------------------------------------------------------
+// Stage 4c — Cross-encoder reranking
+// ---------------------------------------------------------------------------
+
+/// Stage 4c: top-P `BiRankedCandidate`s → single batched cross-encoder call → top-K.
+///
+/// Steps:
+/// 1. Extract `chunk_text` from each candidate (already in memory — no DataFusion needed).
+/// 2. Call `client.score(query, &passages)` — **one call for the whole batch**.
+/// 3. Zip scores back to IDs.
+/// 4. Sort descending by `cross_score`, truncate to `top_k`.
+pub async fn rerank_crossencoder(
+    candidates: Vec<BiRankedCandidate>,
+    query: &str,
+    client: &dyn CrossEncoderClient,
+    top_k: usize,
+) -> Result<Vec<CrossRankedResult>> {
+    if candidates.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let passages: Vec<String> = candidates.iter().map(|c| c.chunk_text.clone()).collect();
+
+    // Single batched call.
+    let cross_scores = client.score(query, &passages).await?;
+    if cross_scores.len() != candidates.len() {
+        return Err(QueryError::Rerank(format!(
+            "cross-encoder returned {} scores for {} candidates",
+            cross_scores.len(),
+            candidates.len()
+        )));
+    }
+
+    let mut results: Vec<CrossRankedResult> = candidates
+        .into_iter()
+        .zip(cross_scores)
+        .map(|(c, cs)| CrossRankedResult {
+            id: c.id,
+            fusion_score: c.fusion_score,
+            bi_score: Some(c.bi_score),
+            cross_score: cs,
+            chunk_text: c.chunk_text,
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.cross_score.partial_cmp(&a.cross_score).unwrap());
+    results.truncate(top_k);
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Float64Array, RecordBatch, StringArray, UInt64Array};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // --- Mock clients ---
+
+    struct MockBiEncoder {
+        call_count: Arc<AtomicUsize>,
+        scores: Vec<f32>,
+    }
+
+    #[async_trait]
+    impl BiEncoderClient for MockBiEncoder {
+        async fn score(&self, _query: &str, texts: &[String]) -> Result<Vec<f32>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(
+                texts.len(),
+                self.scores.len(),
+                "mock received wrong number of texts"
+            );
+            Ok(self.scores.clone())
+        }
+    }
+
+    struct MockCrossEncoder {
+        call_count: Arc<AtomicUsize>,
+        scores: Vec<f32>,
+    }
+
+    #[async_trait]
+    impl CrossEncoderClient for MockCrossEncoder {
+        async fn score(&self, _query: &str, passages: &[String]) -> Result<Vec<f32>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(
+                passages.len(),
+                self.scores.len(),
+                "mock received wrong number of passages"
+            );
+            Ok(self.scores.clone())
+        }
+    }
+
+    // --- Helpers ---
+
+    /// Build a `DataFrame` that looks like Stage 4a output (has fusion_score column).
+    async fn make_fused_df(n: usize) -> DataFrame {
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("ann_rank", DataType::UInt64, false),
+            Field::new("chunk_text", DataType::Utf8, true),
+            Field::new("fusion_score", DataType::Float64, false),
+        ]));
+        let ids: Vec<&str> = (0..n)
+            .map(|i| Box::leak(format!("c{i}").into_boxed_str()) as &str)
+            .collect();
+        let ranks: Vec<u64> = (0..n).map(|i| i as u64 + 1).collect();
+        let texts: Vec<&str> = (0..n)
+            .map(|i| Box::leak(format!("text{i}").into_boxed_str()) as &str)
+            .collect();
+        // Descending fusion scores: 0.9, 0.8, 0.7, ...
+        let scores: Vec<f64> = (0..n).map(|i| 0.9 - i as f64 * 0.1).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(UInt64Array::from(ranks)),
+                Arc::new(StringArray::from(texts)),
+                Arc::new(Float64Array::from(scores)),
+            ],
+        )
+        .unwrap();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.read_table(Arc::new(table)).unwrap()
+    }
+
+    // --- bi-encoder tests ---
+
+    #[tokio::test]
+    async fn biencoder_single_batched_call() {
+        let n = 5;
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let client = MockBiEncoder {
+            call_count: call_count.clone(),
+            scores: vec![0.5; n],
+        };
+        let df = make_fused_df(n).await;
+        rerank_biencoder(df, "query", &client, 0.5, n)
+            .await
+            .unwrap();
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "must be exactly 1 call"
+        );
+    }
+
+    #[tokio::test]
+    async fn biencoder_results_ordered_by_combined_score() {
+        // bi_scores: [0.9, 0.1, 0.5, 0.3, 0.7] — should reorder results.
+        let n = 5;
+        let bi_scores = vec![0.9f32, 0.1, 0.5, 0.3, 0.7];
+        let client = MockBiEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: bi_scores,
+        };
+        let df = make_fused_df(n).await;
+        let results = rerank_biencoder(df, "q", &client, 0.5, n).await.unwrap();
+        for i in 1..results.len() {
+            assert!(
+                results[i - 1].combined_score >= results[i].combined_score - 1e-9,
+                "not descending at {i}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn biencoder_truncates_to_top_p() {
+        let n = 5;
+        let client = MockBiEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: vec![0.5; n],
+        };
+        let df = make_fused_df(n).await;
+        let results = rerank_biencoder(df, "q", &client, 0.5, 2).await.unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn biencoder_empty_input_returns_empty() {
+        let df = make_fused_df(0).await;
+        let client = MockBiEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: vec![],
+        };
+        let results = rerank_biencoder(df, "q", &client, 0.5, 5).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    // --- cross-encoder tests ---
+
+    fn make_bi_candidates(n: usize) -> Vec<BiRankedCandidate> {
+        (0..n)
+            .map(|i| BiRankedCandidate {
+                id: format!("c{i}"),
+                fusion_score: 0.9 - i as f64 * 0.1,
+                bi_score: 0.5,
+                combined_score: 0.7 - i as f64 * 0.05,
+                chunk_text: format!("text{i}"),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn crossencoder_single_batched_call() {
+        let n = 4;
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let client = MockCrossEncoder {
+            call_count: call_count.clone(),
+            scores: vec![0.5; n],
+        };
+        rerank_crossencoder(make_bi_candidates(n), "q", &client, n)
+            .await
+            .unwrap();
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn crossencoder_ordered_by_cross_score() {
+        let n = 4;
+        let cross_scores = vec![0.2f32, 0.9, 0.5, 0.1];
+        let client = MockCrossEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: cross_scores,
+        };
+        let results = rerank_crossencoder(make_bi_candidates(n), "q", &client, n)
+            .await
+            .unwrap();
+        for i in 1..results.len() {
+            assert!(
+                results[i - 1].cross_score >= results[i].cross_score - 1e-6,
+                "not descending at {i}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn crossencoder_truncates_to_top_k() {
+        let n = 4;
+        let client = MockCrossEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: vec![0.5; n],
+        };
+        let results = rerank_crossencoder(make_bi_candidates(n), "q", &client, 2)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn crossencoder_empty_input_returns_empty() {
+        let client = MockCrossEncoder {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scores: vec![],
+        };
+        let results = rerank_crossencoder(vec![], "q", &client, 5).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/likhadb-query/src/session.rs
+++ b/crates/likhadb-query/src/session.rs
@@ -205,6 +205,8 @@ mod tests {
                 recency: RecencyConfig::new(30, 0.01).unwrap(),
             },
             top_m: 20,
+            bi_encoder: None,
+            cross_encoder: None,
         }
     }
 

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -3,7 +3,12 @@ name    = "likhadb-server"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Enables Tier Q: DataFusion enrichment, score fusion, and model-based reranking.
+tier-q = ["dep:likhadb-query"]
+
 [dependencies]
+likhadb-query = { path = "../likhadb-query", features = ["datafusion"], optional = true }
 likhadb-core                 = { path = "../likhadb-core" }
 likhadb-store                = { path = "../likhadb-store", features = ["fts"] }
 likhadb-persist              = { path = "../likhadb-persist", features = ["fts"] }

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -12,6 +12,8 @@ use serde_json::json;
 
 use likhadb_lakehouse::LakehouseExt;
 
+#[cfg(feature = "tier-q")]
+use crate::types::RankedQueryResponse;
 use crate::{
     error::ApiError,
     state::AppState,
@@ -21,6 +23,8 @@ use crate::{
         IndexConfig, InsertRequest, QueryRequest, QueryResponse, VectorResponse,
     },
 };
+#[cfg(feature = "tier-q")]
+use likhadb_query::pipeline::{Candidate, PipelineRequest};
 
 pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
     Router::new()
@@ -213,7 +217,31 @@ async fn query_vectors(
         "index_type" => index_type
     )
     .record(start.elapsed().as_secs_f64());
-    Ok(Json(QueryResponse { results }))
+
+    #[cfg(feature = "tier-q")]
+    if let Some(pipeline) = &state.pipeline {
+        let candidates: Vec<Candidate> = results
+            .iter()
+            .enumerate()
+            .map(|(i, r)| Candidate {
+                id: r.id,
+                ann_distance: r.score,
+                ann_rank: i as u64 + 1,
+            })
+            .collect();
+        let ranked = pipeline
+            .execute(PipelineRequest {
+                candidates,
+                query_text: req.query_text.unwrap_or_default(),
+                allowed_teams: req.allowed_teams,
+                top_k: req.k,
+            })
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        return Ok(Json(RankedQueryResponse { results: ranked }).into_response());
+    }
+
+    Ok(Json(QueryResponse { results }).into_response())
 }
 
 #[tracing::instrument(skip(state, req), fields(collection = %name, k = req.k))]
@@ -243,7 +271,31 @@ async fn hybrid_query_vectors(
         "index_type" => index_type
     )
     .record(start.elapsed().as_secs_f64());
-    Ok(Json(HybridQueryResponse { results }))
+
+    #[cfg(feature = "tier-q")]
+    if let Some(pipeline) = &state.pipeline {
+        let candidates: Vec<Candidate> = results
+            .iter()
+            .enumerate()
+            .map(|(i, r)| Candidate {
+                id: r.id,
+                ann_distance: r.score,
+                ann_rank: i as u64 + 1,
+            })
+            .collect();
+        let ranked = pipeline
+            .execute(PipelineRequest {
+                candidates,
+                query_text: req.text.clone(),
+                allowed_teams: req.allowed_teams,
+                top_k: req.k,
+            })
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        return Ok(Json(RankedQueryResponse { results: ranked }).into_response());
+    }
+
+    Ok(Json(HybridQueryResponse { results }).into_response())
 }
 
 async fn import_parquet(

--- a/crates/likhadb-server/src/state.rs
+++ b/crates/likhadb-server/src/state.rs
@@ -22,13 +22,24 @@ use tokio::task::JoinHandle;
 #[derive(Clone)]
 pub struct AppState {
     inner: Arc<RwLock<WalManager>>,
+    #[cfg(feature = "tier-q")]
+    pub pipeline: Option<Arc<likhadb_query::pipeline::Pipeline>>,
 }
 
 impl AppState {
     pub fn new(wal: WalManager) -> Self {
         Self {
             inner: Arc::new(RwLock::new(wal)),
+            #[cfg(feature = "tier-q")]
+            pipeline: None,
         }
+    }
+
+    /// Attach a Tier Q pipeline. Only available when the `tier-q` feature is enabled.
+    #[cfg(feature = "tier-q")]
+    pub fn with_pipeline(mut self, pipeline: Arc<likhadb_query::pipeline::Pipeline>) -> Self {
+        self.pipeline = Some(pipeline);
+        self
     }
 
     pub async fn read(&self) -> RwLockReadGuard<'_, WalManager> {

--- a/crates/likhadb-server/src/types.rs
+++ b/crates/likhadb-server/src/types.rs
@@ -72,6 +72,14 @@ pub struct QueryRequest {
     pub filter: Option<Value>,
     #[serde(default)]
     pub include_payload: bool,
+    /// Team identifiers for Tier Q ACL enforcement.
+    #[cfg(feature = "tier-q")]
+    #[serde(default)]
+    pub allowed_teams: Vec<String>,
+    /// Query text for Tier Q bi-encoder / cross-encoder reranking.
+    #[cfg(feature = "tier-q")]
+    #[serde(default)]
+    pub query_text: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -91,6 +99,10 @@ pub struct HybridQueryRequest {
     pub filter: Option<Value>,
     #[serde(default)]
     pub include_payload: bool,
+    /// Team identifiers for Tier Q ACL enforcement.
+    #[cfg(feature = "tier-q")]
+    #[serde(default)]
+    pub allowed_teams: Vec<String>,
 }
 
 fn default_rrf_k() -> u32 {
@@ -100,6 +112,14 @@ fn default_rrf_k() -> u32 {
 #[derive(Serialize)]
 pub struct HybridQueryResponse {
     pub results: Vec<ScoredResult>,
+}
+
+// ── Tier Q ranked response ────────────────────────────────────────────────────
+
+#[cfg(feature = "tier-q")]
+#[derive(Serialize)]
+pub struct RankedQueryResponse {
+    pub results: Vec<likhadb_query::pipeline::PipelineResult>,
 }
 
 // ── Lakehouse I/O ─────────────────────────────────────────────────────────────

--- a/crates/likhadb-stress/src/main.rs
+++ b/crates/likhadb-stress/src/main.rs
@@ -442,12 +442,7 @@ async fn insert_hybrid_phase(ctx: QueryCtx, n: usize, concurrency: usize) -> Pha
     PhaseResult::new(lats, errs, tos, wall.elapsed())
 }
 
-async fn hybrid_query_phase(
-    ctx: QueryCtx,
-    q: usize,
-    k: usize,
-    concurrency: usize,
-) -> PhaseResult {
+async fn hybrid_query_phase(ctx: QueryCtx, q: usize, k: usize, concurrency: usize) -> PhaseResult {
     let per = q.div_ceil(concurrency);
     let wall = Instant::now();
     let mut set: JoinSet<WorkerStats> = JoinSet::new();
@@ -1019,8 +1014,7 @@ async fn main() {
                         dim: args.dim,
                         timeout_ms: args.timeout_ms,
                     };
-                    let ins =
-                        insert_hybrid_phase(hctx.clone(), n_hybrid, args.concurrency).await;
+                    let ins = insert_hybrid_phase(hctx.clone(), n_hybrid, args.concurrency).await;
                     println!("done ({:.2?})", ins.elapsed);
                     print_baseline_row("Insert", "hybrid", &ins);
 
@@ -1028,8 +1022,7 @@ async fn main() {
                         "\n  Hybrid queries (k={}, {} queries, {} workers)... ",
                         args.k, q_hybrid, args.concurrency
                     );
-                    let qry =
-                        hybrid_query_phase(hctx, q_hybrid, args.k, args.concurrency).await;
+                    let qry = hybrid_query_phase(hctx, q_hybrid, args.k, args.concurrency).await;
                     println!("done ({:.2?})", qry.elapsed);
                     print_baseline_row("Hybrid", "hybrid", &qry);
                     println!();
@@ -1178,8 +1171,14 @@ async fn main() {
             dim: args.dim,
             timeout_ms: args.timeout_ms,
         };
-        let sr = spike_phase(sctx, args.k, args.concurrency, args.spike_factor, args.queries)
-            .await;
+        let sr = spike_phase(
+            sctx,
+            args.k,
+            args.concurrency,
+            args.spike_factor,
+            args.queries,
+        )
+        .await;
 
         let warmup_p99 = sr.warmup.percentile(99).max(1);
         let spike_p99 = sr.spike.percentile(99);

--- a/crates/likhadb-stress/src/main.rs
+++ b/crates/likhadb-stress/src/main.rs
@@ -253,17 +253,23 @@ fn merge_workers(collected: Vec<WorkerStats>) -> (Vec<u64>, u64, u64) {
     (lats, errs, tos)
 }
 
-// ─── Baseline insert / query ──────────────────────────────────────────────────
+// ─── Query context ────────────────────────────────────────────────────────────
+//
+// Bundles the five per-call parameters that every phase function needs, keeping
+// individual argument counts below Clippy's too_many_arguments threshold.
 
-async fn insert_phase(
+#[derive(Clone)]
+struct QueryCtx {
     client: Client,
     host: String,
     collection: String,
     dim: usize,
-    n: usize,
-    concurrency: usize,
     timeout_ms: u64,
-) -> PhaseResult {
+}
+
+// ─── Baseline insert / query ──────────────────────────────────────────────────
+
+async fn insert_phase(ctx: QueryCtx, n: usize, concurrency: usize) -> PhaseResult {
     let per = n.div_ceil(concurrency);
     let wall = Instant::now();
     let mut set: JoinSet<WorkerStats> = JoinSet::new();
@@ -274,9 +280,11 @@ async fn insert_phase(
         if count == 0 {
             break;
         }
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         set.spawn(async move {
             let mut lats = Vec::with_capacity(count);
             let mut errors = 0u64;
@@ -305,16 +313,7 @@ async fn insert_phase(
     PhaseResult::new(lats, errs, tos, wall.elapsed())
 }
 
-async fn query_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
-    q: usize,
-    k: usize,
-    concurrency: usize,
-    timeout_ms: u64,
-) -> PhaseResult {
+async fn query_phase(ctx: QueryCtx, q: usize, k: usize, concurrency: usize) -> PhaseResult {
     let per = q.div_ceil(concurrency);
     let wall = Instant::now();
     let mut set: JoinSet<WorkerStats> = JoinSet::new();
@@ -325,9 +324,11 @@ async fn query_phase(
         if count == 0 {
             break;
         }
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         set.spawn(async move {
             let mut lats = Vec::with_capacity(count);
             let mut errors = 0u64;
@@ -392,15 +393,7 @@ const SEARCH_TERMS: &[&str] = &[
     "BM25",
 ];
 
-async fn insert_hybrid_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
-    n: usize,
-    concurrency: usize,
-    timeout_ms: u64,
-) -> PhaseResult {
+async fn insert_hybrid_phase(ctx: QueryCtx, n: usize, concurrency: usize) -> PhaseResult {
     let per = n.div_ceil(concurrency);
     let wall = Instant::now();
     let mut set: JoinSet<WorkerStats> = JoinSet::new();
@@ -411,9 +404,11 @@ async fn insert_hybrid_phase(
         if count == 0 {
             break;
         }
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         set.spawn(async move {
             let mut lats = Vec::with_capacity(count);
             let mut errors = 0u64;
@@ -448,14 +443,10 @@ async fn insert_hybrid_phase(
 }
 
 async fn hybrid_query_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
+    ctx: QueryCtx,
     q: usize,
     k: usize,
     concurrency: usize,
-    timeout_ms: u64,
 ) -> PhaseResult {
     let per = q.div_ceil(concurrency);
     let wall = Instant::now();
@@ -467,9 +458,11 @@ async fn hybrid_query_phase(
         if count == 0 {
             break;
         }
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         set.spawn(async move {
             let mut lats = Vec::with_capacity(count);
             let mut errors = 0u64;
@@ -511,16 +504,12 @@ struct RampStep {
 }
 
 async fn ramp_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
+    ctx: QueryCtx,
     k: usize,
     queries_per_step: usize,
     max_concurrency: usize,
     error_threshold: f64,
     p99_slo_ms: u64,
-    timeout_ms: u64,
 ) -> Vec<RampStep> {
     // Build doubling ramp: 1, 2, 4, … up to max_concurrency.
     let mut levels = Vec::new();
@@ -535,17 +524,7 @@ async fn ramp_phase(
 
     let mut steps = Vec::new();
     for &concurrency in &levels {
-        let result = query_phase(
-            client.clone(),
-            host.clone(),
-            collection.clone(),
-            dim,
-            queries_per_step,
-            k,
-            concurrency,
-            timeout_ms,
-        )
-        .await;
+        let result = query_phase(ctx.clone(), queries_per_step, k, concurrency).await;
 
         let is_breaking_point =
             result.error_rate() > error_threshold || !result.meets_p99_slo(p99_slo_ms);
@@ -576,54 +555,18 @@ struct SpikeResult {
 }
 
 async fn spike_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
+    ctx: QueryCtx,
     k: usize,
     base_concurrency: usize,
     spike_factor: usize,
     queries: usize,
-    timeout_ms: u64,
 ) -> SpikeResult {
     let spike_concurrency = (base_concurrency * spike_factor).max(base_concurrency + 1);
     let spike_queries = queries * spike_factor;
 
-    let warmup = query_phase(
-        client.clone(),
-        host.clone(),
-        collection.clone(),
-        dim,
-        queries,
-        k,
-        base_concurrency,
-        timeout_ms,
-    )
-    .await;
-
-    let spike = query_phase(
-        client.clone(),
-        host.clone(),
-        collection.clone(),
-        dim,
-        spike_queries,
-        k,
-        spike_concurrency,
-        timeout_ms,
-    )
-    .await;
-
-    let recovery = query_phase(
-        client.clone(),
-        host.clone(),
-        collection.clone(),
-        dim,
-        queries,
-        k,
-        base_concurrency,
-        timeout_ms,
-    )
-    .await;
+    let warmup = query_phase(ctx.clone(), queries, k, base_concurrency).await;
+    let spike = query_phase(ctx.clone(), spike_queries, k, spike_concurrency).await;
+    let recovery = query_phase(ctx.clone(), queries, k, base_concurrency).await;
 
     SpikeResult {
         warmup,
@@ -639,24 +582,22 @@ async fn spike_phase(
 // Within each window, workers loop continuously until the window deadline.
 
 async fn soak_window(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
+    ctx: QueryCtx,
     k: usize,
     concurrency: usize,
     window_dur: Duration,
     seed_base: u64,
-    timeout_ms: u64,
 ) -> PhaseResult {
     let deadline = Instant::now() + window_dur;
     let wall = Instant::now();
     let mut set: JoinSet<WorkerStats> = JoinSet::new();
 
     for w in 0..concurrency {
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         // Spread seeds across workers so they don't repeat the same query vectors.
         let mut seed = seed_base + w as u64 * 100_000;
         set.spawn(async move {
@@ -691,32 +632,17 @@ async fn soak_window(
 }
 
 async fn soak_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
+    ctx: QueryCtx,
     k: usize,
     concurrency: usize,
     total_duration: Duration,
     n_windows: usize,
-    timeout_ms: u64,
 ) -> Vec<PhaseResult> {
     let window_dur = total_duration / n_windows as u32;
     let mut results = Vec::with_capacity(n_windows);
     for w in 0..n_windows {
         let seed_base = w as u64 * 10_000_000;
-        let r = soak_window(
-            client.clone(),
-            host.clone(),
-            collection.clone(),
-            dim,
-            k,
-            concurrency,
-            window_dur,
-            seed_base,
-            timeout_ms,
-        )
-        .await;
+        let r = soak_window(ctx.clone(), k, concurrency, window_dur, seed_base).await;
         results.push(r);
     }
     results
@@ -744,15 +670,7 @@ struct ChaosResult {
     server_healthy: bool,
 }
 
-async fn chaos_phase(
-    client: Client,
-    host: String,
-    collection: String,
-    dim: usize,
-    n_ops: usize,
-    concurrency: usize,
-    timeout_ms: u64,
-) -> ChaosResult {
+async fn chaos_phase(ctx: QueryCtx, n_ops: usize, concurrency: usize) -> ChaosResult {
     struct WorkerResult {
         valid_ok: u64,
         expected_err: u64,
@@ -769,9 +687,11 @@ async fn chaos_phase(
         if count == 0 {
             break;
         }
-        let c = client.clone();
-        let h = host.clone();
-        let col = collection.clone();
+        let c = ctx.client.clone();
+        let h = ctx.host.clone();
+        let col = ctx.collection.clone();
+        let dim = ctx.dim;
+        let timeout_ms = ctx.timeout_ms;
         set.spawn(async move {
             let mut wr = WorkerResult {
                 valid_ok: 0,
@@ -838,7 +758,7 @@ async fn chaos_phase(
                     // Valid ops succeeded as expected.
                     (0 | 1, Outcome::Success(_)) => wr.valid_ok += 1,
                     // Invalid ops got the expected 4xx rejection.
-                    (2 | 3 | 4, Outcome::HttpError(s)) if s >= 400 && s < 500 => {
+                    (2..=4, Outcome::HttpError(s)) if (400..500).contains(&s) => {
                         wr.expected_err += 1
                     }
                     // Timeouts — server may be overloaded but not crashed.
@@ -862,7 +782,7 @@ async fn chaos_phase(
         timeouts += wr.timeouts;
     }
 
-    let server_healthy = health_check(&client, &host).await.is_ok();
+    let server_healthy = health_check(&ctx.client, &ctx.host).await.is_ok();
 
     ChaosResult {
         total: n_ops as u64,
@@ -1048,16 +968,14 @@ async fn main() {
                 "  Inserting {} vectors ({} workers)... ",
                 args.vectors, args.concurrency
             );
-            let ins = insert_phase(
-                client.clone(),
-                args.host.clone(),
-                name.clone(),
-                args.dim,
-                args.vectors,
-                args.concurrency,
-                args.timeout_ms,
-            )
-            .await;
+            let ctx = QueryCtx {
+                client: client.clone(),
+                host: args.host.clone(),
+                collection: name.clone(),
+                dim: args.dim,
+                timeout_ms: args.timeout_ms,
+            };
+            let ins = insert_phase(ctx.clone(), args.vectors, args.concurrency).await;
             println!("done ({:.2?})", ins.elapsed);
             print_baseline_row("Insert", cfg.tag, &ins);
 
@@ -1065,17 +983,7 @@ async fn main() {
                 "\n  Querying (k={}, {} queries, {} workers)... ",
                 args.k, args.queries, args.concurrency
             );
-            let qry = query_phase(
-                client.clone(),
-                args.host.clone(),
-                name.clone(),
-                args.dim,
-                args.queries,
-                args.k,
-                args.concurrency,
-                args.timeout_ms,
-            )
-            .await;
+            let qry = query_phase(ctx, args.queries, args.k, args.concurrency).await;
             println!("done ({:.2?})", qry.elapsed);
             print_baseline_row("Query", cfg.tag, &qry);
             println!();
@@ -1104,16 +1012,15 @@ async fn main() {
                         "  Inserting {} vectors with text payloads ({} workers)... ",
                         n_hybrid, args.concurrency
                     );
-                    let ins = insert_hybrid_phase(
-                        client.clone(),
-                        args.host.clone(),
-                        name.to_string(),
-                        args.dim,
-                        n_hybrid,
-                        args.concurrency,
-                        args.timeout_ms,
-                    )
-                    .await;
+                    let hctx = QueryCtx {
+                        client: client.clone(),
+                        host: args.host.clone(),
+                        collection: name.to_string(),
+                        dim: args.dim,
+                        timeout_ms: args.timeout_ms,
+                    };
+                    let ins =
+                        insert_hybrid_phase(hctx.clone(), n_hybrid, args.concurrency).await;
                     println!("done ({:.2?})", ins.elapsed);
                     print_baseline_row("Insert", "hybrid", &ins);
 
@@ -1121,17 +1028,8 @@ async fn main() {
                         "\n  Hybrid queries (k={}, {} queries, {} workers)... ",
                         args.k, q_hybrid, args.concurrency
                     );
-                    let qry = hybrid_query_phase(
-                        client.clone(),
-                        args.host.clone(),
-                        name.to_string(),
-                        args.dim,
-                        q_hybrid,
-                        args.k,
-                        args.concurrency,
-                        args.timeout_ms,
-                    )
-                    .await;
+                    let qry =
+                        hybrid_query_phase(hctx, q_hybrid, args.k, args.concurrency).await;
                     println!("done ({:.2?})", qry.elapsed);
                     print_baseline_row("Hybrid", "hybrid", &qry);
                     println!();
@@ -1177,16 +1075,14 @@ async fn main() {
             "  Seeding {} vectors ({} workers)... ",
             args.vectors, args.concurrency
         );
-        let seed_result = insert_phase(
-            client.clone(),
-            args.host.clone(),
-            stress_col.clone(),
-            args.dim,
-            args.vectors,
-            args.concurrency,
-            args.timeout_ms,
-        )
-        .await;
+        let stress_ctx = QueryCtx {
+            client: client.clone(),
+            host: args.host.clone(),
+            collection: stress_col.clone(),
+            dim: args.dim,
+            timeout_ms: args.timeout_ms,
+        };
+        let seed_result = insert_phase(stress_ctx, args.vectors, args.concurrency).await;
         println!(
             "done ({:.2?})  err={:.1}%",
             seed_result.elapsed,
@@ -1206,17 +1102,20 @@ async fn main() {
         println!("  {}", "─".repeat(68));
 
         let queries_per_step = args.queries.max(100);
+        let rctx = QueryCtx {
+            client: client.clone(),
+            host: args.host.clone(),
+            collection: stress_col.clone(),
+            dim: args.dim,
+            timeout_ms: args.timeout_ms,
+        };
         let steps = ramp_phase(
-            client.clone(),
-            args.host.clone(),
-            stress_col.clone(),
-            args.dim,
+            rctx,
             args.k,
             queries_per_step,
             args.max_concurrency,
             args.error_threshold,
             args.p99_slo_ms,
-            args.timeout_ms,
         )
         .await;
 
@@ -1272,18 +1171,15 @@ async fn main() {
         );
         separator();
 
-        let sr = spike_phase(
-            client.clone(),
-            args.host.clone(),
-            stress_col.clone(),
-            args.dim,
-            args.k,
-            args.concurrency,
-            args.spike_factor,
-            args.queries,
-            args.timeout_ms,
-        )
-        .await;
+        let sctx = QueryCtx {
+            client: client.clone(),
+            host: args.host.clone(),
+            collection: stress_col.clone(),
+            dim: args.dim,
+            timeout_ms: args.timeout_ms,
+        };
+        let sr = spike_phase(sctx, args.k, args.concurrency, args.spike_factor, args.queries)
+            .await;
 
         let warmup_p99 = sr.warmup.percentile(99).max(1);
         let spike_p99 = sr.spike.percentile(99);
@@ -1333,16 +1229,19 @@ async fn main() {
         );
         separator();
 
+        let soakctx = QueryCtx {
+            client: client.clone(),
+            host: args.host.clone(),
+            collection: stress_col.clone(),
+            dim: args.dim,
+            timeout_ms: args.timeout_ms,
+        };
         let windows = soak_phase(
-            client.clone(),
-            args.host.clone(),
-            stress_col.clone(),
-            args.dim,
+            soakctx,
             args.k,
             args.concurrency,
             Duration::from_secs(args.soak_secs),
             N_WINDOWS,
-            args.timeout_ms,
         )
         .await;
 
@@ -1399,16 +1298,14 @@ async fn main() {
         println!("          wrong-dimension (20%) · nonexistent-vector (20%)");
         println!();
 
-        let cr = chaos_phase(
-            client.clone(),
-            args.host.clone(),
-            stress_col.clone(),
-            args.dim,
-            args.chaos_ops,
-            chaos_concurrency,
-            args.timeout_ms,
-        )
-        .await;
+        let cctx = QueryCtx {
+            client: client.clone(),
+            host: args.host.clone(),
+            collection: stress_col.clone(),
+            dim: args.dim,
+            timeout_ms: args.timeout_ms,
+        };
+        let cr = chaos_phase(cctx, args.chaos_ops, chaos_concurrency).await;
 
         println!("  Results  ({} total ops):", cr.total);
         println!("    valid successes  : {}", cr.valid_successes);

--- a/crates/likhadb-stress/src/main.rs
+++ b/crates/likhadb-stress/src/main.rs
@@ -50,7 +50,6 @@ struct Args {
     no_cleanup: bool,
 
     // ── Stress controls ───────────────────────────────────────────────────────
-
     /// Per-request timeout in milliseconds (0 = disabled)
     #[arg(long, default_value_t = 5_000)]
     timeout_ms: u64,
@@ -383,7 +382,14 @@ const CORPUS: &[&str] = &[
 ];
 
 const SEARCH_TERMS: &[&str] = &[
-    "vector", "search", "rust", "index", "embedding", "retrieval", "HNSW", "BM25",
+    "vector",
+    "search",
+    "rust",
+    "index",
+    "embedding",
+    "retrieval",
+    "HNSW",
+    "BM25",
 ];
 
 async fn insert_hybrid_phase(
@@ -416,11 +422,13 @@ async fn insert_hybrid_phase(
                 let id = (base + i) as u64;
                 let vec = make_vec(id, dim);
                 let text = CORPUS[id as usize % CORPUS.len()];
-                let req = c.post(format!("{h}/collections/{col}/vectors")).json(&json!({
-                    "id": id,
-                    "vector": vec,
-                    "payload": {"body": text, "seq": id},
-                }));
+                let req = c
+                    .post(format!("{h}/collections/{col}/vectors"))
+                    .json(&json!({
+                        "id": id,
+                        "vector": vec,
+                        "payload": {"body": text, "seq": id},
+                    }));
                 match send_timed(req, timeout_ms).await {
                     Outcome::Success(us) => lats.push(us),
                     Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
@@ -819,10 +827,7 @@ async fn chaos_phase(
                     _ => {
                         // Fetch a vector ID that was never inserted (expect 404).
                         send_timed(
-                            c.get(format!(
-                                "{h}/collections/{col}/vectors/{}",
-                                id + 9_000_000
-                            )),
+                            c.get(format!("{h}/collections/{col}/vectors/{}", id + 9_000_000)),
                             timeout_ms,
                         )
                         .await
@@ -913,26 +918,14 @@ fn slo_mark(passes: bool) -> &'static str {
 // ─── Summary ──────────────────────────────────────────────────────────────────
 
 fn print_baseline_summary(results: &[(&str, PhaseResult, PhaseResult)], args: &Args) {
-    println!(
-        "  ══════════════════════════════════════════════════════════════════════════════"
-    );
+    println!("  ══════════════════════════════════════════════════════════════════════════════");
     println!(
         "  BASELINE SUMMARY  dim={}  vectors={}  queries={}  concurrency={}",
         args.dim, args.vectors, args.queries, args.concurrency
     );
     println!(
         "  {:<10}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5}    {:>9}  {:>8}  {:>8}  {:>8}  {:>5}",
-        "index",
-        "ins/s",
-        "p50",
-        "p95",
-        "p99",
-        "err%",
-        "qry/s",
-        "p50",
-        "p95",
-        "p99",
-        "err%"
+        "index", "ins/s", "p50", "p95", "p99", "err%", "qry/s", "p50", "p95", "p99", "err%"
     );
     println!("  {}", "─".repeat(78));
     for (tag, ins, qry) in results {
@@ -951,9 +944,7 @@ fn print_baseline_summary(results: &[(&str, PhaseResult, PhaseResult)], args: &A
             qry.error_rate(),
         );
     }
-    println!(
-        "  ══════════════════════════════════════════════════════════════════════════════"
-    );
+    println!("  ══════════════════════════════════════════════════════════════════════════════");
     println!();
 }
 
@@ -1149,9 +1140,7 @@ async fn main() {
                 }
                 Err(e) => {
                     eprintln!("FAILED: {e}");
-                    eprintln!(
-                        "  (Compiled without fts feature? Skipping hybrid sub-phase.)"
-                    );
+                    eprintln!("  (Compiled without fts feature? Skipping hybrid sub-phase.)");
                     println!();
                 }
             }
@@ -1164,8 +1153,7 @@ async fn main() {
     // A flat collection pre-seeded with `vectors` entries is shared across
     // ramp, spike, soak, and chaos phases so each phase begins with a warm index.
 
-    let any_stress =
-        !args.skip_ramp || !args.skip_spike || !args.skip_soak || !args.skip_chaos;
+    let any_stress = !args.skip_ramp || !args.skip_spike || !args.skip_soak || !args.skip_chaos;
 
     let stress_col = "stress_main".to_string();
 
@@ -1301,15 +1289,18 @@ async fn main() {
         let spike_p99 = sr.spike.percentile(99);
         let recovery_p99 = sr.recovery.percentile(99);
         let degradation = spike_p99 as f64 / warmup_p99 as f64;
-        let recovered =
-            recovery_p99 <= (warmup_p99 as f64 * 1.5) as u64; // within 1.5× warm-up is "recovered"
+        let recovered = recovery_p99 <= (warmup_p99 as f64 * 1.5) as u64; // within 1.5× warm-up is "recovered"
 
         println!(
             "  {:<12}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5.1}%",
             "phase", "tput", "p50", "p95", "p99", "err%"
         );
         println!("  {}", "─".repeat(60));
-        for (label, r) in [("warm-up", &sr.warmup), ("spike", &sr.spike), ("recovery", &sr.recovery)] {
+        for (label, r) in [
+            ("warm-up", &sr.warmup),
+            ("spike", &sr.spike),
+            ("recovery", &sr.recovery),
+        ] {
             println!(
                 "  {:<12}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5.1}%",
                 label,
@@ -1324,7 +1315,11 @@ async fn main() {
         println!(
             "  p99 degradation during spike: {:.1}×   recovery: {}",
             degradation,
-            if recovered { "✓ clean" } else { "✗ still elevated" }
+            if recovered {
+                "✓ clean"
+            } else {
+                "✗ still elevated"
+            }
         );
         println!();
     }
@@ -1370,7 +1365,11 @@ async fn main() {
         }
 
         if windows.len() >= 2 {
-            let first_p95 = windows.first().map(|w| w.percentile(95)).unwrap_or(0).max(1);
+            let first_p95 = windows
+                .first()
+                .map(|w| w.percentile(95))
+                .unwrap_or(0)
+                .max(1);
             let last_p95 = windows.last().map(|w| w.percentile(95)).unwrap_or(0);
             let drift_pct = (last_p95 as f64 - first_p95 as f64) / first_p95 as f64 * 100.0;
             println!();
@@ -1413,7 +1412,10 @@ async fn main() {
 
         println!("  Results  ({} total ops):", cr.total);
         println!("    valid successes  : {}", cr.valid_successes);
-        println!("    expected errors  : {} (correct 4xx from invalid ops)", cr.expected_errors);
+        println!(
+            "    expected errors  : {} (correct 4xx from invalid ops)",
+            cr.expected_errors
+        );
         println!("    timeouts         : {}", cr.timeouts);
         println!(
             "    unexpected errors: {}  {}",
@@ -1426,15 +1428,17 @@ async fn main() {
         );
         println!(
             "    server health    : {}",
-            if cr.server_healthy { "OK ✓" } else { "FAILED ✗" }
+            if cr.server_healthy {
+                "OK ✓"
+            } else {
+                "FAILED ✗"
+            }
         );
         println!();
     }
 
     // ── Final SLO verdict ─────────────────────────────────────────────────────
-    println!(
-        "  ══════════════════════════════════════════════════════════════════════════════"
-    );
+    println!("  ══════════════════════════════════════════════════════════════════════════════");
     println!("  SLO VERDICT  (p99 threshold = {}ms)", args.p99_slo_ms);
     println!("  {}", "─".repeat(78));
 
@@ -1449,9 +1453,7 @@ async fn main() {
         }
     }
 
-    println!(
-        "  ══════════════════════════════════════════════════════════════════════════════"
-    );
+    println!("  ══════════════════════════════════════════════════════════════════════════════");
     println!();
 
     finalize(&args, &all_collections, &client).await;
@@ -1465,9 +1467,7 @@ async fn finalize(args: &Args, all_collections: &[String], client: &Client) {
         }
         println!("done");
     } else {
-        println!(
-            "  Collections retained (--no-cleanup). Inspect via GET /collections."
-        );
+        println!("  Collections retained (--no-cleanup). Inspect via GET /collections.");
     }
     println!();
 }

--- a/crates/likhadb-stress/src/main.rs
+++ b/crates/likhadb-stress/src/main.rs
@@ -3,46 +3,97 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
-use tokio::task::JoinSet;
+use tokio::{task::JoinSet, time::timeout};
 
 // ─── CLI ──────────────────────────────────────────────────────────────────────
 
 #[derive(Parser, Debug)]
 #[command(
     name = "likhadb-stress",
-    about = "Stress / workload demonstration for LikhaDB",
-    long_about = "Runs concurrent insert + query workloads against a live LikhaDB server.\n\
-                  Compares Flat (brute-force), IVF, and HNSW indexes, then runs a\n\
-                  hybrid vector+BM25 phase to show full-text fusion."
+    about = "Breaking-point stress test for LikhaDB",
+    long_about = "Pushes LikhaDB beyond its normal operational limits to discover breaking\n\
+                  points, validate error handling under pressure, and verify SLO compliance.\n\n\
+                  Phases (all enabled by default):\n\
+                  1. Baseline  — flat / IVF / HNSW / hybrid throughput benchmarks\n\
+                  2. Ramp      — doubles concurrency until error threshold or p99 SLO breach\n\
+                  3. Spike     — sudden traffic surge followed by recovery measurement\n\
+                  4. Soak      — sustained load across time windows; detects latency drift\n\
+                  5. Chaos     — mixed valid/invalid operations; verifies graceful error handling"
 )]
 struct Args {
     /// Base URL of the running LikhaDB server
     #[arg(long, default_value = "http://localhost:8080")]
     host: String,
 
-    /// Vector dimension (should match your embedding model)
+    /// Vector dimension
     #[arg(long, default_value_t = 128)]
     dim: usize,
 
-    /// Vectors to insert per index type
+    /// Vectors to insert per index type during the baseline phase
     #[arg(long, default_value_t = 10_000)]
     vectors: usize,
 
-    /// Query iterations per index type
+    /// Query iterations per index type during the baseline phase
     #[arg(long, default_value_t = 500)]
     queries: usize,
 
-    /// Concurrent HTTP workers
+    /// Base concurrent HTTP workers
     #[arg(long, default_value_t = 8)]
     concurrency: usize,
 
-    /// Top-k results returned per query
+    /// Top-k results per query
     #[arg(long, default_value_t = 10)]
     k: usize,
 
-    /// Keep test collections after the run (useful for inspection)
+    /// Keep test collections after the run
     #[arg(long)]
     no_cleanup: bool,
+
+    // ── Stress controls ───────────────────────────────────────────────────────
+
+    /// Per-request timeout in milliseconds (0 = disabled)
+    #[arg(long, default_value_t = 5_000)]
+    timeout_ms: u64,
+
+    /// Maximum concurrency ceiling for the ramp phase
+    #[arg(long, default_value_t = 64)]
+    max_concurrency: usize,
+
+    /// Error rate (%) that declares a breaking point during the ramp phase
+    #[arg(long, default_value_t = 5.0)]
+    error_threshold: f64,
+
+    /// p99 latency SLO in milliseconds — ramp breaks here; final verdict uses this
+    #[arg(long, default_value_t = 500)]
+    p99_slo_ms: u64,
+
+    /// Concurrency multiplier for the spike phase (e.g. 4 → 4× base concurrency)
+    #[arg(long, default_value_t = 4)]
+    spike_factor: usize,
+
+    /// Duration of the soak phase in seconds
+    #[arg(long, default_value_t = 30)]
+    soak_secs: u64,
+
+    /// Number of random operations in the chaos phase
+    #[arg(long, default_value_t = 1_000)]
+    chaos_ops: usize,
+
+    // ── Phase toggles ─────────────────────────────────────────────────────────
+    #[arg(long)]
+    skip_baseline: bool,
+
+    #[arg(long)]
+    skip_ramp: bool,
+
+    #[arg(long)]
+    skip_spike: bool,
+
+    #[arg(long)]
+    skip_soak: bool,
+
+    #[arg(long)]
+    skip_chaos: bool,
 }
 
 // ─── Vector helpers ───────────────────────────────────────────────────────────
@@ -52,39 +103,90 @@ fn make_vec(seed: u64, dim: usize) -> Vec<f32> {
     (0..dim).map(|_| rng.gen::<f32>() * 2.0 - 1.0).collect()
 }
 
-// Query seeds live in a different space from insert seeds so queries never
-// coincide with stored vectors (which would trivially score 1.0).
+// Query seeds live in a different space so they never coincide with stored vectors.
 fn make_query(seed: u64, dim: usize) -> Vec<f32> {
     make_vec(seed.wrapping_add(u64::MAX / 2), dim)
 }
 
-// ─── Latency stats ────────────────────────────────────────────────────────────
+// ─── Phase result ─────────────────────────────────────────────────────────────
 
-struct Timing {
-    us: Vec<u64>, // per-operation microseconds, sorted after construction
+struct PhaseResult {
+    latencies_us: Vec<u64>, // successful ops only, sorted
+    errors: u64,            // HTTP non-2xx responses
+    timeouts: u64,
+    total: u64,
     elapsed: Duration,
 }
 
-impl Timing {
-    fn new(mut us: Vec<u64>, elapsed: Duration) -> Self {
-        us.sort_unstable();
-        Self { us, elapsed }
+impl PhaseResult {
+    fn new(mut latencies_us: Vec<u64>, errors: u64, timeouts: u64, elapsed: Duration) -> Self {
+        let total = latencies_us.len() as u64 + errors + timeouts;
+        latencies_us.sort_unstable();
+        Self {
+            latencies_us,
+            errors,
+            timeouts,
+            total,
+            elapsed,
+        }
+    }
+
+    fn success(&self) -> u64 {
+        self.latencies_us.len() as u64
+    }
+
+    fn error_rate(&self) -> f64 {
+        if self.total == 0 {
+            return 0.0;
+        }
+        (self.errors + self.timeouts) as f64 / self.total as f64 * 100.0
     }
 
     fn percentile(&self, p: usize) -> u64 {
-        if self.us.is_empty() {
+        if self.latencies_us.is_empty() {
             return 0;
         }
-        let idx = (self.us.len() * p / 100).min(self.us.len() - 1);
-        self.us[idx]
+        let idx = (self.latencies_us.len() * p / 100).min(self.latencies_us.len() - 1);
+        self.latencies_us[idx]
     }
 
     fn throughput(&self) -> f64 {
-        self.us.len() as f64 / self.elapsed.as_secs_f64()
+        self.total as f64 / self.elapsed.as_secs_f64()
+    }
+
+    fn meets_p99_slo(&self, slo_ms: u64) -> bool {
+        self.percentile(99) <= slo_ms * 1_000
     }
 }
 
-// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+// ─── HTTP outcome ─────────────────────────────────────────────────────────────
+
+enum Outcome {
+    Success(u64), // latency µs
+    HttpError(u16),
+    Timeout,
+    NetworkError,
+}
+
+async fn send_timed(req: reqwest::RequestBuilder, timeout_ms: u64) -> Outcome {
+    let t = Instant::now();
+    let resp = if timeout_ms > 0 {
+        match timeout(Duration::from_millis(timeout_ms), req.send()).await {
+            Err(_) => return Outcome::Timeout,
+            Ok(r) => r,
+        }
+    } else {
+        req.send().await
+    };
+    let us = t.elapsed().as_micros() as u64;
+    match resp {
+        Err(_) => Outcome::NetworkError,
+        Ok(r) if r.status().is_success() => Outcome::Success(us),
+        Ok(r) => Outcome::HttpError(r.status().as_u16()),
+    }
+}
+
+// ─── Server helpers ───────────────────────────────────────────────────────────
 
 async fn health_check(client: &Client, host: &str) -> Result<(), String> {
     client
@@ -129,17 +231,31 @@ async fn create_collection(
 }
 
 async fn drop_collection(client: &Client, host: &str, name: &str) {
-    // Best-effort; ignore errors (collection may not exist yet).
     let _ = client
         .delete(format!("{host}/collections/{name}"))
         .send()
         .await;
 }
 
-// ─── Workload phases ──────────────────────────────────────────────────────────
+// ─── Shared worker collectors ─────────────────────────────────────────────────
 
-/// Split `n` items across `concurrency` workers; each worker runs sequentially
-/// to model a realistic multi-client scenario.
+// Returns (latencies, errors, timeouts) collected by one worker task.
+type WorkerStats = (Vec<u64>, u64, u64);
+
+fn merge_workers(collected: Vec<WorkerStats>) -> (Vec<u64>, u64, u64) {
+    let mut lats = Vec::new();
+    let mut errs = 0u64;
+    let mut tos = 0u64;
+    for (l, e, t) in collected {
+        lats.extend(l);
+        errs += e;
+        tos += t;
+    }
+    (lats, errs, tos)
+}
+
+// ─── Baseline insert / query ──────────────────────────────────────────────────
+
 async fn insert_phase(
     client: Client,
     host: String,
@@ -147,10 +263,11 @@ async fn insert_phase(
     dim: usize,
     n: usize,
     concurrency: usize,
-) -> Timing {
+    timeout_ms: u64,
+) -> PhaseResult {
     let per = n.div_ceil(concurrency);
     let wall = Instant::now();
-    let mut set: JoinSet<Vec<u64>> = JoinSet::new();
+    let mut set: JoinSet<WorkerStats> = JoinSet::new();
 
     for w in 0..concurrency {
         let base = w * per;
@@ -162,27 +279,31 @@ async fn insert_phase(
         let h = host.clone();
         let col = collection.clone();
         set.spawn(async move {
-            let mut us = Vec::with_capacity(count);
+            let mut lats = Vec::with_capacity(count);
+            let mut errors = 0u64;
+            let mut tos = 0u64;
             for i in 0..count {
                 let id = (base + i) as u64;
                 let vec = make_vec(id, dim);
-                let t = Instant::now();
-                let _ = c
+                let req = c
                     .post(format!("{h}/collections/{col}/vectors"))
-                    .json(&json!({"id": id, "vector": vec, "payload": {"seq": id}}))
-                    .send()
-                    .await;
-                us.push(t.elapsed().as_micros() as u64);
+                    .json(&json!({"id": id, "vector": vec, "payload": {"seq": id}}));
+                match send_timed(req, timeout_ms).await {
+                    Outcome::Success(us) => lats.push(us),
+                    Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
+                    Outcome::Timeout => tos += 1,
+                }
             }
-            us
+            (lats, errors, tos)
         });
     }
 
-    let mut all = Vec::with_capacity(n);
-    while let Some(Ok(chunk)) = set.join_next().await {
-        all.extend(chunk);
+    let mut collected = Vec::new();
+    while let Some(Ok(stats)) = set.join_next().await {
+        collected.push(stats);
     }
-    Timing::new(all, wall.elapsed())
+    let (lats, errs, tos) = merge_workers(collected);
+    PhaseResult::new(lats, errs, tos, wall.elapsed())
 }
 
 async fn query_phase(
@@ -193,10 +314,11 @@ async fn query_phase(
     q: usize,
     k: usize,
     concurrency: usize,
-) -> Timing {
+    timeout_ms: u64,
+) -> PhaseResult {
     let per = q.div_ceil(concurrency);
     let wall = Instant::now();
-    let mut set: JoinSet<Vec<u64>> = JoinSet::new();
+    let mut set: JoinSet<WorkerStats> = JoinSet::new();
 
     for w in 0..concurrency {
         let base = w * per;
@@ -208,30 +330,35 @@ async fn query_phase(
         let h = host.clone();
         let col = collection.clone();
         set.spawn(async move {
-            let mut us = Vec::with_capacity(count);
+            let mut lats = Vec::with_capacity(count);
+            let mut errors = 0u64;
+            let mut tos = 0u64;
             for i in 0..count {
                 let seed = (base + i) as u64;
                 let vec = make_query(seed, dim);
-                let t = Instant::now();
-                let _ = c
+                let req = c
                     .post(format!("{h}/collections/{col}/query"))
-                    .json(&json!({"vector": vec, "k": k}))
-                    .send()
-                    .await;
-                us.push(t.elapsed().as_micros() as u64);
+                    .json(&json!({"vector": vec, "k": k}));
+                match send_timed(req, timeout_ms).await {
+                    Outcome::Success(us) => lats.push(us),
+                    Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
+                    Outcome::Timeout => tos += 1,
+                }
             }
-            us
+            (lats, errors, tos)
         });
     }
 
-    let mut all = Vec::with_capacity(q);
-    while let Some(Ok(chunk)) = set.join_next().await {
-        all.extend(chunk);
+    let mut collected = Vec::new();
+    while let Some(Ok(stats)) = set.join_next().await {
+        collected.push(stats);
     }
-    Timing::new(all, wall.elapsed())
+    let (lats, errs, tos) = merge_workers(collected);
+    PhaseResult::new(lats, errs, tos, wall.elapsed())
 }
 
-// 20 tech-domain sentences give BM25 meaningful term frequencies to rank.
+// ─── Hybrid (baseline sub-phase) ─────────────────────────────────────────────
+
 const CORPUS: &[&str] = &[
     "vector database semantic similarity embeddings retrieval augmented",
     "approximate nearest neighbor graph HNSW index performance",
@@ -255,6 +382,10 @@ const CORPUS: &[&str] = &[
     "metadata filtering predicate pushdown index scan filter",
 ];
 
+const SEARCH_TERMS: &[&str] = &[
+    "vector", "search", "rust", "index", "embedding", "retrieval", "HNSW", "BM25",
+];
+
 async fn insert_hybrid_phase(
     client: Client,
     host: String,
@@ -262,10 +393,11 @@ async fn insert_hybrid_phase(
     dim: usize,
     n: usize,
     concurrency: usize,
-) -> Timing {
+    timeout_ms: u64,
+) -> PhaseResult {
     let per = n.div_ceil(concurrency);
     let wall = Instant::now();
-    let mut set: JoinSet<Vec<u64>> = JoinSet::new();
+    let mut set: JoinSet<WorkerStats> = JoinSet::new();
 
     for w in 0..concurrency {
         let base = w * per;
@@ -277,44 +409,35 @@ async fn insert_hybrid_phase(
         let h = host.clone();
         let col = collection.clone();
         set.spawn(async move {
-            let mut us = Vec::with_capacity(count);
+            let mut lats = Vec::with_capacity(count);
+            let mut errors = 0u64;
+            let mut tos = 0u64;
             for i in 0..count {
                 let id = (base + i) as u64;
                 let vec = make_vec(id, dim);
                 let text = CORPUS[id as usize % CORPUS.len()];
-                let t = Instant::now();
-                let _ = c
-                    .post(format!("{h}/collections/{col}/vectors"))
-                    .json(&json!({
-                        "id": id,
-                        "vector": vec,
-                        "payload": {"body": text, "seq": id},
-                    }))
-                    .send()
-                    .await;
-                us.push(t.elapsed().as_micros() as u64);
+                let req = c.post(format!("{h}/collections/{col}/vectors")).json(&json!({
+                    "id": id,
+                    "vector": vec,
+                    "payload": {"body": text, "seq": id},
+                }));
+                match send_timed(req, timeout_ms).await {
+                    Outcome::Success(us) => lats.push(us),
+                    Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
+                    Outcome::Timeout => tos += 1,
+                }
             }
-            us
+            (lats, errors, tos)
         });
     }
 
-    let mut all = Vec::with_capacity(n);
-    while let Some(Ok(chunk)) = set.join_next().await {
-        all.extend(chunk);
+    let mut collected = Vec::new();
+    while let Some(Ok(stats)) = set.join_next().await {
+        collected.push(stats);
     }
-    Timing::new(all, wall.elapsed())
+    let (lats, errs, tos) = merge_workers(collected);
+    PhaseResult::new(lats, errs, tos, wall.elapsed())
 }
-
-const SEARCH_TERMS: &[&str] = &[
-    "vector",
-    "search",
-    "rust",
-    "index",
-    "embedding",
-    "retrieval",
-    "HNSW",
-    "BM25",
-];
 
 async fn hybrid_query_phase(
     client: Client,
@@ -324,10 +447,11 @@ async fn hybrid_query_phase(
     q: usize,
     k: usize,
     concurrency: usize,
-) -> Timing {
+    timeout_ms: u64,
+) -> PhaseResult {
     let per = q.div_ceil(concurrency);
     let wall = Instant::now();
-    let mut set: JoinSet<Vec<u64>> = JoinSet::new();
+    let mut set: JoinSet<WorkerStats> = JoinSet::new();
 
     for w in 0..concurrency {
         let base = w * per;
@@ -339,28 +463,410 @@ async fn hybrid_query_phase(
         let h = host.clone();
         let col = collection.clone();
         set.spawn(async move {
-            let mut us = Vec::with_capacity(count);
+            let mut lats = Vec::with_capacity(count);
+            let mut errors = 0u64;
+            let mut tos = 0u64;
             for i in 0..count {
                 let seed = (base + i) as u64;
                 let vec = make_query(seed, dim);
                 let term = SEARCH_TERMS[seed as usize % SEARCH_TERMS.len()];
-                let t = Instant::now();
-                let _ = c
+                let req = c
                     .post(format!("{h}/collections/{col}/hybrid-query"))
-                    .json(&json!({"vector": vec, "text": term, "k": k}))
-                    .send()
-                    .await;
-                us.push(t.elapsed().as_micros() as u64);
+                    .json(&json!({"vector": vec, "text": term, "k": k}));
+                match send_timed(req, timeout_ms).await {
+                    Outcome::Success(us) => lats.push(us),
+                    Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
+                    Outcome::Timeout => tos += 1,
+                }
             }
-            us
+            (lats, errors, tos)
         });
     }
 
-    let mut all = Vec::with_capacity(q);
-    while let Some(Ok(chunk)) = set.join_next().await {
-        all.extend(chunk);
+    let mut collected = Vec::new();
+    while let Some(Ok(stats)) = set.join_next().await {
+        collected.push(stats);
     }
-    Timing::new(all, wall.elapsed())
+    let (lats, errs, tos) = merge_workers(collected);
+    PhaseResult::new(lats, errs, tos, wall.elapsed())
+}
+
+// ─── Stress phase: Ramp ───────────────────────────────────────────────────────
+//
+// Doubles concurrency from 1 → max_concurrency, stopping when error rate exceeds
+// the threshold or p99 breaches the SLO. The last step is the breaking point.
+
+struct RampStep {
+    concurrency: usize,
+    result: PhaseResult,
+    is_breaking_point: bool,
+}
+
+async fn ramp_phase(
+    client: Client,
+    host: String,
+    collection: String,
+    dim: usize,
+    k: usize,
+    queries_per_step: usize,
+    max_concurrency: usize,
+    error_threshold: f64,
+    p99_slo_ms: u64,
+    timeout_ms: u64,
+) -> Vec<RampStep> {
+    // Build doubling ramp: 1, 2, 4, … up to max_concurrency.
+    let mut levels = Vec::new();
+    let mut c = 1usize;
+    loop {
+        levels.push(c);
+        if c >= max_concurrency {
+            break;
+        }
+        c = (c * 2).min(max_concurrency);
+    }
+
+    let mut steps = Vec::new();
+    for &concurrency in &levels {
+        let result = query_phase(
+            client.clone(),
+            host.clone(),
+            collection.clone(),
+            dim,
+            queries_per_step,
+            k,
+            concurrency,
+            timeout_ms,
+        )
+        .await;
+
+        let is_breaking_point =
+            result.error_rate() > error_threshold || !result.meets_p99_slo(p99_slo_ms);
+
+        steps.push(RampStep {
+            concurrency,
+            result,
+            is_breaking_point,
+        });
+
+        if is_breaking_point {
+            break;
+        }
+    }
+    steps
+}
+
+// ─── Stress phase: Spike ──────────────────────────────────────────────────────
+//
+// Models a sudden traffic surge: warm-up at base load, spike to spike_factor×
+// concurrency with proportionally more queries, then recover to base load.
+// Measures the degradation ratio and whether the system recovers cleanly.
+
+struct SpikeResult {
+    warmup: PhaseResult,
+    spike: PhaseResult,
+    recovery: PhaseResult,
+}
+
+async fn spike_phase(
+    client: Client,
+    host: String,
+    collection: String,
+    dim: usize,
+    k: usize,
+    base_concurrency: usize,
+    spike_factor: usize,
+    queries: usize,
+    timeout_ms: u64,
+) -> SpikeResult {
+    let spike_concurrency = (base_concurrency * spike_factor).max(base_concurrency + 1);
+    let spike_queries = queries * spike_factor;
+
+    let warmup = query_phase(
+        client.clone(),
+        host.clone(),
+        collection.clone(),
+        dim,
+        queries,
+        k,
+        base_concurrency,
+        timeout_ms,
+    )
+    .await;
+
+    let spike = query_phase(
+        client.clone(),
+        host.clone(),
+        collection.clone(),
+        dim,
+        spike_queries,
+        k,
+        spike_concurrency,
+        timeout_ms,
+    )
+    .await;
+
+    let recovery = query_phase(
+        client.clone(),
+        host.clone(),
+        collection.clone(),
+        dim,
+        queries,
+        k,
+        base_concurrency,
+        timeout_ms,
+    )
+    .await;
+
+    SpikeResult {
+        warmup,
+        spike,
+        recovery,
+    }
+}
+
+// ─── Stress phase: Soak ───────────────────────────────────────────────────────
+//
+// Runs sustained load for `total_duration`, split into `n_windows` equal windows.
+// Windowed reporting reveals latency drift (memory leaks, GC pressure, lock contention).
+// Within each window, workers loop continuously until the window deadline.
+
+async fn soak_window(
+    client: Client,
+    host: String,
+    collection: String,
+    dim: usize,
+    k: usize,
+    concurrency: usize,
+    window_dur: Duration,
+    seed_base: u64,
+    timeout_ms: u64,
+) -> PhaseResult {
+    let deadline = Instant::now() + window_dur;
+    let wall = Instant::now();
+    let mut set: JoinSet<WorkerStats> = JoinSet::new();
+
+    for w in 0..concurrency {
+        let c = client.clone();
+        let h = host.clone();
+        let col = collection.clone();
+        // Spread seeds across workers so they don't repeat the same query vectors.
+        let mut seed = seed_base + w as u64 * 100_000;
+        set.spawn(async move {
+            let mut lats = Vec::new();
+            let mut errors = 0u64;
+            let mut tos = 0u64;
+            loop {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                let vec = make_query(seed, dim);
+                seed = seed.wrapping_add(1);
+                let req = c
+                    .post(format!("{h}/collections/{col}/query"))
+                    .json(&json!({"vector": vec, "k": k}));
+                match send_timed(req, timeout_ms).await {
+                    Outcome::Success(us) => lats.push(us),
+                    Outcome::HttpError(_) | Outcome::NetworkError => errors += 1,
+                    Outcome::Timeout => tos += 1,
+                }
+            }
+            (lats, errors, tos)
+        });
+    }
+
+    let mut collected = Vec::new();
+    while let Some(Ok(stats)) = set.join_next().await {
+        collected.push(stats);
+    }
+    let (lats, errs, tos) = merge_workers(collected);
+    PhaseResult::new(lats, errs, tos, wall.elapsed())
+}
+
+async fn soak_phase(
+    client: Client,
+    host: String,
+    collection: String,
+    dim: usize,
+    k: usize,
+    concurrency: usize,
+    total_duration: Duration,
+    n_windows: usize,
+    timeout_ms: u64,
+) -> Vec<PhaseResult> {
+    let window_dur = total_duration / n_windows as u32;
+    let mut results = Vec::with_capacity(n_windows);
+    for w in 0..n_windows {
+        let seed_base = w as u64 * 10_000_000;
+        let r = soak_window(
+            client.clone(),
+            host.clone(),
+            collection.clone(),
+            dim,
+            k,
+            concurrency,
+            window_dur,
+            seed_base,
+            timeout_ms,
+        )
+        .await;
+        results.push(r);
+    }
+    results
+}
+
+// ─── Stress phase: Chaos ──────────────────────────────────────────────────────
+//
+// Fires a mix of five operation types at full concurrency:
+//   0 — valid query (expect 200)
+//   1 — valid insert with fresh IDs (expect 204)
+//   2 — query against a nonexistent collection (expect 404)
+//   3 — insert with wrong vector dimension (expect 400)
+//   4 — GET a nonexistent vector ID (expect 404)
+//
+// Unexpected errors: any 5xx from op 0/1, or network failures from any op.
+// Expected errors: 4xx from op 2/3/4 (correct error handling, not a fault).
+// After the chaos, a health check confirms the server survived.
+
+struct ChaosResult {
+    total: u64,
+    valid_successes: u64,
+    expected_errors: u64,
+    unexpected_errors: u64,
+    timeouts: u64,
+    server_healthy: bool,
+}
+
+async fn chaos_phase(
+    client: Client,
+    host: String,
+    collection: String,
+    dim: usize,
+    n_ops: usize,
+    concurrency: usize,
+    timeout_ms: u64,
+) -> ChaosResult {
+    struct WorkerResult {
+        valid_ok: u64,
+        expected_err: u64,
+        unexpected_err: u64,
+        timeouts: u64,
+    }
+
+    let per = n_ops.div_ceil(concurrency);
+    let mut set: JoinSet<WorkerResult> = JoinSet::new();
+
+    for w in 0..concurrency {
+        let base = w * per;
+        let count = per.min(n_ops.saturating_sub(base));
+        if count == 0 {
+            break;
+        }
+        let c = client.clone();
+        let h = host.clone();
+        let col = collection.clone();
+        set.spawn(async move {
+            let mut wr = WorkerResult {
+                valid_ok: 0,
+                expected_err: 0,
+                unexpected_err: 0,
+                timeouts: 0,
+            };
+            for i in 0..count {
+                let id = (base + i) as u64;
+                let op = id % 5;
+
+                let outcome = match op {
+                    0 => {
+                        // Valid query against the populated collection.
+                        let vec = make_query(id, dim);
+                        send_timed(
+                            c.post(format!("{h}/collections/{col}/query"))
+                                .json(&json!({"vector": vec, "k": 5})),
+                            timeout_ms,
+                        )
+                        .await
+                    }
+                    1 => {
+                        // Valid insert using IDs well above the pre-seeded range.
+                        let vec = make_vec(id + 10_000_000, dim);
+                        send_timed(
+                            c.post(format!("{h}/collections/{col}/vectors"))
+                                .json(&json!({"id": id + 10_000_000, "vector": vec})),
+                            timeout_ms,
+                        )
+                        .await
+                    }
+                    2 => {
+                        // Query a collection that does not exist (expect 404).
+                        let vec = make_query(id, dim);
+                        send_timed(
+                            c.post(format!("{h}/collections/ghost_chaos_{id}/query"))
+                                .json(&json!({"vector": vec, "k": 5})),
+                            timeout_ms,
+                        )
+                        .await
+                    }
+                    3 => {
+                        // Insert with one extra dimension — server must reject with 400.
+                        let wrong: Vec<f32> = vec![0.5_f32; dim + 1];
+                        send_timed(
+                            c.post(format!("{h}/collections/{col}/vectors"))
+                                .json(&json!({"id": id + 20_000_000, "vector": wrong})),
+                            timeout_ms,
+                        )
+                        .await
+                    }
+                    _ => {
+                        // Fetch a vector ID that was never inserted (expect 404).
+                        send_timed(
+                            c.get(format!(
+                                "{h}/collections/{col}/vectors/{}",
+                                id + 9_000_000
+                            )),
+                            timeout_ms,
+                        )
+                        .await
+                    }
+                };
+
+                match (op, outcome) {
+                    // Valid ops succeeded as expected.
+                    (0 | 1, Outcome::Success(_)) => wr.valid_ok += 1,
+                    // Invalid ops got the expected 4xx rejection.
+                    (2 | 3 | 4, Outcome::HttpError(s)) if s >= 400 && s < 500 => {
+                        wr.expected_err += 1
+                    }
+                    // Timeouts — server may be overloaded but not crashed.
+                    (_, Outcome::Timeout) => wr.timeouts += 1,
+                    // Anything else: unexpected 5xx, network error, or wrong status.
+                    _ => wr.unexpected_err += 1,
+                }
+            }
+            wr
+        });
+    }
+
+    let mut valid_successes = 0u64;
+    let mut expected_errors = 0u64;
+    let mut unexpected_errors = 0u64;
+    let mut timeouts = 0u64;
+    while let Some(Ok(wr)) = set.join_next().await {
+        valid_successes += wr.valid_ok;
+        expected_errors += wr.expected_err;
+        unexpected_errors += wr.unexpected_err;
+        timeouts += wr.timeouts;
+    }
+
+    let server_healthy = health_check(&client, &host).await.is_ok();
+
+    ChaosResult {
+        total: n_ops as u64,
+        valid_successes,
+        expected_errors,
+        unexpected_errors,
+        timeouts,
+        server_healthy,
+    }
 }
 
 // ─── Display helpers ──────────────────────────────────────────────────────────
@@ -381,18 +887,74 @@ fn fmt_tput(tput: f64) -> String {
     }
 }
 
-fn print_row(label: &str, tag: &str, t: &Timing) {
+fn separator() {
+    println!("  {}", "─".repeat(76));
+}
+
+fn print_baseline_row(label: &str, tag: &str, r: &PhaseResult) {
     println!(
-        "  [{label:6}] {tag:<10}  tput={:>8}  p50={:>8}  p95={:>8}  p99={:>8}",
-        fmt_tput(t.throughput()),
-        fmt_us(t.percentile(50)),
-        fmt_us(t.percentile(95)),
-        fmt_us(t.percentile(99)),
+        "  [{label:6}] {tag:<10}  tput={:>8}  p50={:>8}  p95={:>8}  p99={:>8}  err={:.1}%",
+        fmt_tput(r.throughput()),
+        fmt_us(r.percentile(50)),
+        fmt_us(r.percentile(95)),
+        fmt_us(r.percentile(99)),
+        r.error_rate(),
     );
 }
 
-fn separator() {
-    println!("  {}", "─".repeat(72));
+fn slo_mark(passes: bool) -> &'static str {
+    if passes {
+        "PASS"
+    } else {
+        "FAIL"
+    }
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+fn print_baseline_summary(results: &[(&str, PhaseResult, PhaseResult)], args: &Args) {
+    println!(
+        "  ══════════════════════════════════════════════════════════════════════════════"
+    );
+    println!(
+        "  BASELINE SUMMARY  dim={}  vectors={}  queries={}  concurrency={}",
+        args.dim, args.vectors, args.queries, args.concurrency
+    );
+    println!(
+        "  {:<10}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5}    {:>9}  {:>8}  {:>8}  {:>8}  {:>5}",
+        "index",
+        "ins/s",
+        "p50",
+        "p95",
+        "p99",
+        "err%",
+        "qry/s",
+        "p50",
+        "p95",
+        "p99",
+        "err%"
+    );
+    println!("  {}", "─".repeat(78));
+    for (tag, ins, qry) in results {
+        println!(
+            "  {:<10}  {:>9}  {:>8}  {:>8}  {:>8}  {:>4.1}%    {:>9}  {:>8}  {:>8}  {:>8}  {:>4.1}%",
+            tag,
+            fmt_tput(ins.throughput()),
+            fmt_us(ins.percentile(50)),
+            fmt_us(ins.percentile(95)),
+            fmt_us(ins.percentile(99)),
+            ins.error_rate(),
+            fmt_tput(qry.throughput()),
+            fmt_us(qry.percentile(50)),
+            fmt_us(qry.percentile(95)),
+            fmt_us(qry.percentile(99)),
+            qry.error_rate(),
+        );
+    }
+    println!(
+        "  ══════════════════════════════════════════════════════════════════════════════"
+    );
+    println!();
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -403,18 +965,22 @@ async fn main() {
     let client = Client::new();
 
     println!();
-    println!("  ╔══════════════════════════════════════════════════════════════╗");
-    println!("  ║              LikhaDB Stress Test                            ║");
-    println!("  ╚══════════════════════════════════════════════════════════════╝");
+    println!("  ╔══════════════════════════════════════════════════════════════════════╗");
+    println!("  ║         LikhaDB Stress Test  —  Breaking-Point Analysis            ║");
+    println!("  ╚══════════════════════════════════════════════════════════════════════╝");
     println!();
-    println!("  host={}", args.host);
     println!(
-        "  dim={dim}  vectors={v}  queries={q}  concurrency={c}  k={k}",
-        dim = args.dim,
-        v = args.vectors,
-        q = args.queries,
-        c = args.concurrency,
-        k = args.k
+        "  host={}  dim={}  vectors={}  queries={}  concurrency={}  k={}",
+        args.host, args.dim, args.vectors, args.queries, args.concurrency, args.k
+    );
+    println!(
+        "  timeout={}ms  error_threshold={:.0}%  p99_slo={}ms  spike={}×  soak={}s  chaos_ops={}",
+        args.timeout_ms,
+        args.error_threshold,
+        args.p99_slo_ms,
+        args.spike_factor,
+        args.soak_secs,
+        args.chaos_ops,
     );
     println!();
 
@@ -430,208 +996,478 @@ async fn main() {
     }
     println!();
 
-    // ── Index phases ──────────────────────────────────────────────────────────
+    let mut all_collections: Vec<String> = Vec::new();
+    let mut baseline_results: Vec<(&str, PhaseResult, PhaseResult)> = Vec::new();
 
-    struct Config {
-        tag: &'static str,
-        index: Option<Value>,
-    }
+    // ── Phase 1: Baseline ─────────────────────────────────────────────────────
+    if !args.skip_baseline {
+        struct Config {
+            tag: &'static str,
+            index: Option<Value>,
+        }
 
-    let configs = [
-        Config {
-            tag: "flat",
-            index: None, // uses server default (brute-force SIMD)
-        },
-        Config {
-            tag: "ivf",
-            // Auto-trains after nlist=100 inserts; nprobe=10 searches 10% of clusters.
-            index: Some(json!({"type": "ivf", "nlist": 100, "nprobe": 10})),
-        },
-        Config {
-            tag: "hnsw",
-            // m=16 balances graph fan-out vs. memory; ef_search=50 for good recall.
-            index: Some(json!({"type": "hnsw", "m": 16, "ef_construction": 200, "ef_search": 50})),
-        },
-    ];
+        let configs = [
+            Config {
+                tag: "flat",
+                index: None,
+            },
+            Config {
+                tag: "ivf",
+                index: Some(json!({"type": "ivf", "nlist": 100, "nprobe": 10})),
+            },
+            Config {
+                tag: "hnsw",
+                index: Some(
+                    json!({"type": "hnsw", "m": 16, "ef_construction": 200, "ef_search": 50}),
+                ),
+            },
+        ];
 
-    let mut results: Vec<(&str, Timing, Timing)> = Vec::new();
+        for cfg in &configs {
+            let name = format!("stress_{}", cfg.tag);
+            println!(
+                "  ── BASELINE: {} index  ({})",
+                cfg.tag.to_uppercase(),
+                name
+            );
+            separator();
 
-    for cfg in &configs {
-        let name = format!("stress_{}", cfg.tag);
-        println!("  ── {} index ({name})", cfg.tag.to_uppercase());
-        separator();
+            drop_collection(&client, &args.host, &name).await;
+            all_collections.push(name.clone());
 
-        // Idempotent: delete any leftover collection from a previous run.
-        drop_collection(&client, &args.host, &name).await;
+            print!("  Creating collection... ");
+            match create_collection(
+                &client,
+                &args.host,
+                &name,
+                args.dim,
+                cfg.index.clone(),
+                false,
+            )
+            .await
+            {
+                Ok(()) => println!("OK"),
+                Err(e) => {
+                    eprintln!("FAILED: {e}");
+                    continue;
+                }
+            }
 
-        print!("  Creating collection... ");
-        match create_collection(
-            &client,
-            &args.host,
-            &name,
-            args.dim,
-            cfg.index.clone(),
-            false,
-        )
-        .await
+            print!(
+                "  Inserting {} vectors ({} workers)... ",
+                args.vectors, args.concurrency
+            );
+            let ins = insert_phase(
+                client.clone(),
+                args.host.clone(),
+                name.clone(),
+                args.dim,
+                args.vectors,
+                args.concurrency,
+                args.timeout_ms,
+            )
+            .await;
+            println!("done ({:.2?})", ins.elapsed);
+            print_baseline_row("Insert", cfg.tag, &ins);
+
+            print!(
+                "\n  Querying (k={}, {} queries, {} workers)... ",
+                args.k, args.queries, args.concurrency
+            );
+            let qry = query_phase(
+                client.clone(),
+                args.host.clone(),
+                name.clone(),
+                args.dim,
+                args.queries,
+                args.k,
+                args.concurrency,
+                args.timeout_ms,
+            )
+            .await;
+            println!("done ({:.2?})", qry.elapsed);
+            print_baseline_row("Query", cfg.tag, &qry);
+            println!();
+
+            baseline_results.push((cfg.tag, ins, qry));
+        }
+
+        // Hybrid sub-phase
         {
-            Ok(()) => println!("OK"),
-            Err(e) => {
-                eprintln!("FAILED: {e}");
-                continue;
+            let n_hybrid = (args.vectors / 10).max(500);
+            let q_hybrid = (args.queries / 5).max(50);
+            let name = "stress_hybrid";
+
+            println!("  ── BASELINE: HYBRID (flat + BM25, RRF)");
+            separator();
+
+            drop_collection(&client, &args.host, name).await;
+
+            print!("  Creating collection (enable_fts=true)... ");
+            match create_collection(&client, &args.host, name, args.dim, None, true).await {
+                Ok(()) => {
+                    println!("OK");
+                    all_collections.push(name.to_string());
+
+                    print!(
+                        "  Inserting {} vectors with text payloads ({} workers)... ",
+                        n_hybrid, args.concurrency
+                    );
+                    let ins = insert_hybrid_phase(
+                        client.clone(),
+                        args.host.clone(),
+                        name.to_string(),
+                        args.dim,
+                        n_hybrid,
+                        args.concurrency,
+                        args.timeout_ms,
+                    )
+                    .await;
+                    println!("done ({:.2?})", ins.elapsed);
+                    print_baseline_row("Insert", "hybrid", &ins);
+
+                    print!(
+                        "\n  Hybrid queries (k={}, {} queries, {} workers)... ",
+                        args.k, q_hybrid, args.concurrency
+                    );
+                    let qry = hybrid_query_phase(
+                        client.clone(),
+                        args.host.clone(),
+                        name.to_string(),
+                        args.dim,
+                        q_hybrid,
+                        args.k,
+                        args.concurrency,
+                        args.timeout_ms,
+                    )
+                    .await;
+                    println!("done ({:.2?})", qry.elapsed);
+                    print_baseline_row("Hybrid", "hybrid", &qry);
+                    println!();
+
+                    baseline_results.push(("hybrid", ins, qry));
+                }
+                Err(e) => {
+                    eprintln!("FAILED: {e}");
+                    eprintln!(
+                        "  (Compiled without fts feature? Skipping hybrid sub-phase.)"
+                    );
+                    println!();
+                }
             }
         }
 
-        // Insert
-        print!(
-            "  Inserting {} vectors ({} workers)... ",
-            args.vectors, args.concurrency
-        );
-        let ins = insert_phase(
-            client.clone(),
-            args.host.clone(),
-            name.clone(),
-            args.dim,
-            args.vectors,
-            args.concurrency,
-        )
-        .await;
-        println!("done ({:.2?})", ins.elapsed);
-        print_row("Insert", cfg.tag, &ins);
-
-        // Query
-        print!(
-            "\n  Querying (k={}, {} queries, {} workers)... ",
-            args.k, args.queries, args.concurrency
-        );
-        let qry = query_phase(
-            client.clone(),
-            args.host.clone(),
-            name.clone(),
-            args.dim,
-            args.queries,
-            args.k,
-            args.concurrency,
-        )
-        .await;
-        println!("done ({:.2?})", qry.elapsed);
-        print_row("Query", cfg.tag, &qry);
-
-        println!();
-        results.push((cfg.tag, ins, qry));
+        print_baseline_summary(&baseline_results, &args);
     }
 
-    // ── Hybrid phase ──────────────────────────────────────────────────────────
+    // ── Stress collection setup ───────────────────────────────────────────────
+    // A flat collection pre-seeded with `vectors` entries is shared across
+    // ramp, spike, soak, and chaos phases so each phase begins with a warm index.
 
-    {
-        // Smaller dataset so FTS indexing doesn't dominate demo time.
-        let n_hybrid = (args.vectors / 10).max(500);
-        let q_hybrid = (args.queries / 5).max(50);
-        let name = "stress_hybrid";
+    let any_stress =
+        !args.skip_ramp || !args.skip_spike || !args.skip_soak || !args.skip_chaos;
 
-        println!("  ── HYBRID (flat + BM25, RRF fusion)");
+    let stress_col = "stress_main".to_string();
+
+    if any_stress {
+        println!("  ── STRESS COLLECTION SETUP");
         separator();
+        drop_collection(&client, &args.host, &stress_col).await;
+        all_collections.push(stress_col.clone());
 
-        drop_collection(&client, &args.host, name).await;
-
-        print!("  Creating collection (enable_fts=true)... ");
-        match create_collection(
-            &client, &args.host, name, args.dim, None, // flat index under the hood
-            true,
-        )
-        .await
-        {
+        print!("  Creating stress_main (flat)... ");
+        match create_collection(&client, &args.host, &stress_col, args.dim, None, false).await {
             Ok(()) => println!("OK"),
             Err(e) => {
-                eprintln!("FAILED: {e}");
-                eprintln!("  (Compiled without fts feature? Skipping hybrid phase.)");
-                goto_summary(&results, &args);
+                eprintln!("FAILED: {e}  — aborting stress phases.");
+                finalize(&args, &all_collections, &client).await;
                 return;
             }
         }
 
         print!(
-            "  Inserting {} vectors with text payloads ({} workers)... ",
-            n_hybrid, args.concurrency
+            "  Seeding {} vectors ({} workers)... ",
+            args.vectors, args.concurrency
         );
-        let ins = insert_hybrid_phase(
+        let seed_result = insert_phase(
             client.clone(),
             args.host.clone(),
-            name.to_string(),
+            stress_col.clone(),
             args.dim,
-            n_hybrid,
+            args.vectors,
             args.concurrency,
+            args.timeout_ms,
         )
         .await;
-        println!("done ({:.2?})", ins.elapsed);
-        print_row("Insert", "hybrid", &ins);
-
-        print!(
-            "\n  Running {} hybrid queries (k={}, {} workers)... ",
-            q_hybrid, args.k, args.concurrency
+        println!(
+            "done ({:.2?})  err={:.1}%",
+            seed_result.elapsed,
+            seed_result.error_rate()
         );
-        let qry = hybrid_query_phase(
-            client.clone(),
-            args.host.clone(),
-            name.to_string(),
-            args.dim,
-            q_hybrid,
-            args.k,
-            args.concurrency,
-        )
-        .await;
-        println!("done ({:.2?})", qry.elapsed);
-        print_row("Hybrid", "hybrid", &qry);
         println!();
-
-        results.push(("hybrid", ins, qry));
     }
 
-    goto_summary(&results, &args);
+    // ── Phase 2: Ramp ─────────────────────────────────────────────────────────
+    if !args.skip_ramp {
+        println!("  ── PHASE 2: RAMP  (concurrency doubles until breaking point)");
+        separator();
+        println!(
+            "  {:<14}  {:>9}  {:>8}  {:>8}  {:>8}  {:>6}  {:>5}",
+            "concurrency", "tput", "p50", "p95", "p99", "err%", "p99 SLO"
+        );
+        println!("  {}", "─".repeat(68));
 
-    // ── Cleanup ───────────────────────────────────────────────────────────────
+        let queries_per_step = args.queries.max(100);
+        let steps = ramp_phase(
+            client.clone(),
+            args.host.clone(),
+            stress_col.clone(),
+            args.dim,
+            args.k,
+            queries_per_step,
+            args.max_concurrency,
+            args.error_threshold,
+            args.p99_slo_ms,
+            args.timeout_ms,
+        )
+        .await;
+
+        let mut breaking_concurrency: Option<usize> = None;
+        for step in &steps {
+            let slo = if step.result.meets_p99_slo(args.p99_slo_ms) {
+                "✓"
+            } else {
+                "✗ BREAK"
+            };
+            let err_marker = if step.result.error_rate() > args.error_threshold {
+                " ← err"
+            } else {
+                ""
+            };
+            println!(
+                "  {:<14}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5.1}%  {}{} ",
+                step.concurrency,
+                fmt_tput(step.result.throughput()),
+                fmt_us(step.result.percentile(50)),
+                fmt_us(step.result.percentile(95)),
+                fmt_us(step.result.percentile(99)),
+                step.result.error_rate(),
+                slo,
+                err_marker,
+            );
+            if step.is_breaking_point {
+                breaking_concurrency = Some(step.concurrency);
+            }
+        }
+
+        println!();
+        match breaking_concurrency {
+            Some(bp) => println!(
+                "  ⚠ Breaking point at concurrency={bp}  \
+                 (err>{:.0}% or p99>{}ms)",
+                args.error_threshold, args.p99_slo_ms
+            ),
+            None => println!(
+                "  ✓ No breaking point found up to concurrency={}",
+                args.max_concurrency
+            ),
+        }
+        println!();
+    }
+
+    // ── Phase 3: Spike ────────────────────────────────────────────────────────
+    if !args.skip_spike {
+        let spike_concurrency = args.concurrency * args.spike_factor;
+        println!(
+            "  ── PHASE 3: SPIKE  ({}→{}→{} workers)",
+            args.concurrency, spike_concurrency, args.concurrency
+        );
+        separator();
+
+        let sr = spike_phase(
+            client.clone(),
+            args.host.clone(),
+            stress_col.clone(),
+            args.dim,
+            args.k,
+            args.concurrency,
+            args.spike_factor,
+            args.queries,
+            args.timeout_ms,
+        )
+        .await;
+
+        let warmup_p99 = sr.warmup.percentile(99).max(1);
+        let spike_p99 = sr.spike.percentile(99);
+        let recovery_p99 = sr.recovery.percentile(99);
+        let degradation = spike_p99 as f64 / warmup_p99 as f64;
+        let recovered =
+            recovery_p99 <= (warmup_p99 as f64 * 1.5) as u64; // within 1.5× warm-up is "recovered"
+
+        println!(
+            "  {:<12}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5.1}%",
+            "phase", "tput", "p50", "p95", "p99", "err%"
+        );
+        println!("  {}", "─".repeat(60));
+        for (label, r) in [("warm-up", &sr.warmup), ("spike", &sr.spike), ("recovery", &sr.recovery)] {
+            println!(
+                "  {:<12}  {:>9}  {:>8}  {:>8}  {:>8}  {:>5.1}%",
+                label,
+                fmt_tput(r.throughput()),
+                fmt_us(r.percentile(50)),
+                fmt_us(r.percentile(95)),
+                fmt_us(r.percentile(99)),
+                r.error_rate(),
+            );
+        }
+        println!();
+        println!(
+            "  p99 degradation during spike: {:.1}×   recovery: {}",
+            degradation,
+            if recovered { "✓ clean" } else { "✗ still elevated" }
+        );
+        println!();
+    }
+
+    // ── Phase 4: Soak ─────────────────────────────────────────────────────────
+    if !args.skip_soak {
+        const N_WINDOWS: usize = 5;
+        println!(
+            "  ── PHASE 4: SOAK  ({}s sustained, {} windows, {} workers)",
+            args.soak_secs, N_WINDOWS, args.concurrency
+        );
+        separator();
+
+        let windows = soak_phase(
+            client.clone(),
+            args.host.clone(),
+            stress_col.clone(),
+            args.dim,
+            args.k,
+            args.concurrency,
+            Duration::from_secs(args.soak_secs),
+            N_WINDOWS,
+            args.timeout_ms,
+        )
+        .await;
+
+        println!(
+            "  {:<10}  {:>8}  {:>8}  {:>8}  {:>8}  {:>6}  {:>8}",
+            "window", "ops", "p50", "p95", "p99", "err%", "tput"
+        );
+        println!("  {}", "─".repeat(68));
+        for (i, w) in windows.iter().enumerate() {
+            println!(
+                "  {:<10}  {:>8}  {:>8}  {:>8}  {:>8}  {:>5.1}%  {:>8}",
+                format!("{}/{}", i + 1, N_WINDOWS),
+                w.success(),
+                fmt_us(w.percentile(50)),
+                fmt_us(w.percentile(95)),
+                fmt_us(w.percentile(99)),
+                w.error_rate(),
+                fmt_tput(w.throughput()),
+            );
+        }
+
+        if windows.len() >= 2 {
+            let first_p95 = windows.first().map(|w| w.percentile(95)).unwrap_or(0).max(1);
+            let last_p95 = windows.last().map(|w| w.percentile(95)).unwrap_or(0);
+            let drift_pct = (last_p95 as f64 - first_p95 as f64) / first_p95 as f64 * 100.0;
+            println!();
+            println!(
+                "  Latency drift (p95 first→last window): {}{:.1}%  {}",
+                if drift_pct >= 0.0 { "+" } else { "" },
+                drift_pct,
+                if drift_pct.abs() <= 20.0 {
+                    "✓ stable"
+                } else {
+                    "⚠ drifting"
+                }
+            );
+        }
+        println!();
+    }
+
+    // ── Phase 5: Chaos ────────────────────────────────────────────────────────
+    if !args.skip_chaos {
+        let chaos_concurrency = (args.concurrency * 2).max(4);
+        println!(
+            "  ── PHASE 5: CHAOS  ({} ops, {} workers, mixed valid/invalid)",
+            args.chaos_ops, chaos_concurrency
+        );
+        separator();
+        println!("  Op mix: valid-query (20%) · valid-insert (20%) · ghost-collection (20%)");
+        println!("          wrong-dimension (20%) · nonexistent-vector (20%)");
+        println!();
+
+        let cr = chaos_phase(
+            client.clone(),
+            args.host.clone(),
+            stress_col.clone(),
+            args.dim,
+            args.chaos_ops,
+            chaos_concurrency,
+            args.timeout_ms,
+        )
+        .await;
+
+        println!("  Results  ({} total ops):", cr.total);
+        println!("    valid successes  : {}", cr.valid_successes);
+        println!("    expected errors  : {} (correct 4xx from invalid ops)", cr.expected_errors);
+        println!("    timeouts         : {}", cr.timeouts);
+        println!(
+            "    unexpected errors: {}  {}",
+            cr.unexpected_errors,
+            if cr.unexpected_errors == 0 {
+                "✓"
+            } else {
+                "✗ (5xx or wrong status from valid ops)"
+            }
+        );
+        println!(
+            "    server health    : {}",
+            if cr.server_healthy { "OK ✓" } else { "FAILED ✗" }
+        );
+        println!();
+    }
+
+    // ── Final SLO verdict ─────────────────────────────────────────────────────
+    println!(
+        "  ══════════════════════════════════════════════════════════════════════════════"
+    );
+    println!("  SLO VERDICT  (p99 threshold = {}ms)", args.p99_slo_ms);
+    println!("  {}", "─".repeat(78));
+
+    if !baseline_results.is_empty() {
+        for (tag, _, qry) in &baseline_results {
+            println!(
+                "  baseline/{:<8}  p99={}  {}",
+                tag,
+                fmt_us(qry.percentile(99)),
+                slo_mark(qry.meets_p99_slo(args.p99_slo_ms))
+            );
+        }
+    }
+
+    println!(
+        "  ══════════════════════════════════════════════════════════════════════════════"
+    );
+    println!();
+
+    finalize(&args, &all_collections, &client).await;
+}
+
+async fn finalize(args: &Args, all_collections: &[String], client: &Client) {
     if !args.no_cleanup {
         print!("  Cleaning up test collections... ");
-        for (tag, _, _) in &results {
-            let name = if *tag == "hybrid" {
-                "stress_hybrid".to_string()
-            } else {
-                format!("stress_{tag}")
-            };
-            drop_collection(&client, &args.host, &name).await;
+        for name in all_collections {
+            drop_collection(client, &args.host, name).await;
         }
         println!("done");
     } else {
-        println!("  Collections retained (--no-cleanup). Inspect via GET /collections.");
-    }
-    println!();
-}
-
-fn goto_summary(results: &[(&str, Timing, Timing)], args: &Args) {
-    println!("  ══════════════════════════════════════════════════════════════════════════");
-    println!(
-        "  SUMMARY  dim={}  vectors={}  queries={}  concurrency={}",
-        args.dim, args.vectors, args.queries, args.concurrency
-    );
-    println!(
-        "  {:<10}  {:>9}  {:>8}  {:>8}  {:>8}    {:>9}  {:>8}  {:>8}  {:>8}",
-        "index", "ins/s", "p50", "p95", "p99", "qry/s", "p50", "p95", "p99"
-    );
-    println!("  {}", "─".repeat(74));
-    for (tag, ins, qry) in results {
         println!(
-            "  {:<10}  {:>9}  {:>8}  {:>8}  {:>8}    {:>9}  {:>8}  {:>8}  {:>8}",
-            tag,
-            fmt_tput(ins.throughput()),
-            fmt_us(ins.percentile(50)),
-            fmt_us(ins.percentile(95)),
-            fmt_us(ins.percentile(99)),
-            fmt_tput(qry.throughput()),
-            fmt_us(qry.percentile(50)),
-            fmt_us(qry.percentile(95)),
-            fmt_us(qry.percentile(99)),
+            "  Collections retained (--no-cleanup). Inspect via GET /collections."
         );
     }
-    println!("  ══════════════════════════════════════════════════════════════════════════");
     println!();
 }


### PR DESCRIPTION
## Summary

- **enrich.rs** (Stage 3): 5-table JOIN (`embeddings → documents → authors → classifications → access_control`) with ACL enforcement in the SQL `WHERE` clause; team name sanitisation prevents SQL injection
- **fusion.rs** (Stage 4a): multi-signal score fusion via DataFusion SQL window functions — min-max normalisation, exponential recency decay, configurable weighted sum, `LIMIT top-M`
- **rerank.rs** (Stage 4b/4c): `BiEncoderClient` / `CrossEncoderClient` trait abstraction + reqwest HTTP impls (`rerank` feature); materialize-then-call guarantees a **single batched model call** per stage, not per-row
- **pipeline.rs**: `Pipeline` orchestrator that chains all stages; converts `Vec<Candidate>` to Arrow `RecordBatch`; skips reranking when clients are not configured
- **Config**: `BiEncoderConfig` (`alpha ∈ (0,1)`, `top_p`) and `CrossEncoderConfig` (`top_k`) with startup validation
- **Server** (`tier-q` feature): `AppState::with_pipeline()` setter; `query_vectors` and `hybrid_query_vectors` return `RankedQueryResponse` when a pipeline is attached, `QueryResponse` otherwise (backward-compatible)

## Test plan

- [ ] `cargo test -p likhadb-query --features datafusion` — 47 new tests across config, enrich, fusion, rerank, pipeline modules
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo build --workspace` — builds without `tier-q` (pipeline = None path); existing REST smoke test unchanged
- [ ] `cargo build -p likhadb-server --features tier-q` — builds with Tier Q wired into axum handlers
- [ ] ACL filter: candidate with `sensitivity_label = 'restricted'` must be absent from enrichment output
- [ ] Score bounds: all `fusion_score` values in `[0.0, 1.0]`
- [ ] Single batch: mock call counter asserts `call_count == 1` after bi-encoder and cross-encoder stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)