### PR TITLE
feat(sdk/python): sync with enriched-search server changes

### DIFF
--- a/sdk/python/likhadb/__init__.py
+++ b/sdk/python/likhadb/__init__.py
@@ -16,6 +16,7 @@ from .models import (
     HnswIndex,
     IvfIndex,
     IvfSq8Index,
+    PipelineResult,
     ScoredResult,
     VectorRecord,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "AsyncCollection",
     # Response models
     "CollectionInfo",
+    "PipelineResult",
     "ScoredResult",
     "VectorRecord",
     # Index config models

--- a/sdk/python/likhadb/collection.py
+++ b/sdk/python/likhadb/collection.py
@@ -11,10 +11,19 @@ from .models import (
     HybridQueryRequest,
     ImportParquetRequest,
     InsertRequest,
+    PipelineResult,
     QueryRequest,
     ScoredResult,
     VectorRecord,
 )
+
+SearchResult = ScoredResult | PipelineResult
+
+
+def _parse_search_results(items: list) -> list[SearchResult]:
+    if items and "fusion_score" in items[0]:
+        return [PipelineResult.model_validate(item) for item in items]
+    return [ScoredResult.model_validate(item) for item in items]
 
 
 class Collection:
@@ -61,14 +70,27 @@ class Collection:
         k: int,
         filter: Any | None = None,
         include_payload: bool = False,
-    ) -> list[ScoredResult]:
-        """k-nearest-neighbour search with optional metadata filter."""
-        req = QueryRequest(vector=vector, k=k, filter=filter, include_payload=include_payload)
+        allowed_teams: list[str] | None = None,
+        query_text: str | None = None,
+    ) -> list[SearchResult]:
+        """k-nearest-neighbour search with optional metadata filter.
+
+        When the server runs with the enriched-search pipeline, returns
+        ``list[PipelineResult]``; otherwise returns ``list[ScoredResult]``.
+        """
+        req = QueryRequest(
+            vector=vector,
+            k=k,
+            filter=filter,
+            include_payload=include_payload,
+            allowed_teams=allowed_teams or [],
+            query_text=query_text,
+        )
         r = self._http.post(
             f"/collections/{self._name}/query",
             json=req.model_dump(exclude_none=True),
         )
-        return [ScoredResult.model_validate(item) for item in r.json()["results"]]
+        return _parse_search_results(r.json()["results"])
 
     def hybrid_search(
         self,
@@ -78,7 +100,8 @@ class Collection:
         rrf_k: int = 60,
         filter: Any | None = None,
         include_payload: bool = False,
-    ) -> list[ScoredResult]:
+        allowed_teams: list[str] | None = None,
+    ) -> list[SearchResult]:
         """Hybrid vector + BM25 search fused via Reciprocal Rank Fusion."""
         req = HybridQueryRequest(
             vector=vector,
@@ -87,12 +110,13 @@ class Collection:
             rrf_k=rrf_k,
             filter=filter,
             include_payload=include_payload,
+            allowed_teams=allowed_teams or [],
         )
         r = self._http.post(
             f"/collections/{self._name}/hybrid-query",
             json=req.model_dump(exclude_none=True),
         )
-        return [ScoredResult.model_validate(item) for item in r.json()["results"]]
+        return _parse_search_results(r.json()["results"])
 
     def import_parquet(
         self,
@@ -163,13 +187,22 @@ class AsyncCollection:
         k: int,
         filter: Any | None = None,
         include_payload: bool = False,
-    ) -> list[ScoredResult]:
-        req = QueryRequest(vector=vector, k=k, filter=filter, include_payload=include_payload)
+        allowed_teams: list[str] | None = None,
+        query_text: str | None = None,
+    ) -> list[SearchResult]:
+        req = QueryRequest(
+            vector=vector,
+            k=k,
+            filter=filter,
+            include_payload=include_payload,
+            allowed_teams=allowed_teams or [],
+            query_text=query_text,
+        )
         r = await self._http.post(
             f"/collections/{self._name}/query",
             json=req.model_dump(exclude_none=True),
         )
