### PR TITLE
refactor(server): rename feature flag tier-q → enriched-search

### DIFF
--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 # Enables Tier Q: DataFusion enrichment, score fusion, and model-based reranking.
-tier-q = ["dep:likhadb-query"]
+enriched-search = ["dep:likhadb-query"]
 
 [dependencies]
 likhadb-query = { path = "../likhadb-query", features = ["datafusion"], optional = true }

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 
 use likhadb_lakehouse::LakehouseExt;
 
-#[cfg(feature = "tier-q")]
+#[cfg(feature = "enriched-search")]
 use crate::types::RankedQueryResponse;
 use crate::{
     error::ApiError,
@@ -23,7 +23,7 @@ use crate::{
         IndexConfig, InsertRequest, QueryRequest, QueryResponse, VectorResponse,
     },
 };
-#[cfg(feature = "tier-q")]
+#[cfg(feature = "enriched-search")]
 use likhadb_query::pipeline::{Candidate, PipelineRequest};
 
 pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
@@ -218,7 +218,7 @@ async fn query_vectors(
     )
     .record(start.elapsed().as_secs_f64());
 
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     if let Some(pipeline) = &state.pipeline {
         let candidates: Vec<Candidate> = results
             .iter()
@@ -272,7 +272,7 @@ async fn hybrid_query_vectors(
     )
     .record(start.elapsed().as_secs_f64());
 
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     if let Some(pipeline) = &state.pipeline {
         let candidates: Vec<Candidate> = results
             .iter()

--- a/crates/likhadb-server/src/state.rs
+++ b/crates/likhadb-server/src/state.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 #[derive(Clone)]
 pub struct AppState {
     inner: Arc<RwLock<WalManager>>,
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     pub pipeline: Option<Arc<likhadb_query::pipeline::Pipeline>>,
 }
 
@@ -30,13 +30,13 @@ impl AppState {
     pub fn new(wal: WalManager) -> Self {
         Self {
             inner: Arc::new(RwLock::new(wal)),
-            #[cfg(feature = "tier-q")]
+            #[cfg(feature = "enriched-search")]
             pipeline: None,
         }
     }
 
-    /// Attach a Tier Q pipeline. Only available when the `tier-q` feature is enabled.
-    #[cfg(feature = "tier-q")]
+    /// Attach a Tier Q pipeline. Only available when the `enriched-search` feature is enabled.
+    #[cfg(feature = "enriched-search")]
     pub fn with_pipeline(mut self, pipeline: Arc<likhadb_query::pipeline::Pipeline>) -> Self {
         self.pipeline = Some(pipeline);
         self

--- a/crates/likhadb-server/src/types.rs
+++ b/crates/likhadb-server/src/types.rs
@@ -73,11 +73,11 @@ pub struct QueryRequest {
     #[serde(default)]
     pub include_payload: bool,
     /// Team identifiers for Tier Q ACL enforcement.
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     #[serde(default)]
     pub allowed_teams: Vec<String>,
     /// Query text for Tier Q bi-encoder / cross-encoder reranking.
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     #[serde(default)]
     pub query_text: Option<String>,
 }
@@ -100,7 +100,7 @@ pub struct HybridQueryRequest {
     #[serde(default)]
     pub include_payload: bool,
     /// Team identifiers for Tier Q ACL enforcement.
-    #[cfg(feature = "tier-q")]
+    #[cfg(feature = "enriched-search")]
     #[serde(default)]
     pub allowed_teams: Vec<String>,
 }
@@ -116,7 +116,7 @@ pub struct HybridQueryResponse {
 
 // ── Tier Q ranked response ────────────────────────────────────────────────────
 
-#[cfg(feature = "tier-q")]
+#[cfg(feature = "enriched-search")]
 #[derive(Serialize)]
 pub struct RankedQueryResponse {
     pub results: Vec<likhadb_query::pipeline::PipelineResult>,


### PR DESCRIPTION
## Summary

- `tier-q` is an internal architecture label that means nothing to someone reading `Cargo.toml` or a build command
- `enriched-search` describes what the feature actually delivers: query responses enriched with metadata joins, ACL filtering, multi-signal score fusion, and optional reranking

## Changes

Rename the `likhadb-server` feature flag and all associated `#[cfg(feature = ...)]` attributes across `Cargo.toml`, `state.rs`, `routes.rs`, and `types.rs`.

## Test plan

- [ ] `cargo build --workspace` — no `tier-q` references remain (`rg "tier-q"` returns nothing)
- [ ] `cargo build -p likhadb-server --features enriched-search` — compiles with pipeline wired in

🤖 Generated with [Claude Code](https://claude.com/claude-code)