-        return [ScoredResult.model_validate(item) for item in r.json()["results"]]
+        return _parse_search_results(r.json()["results"])
 
     async def hybrid_search(
         self,
@@ -179,7 +212,8 @@ class AsyncCollection:
         rrf_k: int = 60,
         filter: Any | None = None,
         include_payload: bool = False,
-    ) -> list[ScoredResult]:
+        allowed_teams: list[str] | None = None,
+    ) -> list[SearchResult]:
         req = HybridQueryRequest(
             vector=vector,
             text=text,
@@ -187,12 +221,13 @@ class AsyncCollection:
             rrf_k=rrf_k,
             filter=filter,
             include_payload=include_payload,
+            allowed_teams=allowed_teams or [],
         )
         r = await self._http.post(
             f"/collections/{self._name}/hybrid-query",
             json=req.model_dump(exclude_none=True),
         )
-        return [ScoredResult.model_validate(item) for item in r.json()["results"]]
+        return _parse_search_results(r.json()["results"])
 
     async def import_parquet(
         self,

--- a/sdk/python/likhadb/collection.py
+++ b/sdk/python/likhadb/collection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Union
 
 from ._http import AsyncHttpClient, HttpClient
 from .models import (
@@ -17,7 +17,7 @@ from .models import (
     VectorRecord,
 )
 
-SearchResult = ScoredResult | PipelineResult
+SearchResult = Union[ScoredResult, PipelineResult]
 
 
 def _parse_search_results(items: list) -> list[SearchResult]:

--- a/sdk/python/likhadb/models.py
+++ b/sdk/python/likhadb/models.py
@@ -65,6 +65,8 @@ class QueryRequest(BaseModel):
     k: int
     filter: Optional[Any] = None
     include_payload: bool = False
+    allowed_teams: list[str] = Field(default_factory=list)
+    query_text: Optional[str] = None
 
 
 class HybridQueryRequest(BaseModel):
@@ -74,6 +76,7 @@ class HybridQueryRequest(BaseModel):
     rrf_k: int = 60
     filter: Optional[Any] = None
     include_payload: bool = False
+    allowed_teams: list[str] = Field(default_factory=list)
 
 
 class ImportParquetRequest(BaseModel):
@@ -96,6 +99,16 @@ class ScoredResult(BaseModel):
     id: VecId
     score: float
     payload: Optional[Payload] = None
+
+
+class PipelineResult(BaseModel):
+    """Returned by the enriched-search pipeline (server compiled with enriched-search feature)."""
+
+    id: str
+    fusion_score: float
+    bi_score: Optional[float] = None
+    cross_score: Optional[float] = None
+    chunk_text: Optional[str] = None
 
 
 class VectorRecord(BaseModel):


### PR DESCRIPTION
## Summary

- Add `PipelineResult` response model (`id`, `fusion_score`, `bi_score`, `cross_score`, `chunk_text`) to mirror the server's `RankedQueryResponse` shape from the enriched-search pipeline
- Add `allowed_teams: list[str]` and `query_text: Optional[str]` to `QueryRequest`; `allowed_teams` to `HybridQueryRequest` — these were added to `types.rs` behind the `enriched-search` feature flag in #80 but the SDK was never updated
- `search()` and `hybrid_search()` on both `Collection` and `AsyncCollection` now accept the new params and auto-detect which response shape the server returned (keyed on presence of `fusion_score`), returning `list[ScoredResult | PipelineResult]`
- `PipelineResult` exported from the top-level package

## Test plan

- [ ] All 37 existing SDK tests pass (`pytest sdk/python/tests/ -q`)
- [ ] Verify `search()` against a standard server still returns `list[ScoredResult]`
- [ ] Verify `search()` against a server compiled with `enriched-search` and a configured pipeline returns `list[PipelineResult]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)