### PR TITLE
harden: authenticate REST/gRPC, clamp scans, cap DoS surface, confine parquet paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy to .env and fill in real secrets. .env is gitignored.
+
+# Grafana admin password (replaces the old anonymous-Admin access).
+GRAFANA_ADMIN_PASSWORD=change-me
+
+# MinIO root credentials (replace the old minioadmin/minioadmin defaults).
+MINIO_ROOT_USER=change-me
+MINIO_ROOT_PASSWORD=change-me
+
+# Shared bearer token gating the REST + gRPC APIs.
+# Unset => server runs UNAUTHENTICATED (dev only; logs a warning).
+LIKHADB_API_TOKEN=change-me
+
+# Base directory that import/export-parquet paths are confined to.
+# Unset => parquet I/O endpoints are disabled (403).
+LIKHADB_PARQUET_ROOT=/data/parquet

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 Cargo.lock
+.env
 likhadb_tier1_prompt.md
 .DS_Store
 BIZ.md

--- a/compose.yml
+++ b/compose.yml
@@ -43,10 +43,10 @@ services:
   grafana:
     image: grafana/grafana:11.0.0
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env}"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
@@ -59,11 +59,11 @@ services:
     image: quay.io/minio/minio:latest
     command: server /data --console-address ":9001"
     ports:
-      - "9000:9000"   # S3 API
-      - "9001:9001"   # web console
+      - "127.0.0.1:9000:9000"   # S3 API
+      - "127.0.0.1:9001:9001"   # web console
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}"
     volumes:
       - minio-data:/data
     restart: unless-stopped
@@ -82,7 +82,7 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc alias set local http://minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD &&
         mc mb --ignore-existing local/likhadb
       "
     restart: "no"

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -31,7 +31,7 @@ metrics                      = "0.23"
 metrics-exporter-prometheus  = "0.15"
 tracing                      = "0.1"
 tracing-subscriber           = { version = "0.3", features = ["env-filter", "json"] }
-tower                        = { version = "0.5", features = ["util"] }
+tower                        = { version = "0.5", features = ["util", "limit"] }
 http                         = "1"
 
 [build-dependencies]

--- a/crates/likhadb-server/src/auth.rs
+++ b/crates/likhadb-server/src/auth.rs
@@ -17,11 +17,14 @@ use tonic::Status;
 pub struct ApiToken(Arc<Option<String>>);
 
 impl ApiToken {
+    /// Construct directly. `None` disables auth. Prefer [`ApiToken::from_env`]
+    /// in production; this is handy for tests and explicit wiring.
+    pub fn new(token: Option<String>) -> Self {
+        Self(Arc::new(token.filter(|s| !s.is_empty())))
+    }
+
     pub fn from_env() -> Self {
-        let tok = std::env::var("LIKHADB_API_TOKEN")
-            .ok()
-            .filter(|s| !s.is_empty());
-        Self(Arc::new(tok))
+        Self::new(std::env::var("LIKHADB_API_TOKEN").ok())
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -113,14 +116,14 @@ mod tests {
 
     #[test]
     fn disabled_token_accepts_anything() {
-        let t = ApiToken(Arc::new(None));
+        let t = ApiToken::new(None);
         assert!(!t.is_enabled());
         assert!(t.verify("whatever"));
     }
 
     #[test]
     fn enabled_token_requires_exact_match() {
-        let t = ApiToken(Arc::new(Some("s3cr3t".to_string())));
+        let t = ApiToken::new(Some("s3cr3t".to_string()));
         assert!(t.is_enabled());
         assert!(t.verify("s3cr3t"));
         assert!(!t.verify("wrong"));

--- a/crates/likhadb-server/src/auth.rs
+++ b/crates/likhadb-server/src/auth.rs
@@ -74,6 +74,10 @@ pub async fn require_bearer(
 }
 
 /// gRPC interceptor. Gates every method on the service.
+//
+// tonic fixes the closure's return type as `Result<_, Status>`; Status is 176
+// bytes and cannot be boxed here, matching the allow in `grpc/service.rs`.
+#[allow(clippy::result_large_err)]
 pub fn grpc_interceptor(
     token: ApiToken,
 ) -> impl FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, Status> + Clone {

--- a/crates/likhadb-server/src/auth.rs
+++ b/crates/likhadb-server/src/auth.rs
@@ -128,4 +128,31 @@ mod tests {
         assert!(t.verify("s3cr3t"));
         assert!(!t.verify("wrong"));
     }
+
+    fn grpc_req(auth: Option<&str>) -> tonic::Request<()> {
+        let mut req = tonic::Request::new(());
+        if let Some(t) = auth {
+            req.metadata_mut()
+                .insert("authorization", format!("Bearer {t}").parse().unwrap());
+        }
+        req
+    }
+
+    #[test]
+    fn grpc_interceptor_enforces_token() {
+        let mut intercept = grpc_interceptor(ApiToken::new(Some("tok".to_string())));
+        assert!(intercept(grpc_req(Some("tok"))).is_ok());
+
+        let err = intercept(grpc_req(Some("nope"))).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+        let err = intercept(grpc_req(None)).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn grpc_interceptor_open_when_disabled() {
+        let mut intercept = grpc_interceptor(ApiToken::new(None));
+        assert!(intercept(grpc_req(None)).is_ok());
+    }
 }

--- a/crates/likhadb-server/src/auth.rs
+++ b/crates/likhadb-server/src/auth.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Request, State},
+    http::{header, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use tonic::Status;
+
+/// Shared bearer secret from `LIKHADB_API_TOKEN`.
+///
+/// `None` means auth is disabled (intended for local dev only; `main` logs a
+/// loud warning at startup). The check lives at the application layer, so
+/// enabling transport-level mTLS later is additive — no change to this type.
+#[derive(Clone)]
+pub struct ApiToken(Arc<Option<String>>);
+
+impl ApiToken {
+    pub fn from_env() -> Self {
+        let tok = std::env::var("LIKHADB_API_TOKEN")
+            .ok()
+            .filter(|s| !s.is_empty());
+        Self(Arc::new(tok))
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.0.is_some()
+    }
+
+    fn verify(&self, presented: &str) -> bool {
+        match self.0.as_deref() {
+            None => true,
+            Some(expected) => constant_time_eq(expected.as_bytes(), presented.as_bytes()),
+        }
+    }
+}
+
+/// Compares without short-circuiting on content, so timing does not reveal how
+/// many leading bytes matched. Only leaks length, which is fixed per deploy.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+fn extract_bearer(raw: Option<&str>) -> Option<&str> {
+    raw?.strip_prefix("Bearer ")
+}
+
+/// REST middleware. Apply with `route_layer` so public routes (`/health`)
+/// are not gated.
+pub async fn require_bearer(
+    State(token): State<ApiToken>,
+    req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if !token.is_enabled() {
+        return Ok(next.run(req).await);
+    }
+    let provided = extract_bearer(
+        req.headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok()),
+    );
+    match provided {
+        Some(t) if token.verify(t) => Ok(next.run(req).await),
+        _ => Err(StatusCode::UNAUTHORIZED),
+    }
+}
+
+/// gRPC interceptor. Gates every method on the service.
+pub fn grpc_interceptor(
+    token: ApiToken,
+) -> impl FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, Status> + Clone {
+    move |req| {
+        if !token.is_enabled() {
+            return Ok(req);
+        }
+        let provided = extract_bearer(
+            req.metadata()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok()),
+        );
+        match provided {
+            Some(t) if token.verify(t) => Ok(req),
+            _ => Err(Status::unauthenticated("missing or invalid bearer token")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_only_identical() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+        assert!(!constant_time_eq(b"secret", b"secreT"));
+        assert!(!constant_time_eq(b"secret", b"secret-longer"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn extract_bearer_strips_prefix() {
+        assert_eq!(extract_bearer(Some("Bearer abc")), Some("abc"));
+        assert_eq!(extract_bearer(Some("bearer abc")), None);
+        assert_eq!(extract_bearer(Some("abc")), None);
+        assert_eq!(extract_bearer(None), None);
+    }
+
+    #[test]
+    fn disabled_token_accepts_anything() {
+        let t = ApiToken(Arc::new(None));
+        assert!(!t.is_enabled());
+        assert!(t.verify("whatever"));
+    }
+
+    #[test]
+    fn enabled_token_requires_exact_match() {
+        let t = ApiToken(Arc::new(Some("s3cr3t".to_string())));
+        assert!(t.is_enabled());
+        assert!(t.verify("s3cr3t"));
+        assert!(!t.verify("wrong"));
+    }
+}

--- a/crates/likhadb-server/src/error.rs
+++ b/crates/likhadb-server/src/error.rs
@@ -12,7 +12,6 @@ pub enum ApiError {
     NotFound(String),
     Conflict(String),
     BadRequest(String),
-    Unauthorized,
     Forbidden(String),
     Internal(String),
 }
@@ -29,7 +28,6 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(m) => (StatusCode::NOT_FOUND, m),
             ApiError::Conflict(m) => (StatusCode::CONFLICT, m),
             ApiError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
-            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized".into()),
             ApiError::Forbidden(m) => (StatusCode::FORBIDDEN, m),
             ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
         };

--- a/crates/likhadb-server/src/error.rs
+++ b/crates/likhadb-server/src/error.rs
@@ -12,6 +12,8 @@ pub enum ApiError {
     NotFound(String),
     Conflict(String),
     BadRequest(String),
+    Unauthorized,
+    Forbidden(String),
     Internal(String),
 }
 
@@ -27,6 +29,8 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(m) => (StatusCode::NOT_FOUND, m),
             ApiError::Conflict(m) => (StatusCode::CONFLICT, m),
             ApiError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized".into()),
+            ApiError::Forbidden(m) => (StatusCode::FORBIDDEN, m),
             ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
         };
         (status, Json(json!({"error": msg}))).into_response()

--- a/crates/likhadb-server/src/grpc/error.rs
+++ b/crates/likhadb-server/src/grpc/error.rs
@@ -28,6 +28,8 @@ pub fn api_err(e: ApiError) -> tonic::Status {
         ApiError::BadRequest(m) => tonic::Status::invalid_argument(m),
         ApiError::NotFound(m) => tonic::Status::not_found(m),
         ApiError::Conflict(m) => tonic::Status::already_exists(m),
+        ApiError::Unauthorized => tonic::Status::unauthenticated("unauthorized"),
+        ApiError::Forbidden(m) => tonic::Status::permission_denied(m),
         ApiError::Internal(m) => tonic::Status::internal(m),
     }
 }

--- a/crates/likhadb-server/src/grpc/error.rs
+++ b/crates/likhadb-server/src/grpc/error.rs
@@ -28,7 +28,6 @@ pub fn api_err(e: ApiError) -> tonic::Status {
         ApiError::BadRequest(m) => tonic::Status::invalid_argument(m),
         ApiError::NotFound(m) => tonic::Status::not_found(m),
         ApiError::Conflict(m) => tonic::Status::already_exists(m),
-        ApiError::Unauthorized => tonic::Status::unauthenticated("unauthorized"),
         ApiError::Forbidden(m) => tonic::Status::permission_denied(m),
         ApiError::Internal(m) => tonic::Status::internal(m),
     }

--- a/crates/likhadb-server/src/grpc/service.rs
+++ b/crates/likhadb-server/src/grpc/service.rs
@@ -19,7 +19,7 @@ use tonic::{Request, Response, Status};
 use crate::{
     grpc::error::{api_err, core_err, persist_err},
     state::AppState,
-    types::{metric_str, parse_metric},
+    types::{metric_str, parse_metric, validate_k},
 };
 
 pub struct LikhaDbGrpc {
@@ -204,17 +204,13 @@ impl LikhaDb for LikhaDbGrpc {
         request: Request<proto::QueryRequest>,
     ) -> Result<Response<QueryResponse>, Status> {
         let req = request.into_inner();
+        let k = validate_k(req.k as usize).map_err(api_err)?;
         let filter = decode_filter(&req.filter_json)?;
         let results = {
             let guard = self.state.read().await;
             let col = guard.get(&req.collection).map_err(core_err)?;
-            col.search(
-                &req.vector,
-                req.k as usize,
-                filter.as_ref(),
-                req.include_payload,
-            )
-            .map_err(core_err)?
+            col.search(&req.vector, k, filter.as_ref(), req.include_payload)
+                .map_err(core_err)?
         };
         let results = encode_scored_results(results)?;
         Ok(Response::new(QueryResponse { results }))
@@ -225,6 +221,7 @@ impl LikhaDb for LikhaDbGrpc {
         request: Request<proto::HybridQueryRequest>,
     ) -> Result<Response<HybridQueryResponse>, Status> {
         let req = request.into_inner();
+        let k = validate_k(req.k as usize).map_err(api_err)?;
         let filter = decode_filter(&req.filter_json)?;
         let rrf_k = if req.rrf_k == 0 { 60 } else { req.rrf_k };
         let results = {
@@ -233,7 +230,7 @@ impl LikhaDb for LikhaDbGrpc {
             col.hybrid_search(
                 &req.vector,
                 &req.text,
-                req.k as usize,
+                k,
                 rrf_k,
                 filter.as_ref(),
                 req.include_payload,
@@ -251,17 +248,13 @@ impl LikhaDb for LikhaDbGrpc {
         request: Request<proto::QueryRequest>,
     ) -> Result<Response<Self::QueryStreamStream>, Status> {
         let req = request.into_inner();
+        let k = validate_k(req.k as usize).map_err(api_err)?;
         let filter = decode_filter(&req.filter_json)?;
         let results = {
             let guard = self.state.read().await;
             let col = guard.get(&req.collection).map_err(core_err)?;
-            col.search(
-                &req.vector,
-                req.k as usize,
-                filter.as_ref(),
-                req.include_payload,
-            )
-            .map_err(core_err)?
+            col.search(&req.vector, k, filter.as_ref(), req.include_payload)
+                .map_err(core_err)?
         };
 
         let (tx, rx) = tokio::sync::mpsc::channel(32);

--- a/crates/likhadb-server/src/lib.rs
+++ b/crates/likhadb-server/src/lib.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod error;
 mod grpc;
 mod metrics;
@@ -7,6 +8,7 @@ mod routes;
 mod state;
 mod types;
 
+pub use auth::{grpc_interceptor, require_bearer, ApiToken};
 pub use grpc::{GrpcMetricsLayer, LikhaDbGrpc, LikhaDbServer};
 #[cfg(feature = "iceberg-recovery")]
 pub use likhadb_lakehouse::{

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -134,8 +134,9 @@ async fn main() {
     let grpc_token = api_token.clone();
     let grpc_shutdown_rx = shutdown_rx.clone();
     let mut grpc_handle = tokio::spawn(async move {
-        let service = likhadb_server::LikhaDbServer::new(likhadb_server::LikhaDbGrpc::new(grpc_state))
-            .max_decoding_message_size(MAX_GRPC_MSG);
+        let service =
+            likhadb_server::LikhaDbServer::new(likhadb_server::LikhaDbGrpc::new(grpc_state))
+                .max_decoding_message_size(MAX_GRPC_MSG);
         tonic::transport::Server::builder()
             .layer(likhadb_server::GrpcMetricsLayer)
             .add_service(tonic::service::interceptor::InterceptedService::new(
@@ -155,11 +156,11 @@ async fn main() {
             listener,
             likhadb_server::router(state, prometheus, api_token),
         )
-            .with_graceful_shutdown(async move {
-                let mut rx = rest_shutdown_rx;
-                rx.changed().await.ok();
-            })
-            .await
+        .with_graceful_shutdown(async move {
+            let mut rx = rest_shutdown_rx;
+            rx.changed().await.ok();
+        })
+        .await
     });
 
     // Block until a server crashes unexpectedly or a shutdown signal arrives.

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -68,6 +68,11 @@ async fn main() {
 
     let state = likhadb_server::AppState::new(wal);
 
+    let api_token = likhadb_server::ApiToken::from_env();
+    if !api_token.is_enabled() {
+        tracing::warn!("LIKHADB_API_TOKEN unset — REST and gRPC are UNAUTHENTICATED (dev mode)");
+    }
+
     // Attach the Tier Q pipeline when both Iceberg and LIKHADB_ENRICH_NAMESPACE
     // are configured. Failures inside the helper are logged; state.pipeline
     // stays None and the server keeps serving non-enriched queries.
@@ -139,7 +144,10 @@ async fn main() {
 
     let rest_shutdown_rx = shutdown_rx;
     let mut rest_handle = tokio::spawn(async move {
-        axum::serve(listener, likhadb_server::router(state, prometheus))
+        axum::serve(
+            listener,
+            likhadb_server::router(state, prometheus, api_token),
+        )
             .with_graceful_shutdown(async move {
                 let mut rx = rest_shutdown_rx;
                 rx.changed().await.ok();

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -127,13 +127,20 @@ async fn main() {
     // Keep a clone of state alive for the final checkpoint after servers drain.
     let checkpoint_state = state.clone();
 
+    // Cap inbound gRPC frames so a single oversized message can't exhaust memory.
+    const MAX_GRPC_MSG: usize = 4 * 1024 * 1024;
+
     let grpc_state = state.clone();
+    let grpc_token = api_token.clone();
     let grpc_shutdown_rx = shutdown_rx.clone();
     let mut grpc_handle = tokio::spawn(async move {
+        let service = likhadb_server::LikhaDbServer::new(likhadb_server::LikhaDbGrpc::new(grpc_state))
+            .max_decoding_message_size(MAX_GRPC_MSG);
         tonic::transport::Server::builder()
             .layer(likhadb_server::GrpcMetricsLayer)
-            .add_service(likhadb_server::LikhaDbServer::new(
-                likhadb_server::LikhaDbGrpc::new(grpc_state),
+            .add_service(tonic::service::interceptor::InterceptedService::new(
+                service,
+                likhadb_server::grpc_interceptor(grpc_token),
             ))
             .serve_with_shutdown(grpc_addr, async move {
                 let mut rx = grpc_shutdown_rx;

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -19,9 +19,10 @@ use crate::{
     error::ApiError,
     state::AppState,
     types::{
-        metric_str, parse_metric, CollectionInfo, CreateCollectionRequest, ExportParquetRequest,
-        HybridQueryRequest, HybridQueryResponse, ImportParquetRequest, ImportParquetResponse,
-        IndexConfig, InsertRequest, QueryRequest, QueryResponse, VectorResponse,
+        metric_str, parse_metric, validate_k, CollectionInfo, CreateCollectionRequest,
+        ExportParquetRequest, HybridQueryRequest, HybridQueryResponse, ImportParquetRequest,
+        ImportParquetResponse, IndexConfig, InsertRequest, QueryRequest, QueryResponse,
+        VectorResponse,
     },
 };
 #[cfg(feature = "enriched-search")]
@@ -211,12 +212,13 @@ async fn query_vectors(
     Path(name): Path<String>,
     Json(req): Json<QueryRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    let k = validate_k(req.k)?;
     let start = Instant::now();
     let (results, index_type) = {
         let guard = state.read().await;
         let col = guard.get(&name)?;
         let index_type = col.index_type().to_string();
-        let results = col.search(&req.vector, req.k, req.filter.as_ref(), req.include_payload)?;
+        let results = col.search(&req.vector, k, req.filter.as_ref(), req.include_payload)?;
         (results, index_type)
     };
     metrics::histogram!(
@@ -242,7 +244,7 @@ async fn query_vectors(
                 candidates,
                 query_text: req.query_text.unwrap_or_default(),
                 allowed_teams: req.allowed_teams,
-                top_k: req.k,
+                top_k: k,
             })
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -258,6 +260,7 @@ async fn hybrid_query_vectors(
     Path(name): Path<String>,
     Json(req): Json<HybridQueryRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    let k = validate_k(req.k)?;
     let start = Instant::now();
     let (results, index_type) = {
         let guard = state.read().await;
@@ -266,7 +269,7 @@ async fn hybrid_query_vectors(
         let results = col.hybrid_search(
             &req.vector,
             &req.text,
-            req.k,
+            k,
             req.rrf_k,
             req.filter.as_ref(),
             req.include_payload,
@@ -296,7 +299,7 @@ async fn hybrid_query_vectors(
                 candidates,
                 query_text: req.text.clone(),
                 allowed_teams: req.allowed_teams,
-                top_k: req.k,
+                top_k: k,
             })
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?;

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -320,16 +320,48 @@ async fn hybrid_query_vectors(
     Ok(Json(HybridQueryResponse { results }).into_response())
 }
 
+/// Confine a client-supplied parquet path to `LIKHADB_PARQUET_ROOT`, defeating
+/// `../` traversal and absolute-path escapes. `must_exist` is true for import
+/// (the file must already exist) and false for export (only the parent must).
+fn resolve_under_root(requested: &str, must_exist: bool) -> Result<std::path::PathBuf, ApiError> {
+    let root = std::env::var("LIKHADB_PARQUET_ROOT").map_err(|_| {
+        ApiError::Forbidden("parquet I/O disabled: LIKHADB_PARQUET_ROOT unset".into())
+    })?;
+    let root = std::path::Path::new(&root)
+        .canonicalize()
+        .map_err(|e| ApiError::Internal(format!("bad LIKHADB_PARQUET_ROOT: {e}")))?;
+
+    let joined = root.join(requested);
+    let resolved = if must_exist {
+        joined.canonicalize()
+    } else {
+        // File may not exist yet — canonicalize the parent, re-attach the name.
+        let parent = joined
+            .parent()
+            .ok_or_else(|| ApiError::bad_request("invalid path"))?;
+        let name = joined
+            .file_name()
+            .ok_or_else(|| ApiError::bad_request("invalid path"))?;
+        parent.canonicalize().map(|p| p.join(name))
+    }
+    .map_err(|_| ApiError::Forbidden("path outside parquet root".into()))?;
+
+    if !resolved.starts_with(&root) {
+        return Err(ApiError::Forbidden("path outside parquet root".into()));
+    }
+    Ok(resolved)
+}
+
 async fn import_parquet(
     State(state): State<AppState>,
     Path(name): Path<String>,
     Json(req): Json<ImportParquetRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let path = std::path::Path::new(&req.path);
+    let path = resolve_under_root(&req.path, true)?;
     let payload_cols: Vec<&str> = req.payload_cols.iter().map(String::as_str).collect();
     let imported = {
         let mut guard = state.write().await;
-        guard.import_parquet(&name, path, &req.id_col, &req.vector_col, &payload_cols)?
+        guard.import_parquet(&name, &path, &req.id_col, &req.vector_col, &payload_cols)?
     };
     Ok((StatusCode::OK, Json(ImportParquetResponse { imported })))
 }
@@ -339,10 +371,10 @@ async fn export_parquet(
     Path(name): Path<String>,
     Json(req): Json<ExportParquetRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let path = std::path::Path::new(&req.path);
+    let path = resolve_under_root(&req.path, false)?;
     {
         let guard = state.read().await;
-        guard.export_parquet(&name, path)?;
+        guard.export_parquet(&name, &path)?;
     }
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use axum::{
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
@@ -9,6 +9,12 @@ use axum::{
 };
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde_json::json;
+use tower::limit::GlobalConcurrencyLimitLayer;
+
+/// Reject request bodies larger than this (caps a single oversized insert).
+const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+/// Cap concurrent in-flight requests across all connections (flood control).
+const MAX_INFLIGHT: usize = 256;
 
 use likhadb_lakehouse::LakehouseExt;
 
@@ -59,8 +65,13 @@ pub fn router(state: AppState, prometheus: PrometheusHandle, token: ApiToken) ->
         .layer(Extension(prometheus))
         .with_state(state);
 
-    // /health stays public for liveness probes.
-    Router::new().route("/health", get(health)).merge(protected)
+    // /health stays public for liveness probes. Body-size and global
+    // concurrency limits wrap everything as a blunt anti-flood / anti-OOM layer.
+    Router::new()
+        .route("/health", get(health))
+        .merge(protected)
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
+        .layer(GlobalConcurrencyLimitLayer::new(MAX_INFLIGHT))
 }
 
 async fn health() -> impl IntoResponse {

--- a/crates/likhadb-server/src/routes.rs
+++ b/crates/likhadb-server/src/routes.rs
@@ -15,6 +15,7 @@ use likhadb_lakehouse::LakehouseExt;
 #[cfg(feature = "enriched-search")]
 use crate::types::RankedQueryResponse;
 use crate::{
+    auth::ApiToken,
     error::ApiError,
     state::AppState,
     types::{
@@ -26,9 +27,9 @@ use crate::{
 #[cfg(feature = "enriched-search")]
 use likhadb_query::pipeline::{Candidate, PipelineRequest};
 
-pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
-    Router::new()
-        .route("/health", get(health))
+pub fn router(state: AppState, prometheus: PrometheusHandle, token: ApiToken) -> Router {
+    // /metrics is gated too: it leaks collection names and row counts.
+    let protected = Router::new()
         .route("/metrics", get(metrics_endpoint))
         .route(
             "/collections",
@@ -50,8 +51,15 @@ pub fn router(state: AppState, prometheus: PrometheusHandle) -> Router {
         )
         .route("/collections/:name/import-parquet", post(import_parquet))
         .route("/collections/:name/export-parquet", post(export_parquet))
+        .route_layer(axum::middleware::from_fn_with_state(
+            token,
+            crate::require_bearer,
+        ))
         .layer(Extension(prometheus))
-        .with_state(state)
+        .with_state(state);
+
+    // /health stays public for liveness probes.
+    Router::new().route("/health", get(health)).merge(protected)
 }
 
 async fn health() -> impl IntoResponse {

--- a/crates/likhadb-server/src/types.rs
+++ b/crates/likhadb-server/src/types.rs
@@ -65,6 +65,18 @@ pub struct VectorResponse {
 
 // ── Query ─────────────────────────────────────────────────────────────────────
 
+/// Upper bound on `k` for any search. Caps result-set size so an open query
+/// endpoint can't be used to scan an entire collection in one request.
+pub const MAX_K: usize = 1024;
+
+pub fn validate_k(k: usize) -> Result<usize, ApiError> {
+    match k {
+        0 => Err(ApiError::bad_request("k must be >= 1")),
+        k if k > MAX_K => Err(ApiError::bad_request(format!("k={k} exceeds max {MAX_K}"))),
+        k => Ok(k),
+    }
+}
+
 #[derive(Deserialize)]
 pub struct QueryRequest {
     pub vector: Vector,

--- a/crates/likhadb-server/tests/auth_integration.rs
+++ b/crates/likhadb-server/tests/auth_integration.rs
@@ -1,0 +1,66 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use likhadb_persist::WalManager;
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToken, AppState};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const TOKEN: &str = "test-secret-token";
+
+fn build_app() -> (axum::Router, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let wal = WalManager::open(dir.path()).unwrap();
+    let prometheus = install_prometheus();
+    seed_collection_gauges(&wal);
+    let state = AppState::new(wal);
+    (
+        router(state, prometheus, ApiToken::new(Some(TOKEN.into()))),
+        dir,
+    )
+}
+
+fn get(uri: &str, auth: Option<&str>) -> Request<Body> {
+    let mut b = Request::builder().method("GET").uri(uri);
+    if let Some(t) = auth {
+        b = b.header("authorization", format!("Bearer {t}"));
+    }
+    b.body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn health_is_public() {
+    let (app, _dir) = build_app();
+    let res = app.oneshot(get("/health", None)).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn protected_route_rejects_without_token() {
+    let (app, _dir) = build_app();
+    let res = app.oneshot(get("/collections", None)).await.unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn protected_route_rejects_wrong_token() {
+    let (app, _dir) = build_app();
+    let res = app
+        .oneshot(get("/collections", Some("wrong")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn protected_route_accepts_correct_token() {
+    let (app, _dir) = build_app();
+    let res = app.oneshot(get("/collections", Some(TOKEN))).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn metrics_is_gated() {
+    let (app, _dir) = build_app();
+    let res = app.oneshot(get("/metrics", None)).await.unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/likhadb-server/tests/hybrid_integration.rs
+++ b/crates/likhadb-server/tests/hybrid_integration.rs
@@ -1,7 +1,7 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use likhadb_persist::WalManager;
-use likhadb_server::{install_prometheus, router, seed_collection_gauges, AppState};
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToken, AppState};
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -11,7 +11,7 @@ fn build_app() -> (axum::Router, TempDir) {
     let prometheus = install_prometheus();
     seed_collection_gauges(&wal);
     let state = AppState::new(wal);
-    (router(state, prometheus), dir)
+    (router(state, prometheus, ApiToken::new(None)), dir)
 }
 
 fn json_req(method: &str, uri: &str, body: impl Into<String>) -> Request<Body> {

--- a/crates/likhadb-server/tests/metrics_integration.rs
+++ b/crates/likhadb-server/tests/metrics_integration.rs
@@ -1,7 +1,7 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use likhadb_persist::WalManager;
-use likhadb_server::{install_prometheus, router, seed_collection_gauges, AppState};
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToken, AppState};
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -11,7 +11,8 @@ fn build_app() -> (axum::Router, TempDir) {
     let prometheus = install_prometheus();
     seed_collection_gauges(&wal);
     let state = AppState::new(wal);
-    (router(state, prometheus), dir)
+    // Auth disabled so existing assertions exercise the handlers directly.
+    (router(state, prometheus, ApiToken::new(None)), dir)
 }
 
 fn json_request(method: &str, uri: &str, body: &'static str) -> Request<Body> {

--- a/crates/likhadb-server/tests/parquet_paths_integration.rs
+++ b/crates/likhadb-server/tests/parquet_paths_integration.rs
@@ -1,0 +1,57 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use likhadb_persist::WalManager;
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToken, AppState};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn build_app() -> (axum::Router, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let wal = WalManager::open(dir.path()).unwrap();
+    let prometheus = install_prometheus();
+    seed_collection_gauges(&wal);
+    let state = AppState::new(wal);
+    (router(state, prometheus, ApiToken::new(None)), dir)
+}
+
+fn import_req(path: &str) -> Request<Body> {
+    let body = format!(r#"{{"path":"{path}","id_col":"id","vector_col":"vec"}}"#);
+    Request::builder()
+        .method("POST")
+        .uri("/collections/c/import-parquet")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+// Single test: LIKHADB_PARQUET_ROOT is process-global, so we keep all
+// assertions that mutate it in one sequential test.
+#[tokio::test]
+async fn parquet_paths_are_confined() {
+    let (app, _dir) = build_app();
+
+    // No root configured → endpoint disabled.
+    std::env::remove_var("LIKHADB_PARQUET_ROOT");
+    let res = app.clone().oneshot(import_req("x.parquet")).await.unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    // With a root set, traversal and absolute escapes are rejected.
+    let root = TempDir::new().unwrap();
+    std::env::set_var("LIKHADB_PARQUET_ROOT", root.path());
+
+    let res = app
+        .clone()
+        .oneshot(import_req("../../../../etc/passwd"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    let res = app
+        .clone()
+        .oneshot(import_req("/etc/passwd"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    std::env::remove_var("LIKHADB_PARQUET_ROOT");
+}

--- a/crates/likhadb-server/tests/query_limits_integration.rs
+++ b/crates/likhadb-server/tests/query_limits_integration.rs
@@ -54,3 +54,18 @@ async fn k_is_clamped() {
     // A sane k succeeds (empty collection still returns 200 with no results).
     assert_eq!(query_status(&app, 5).await, StatusCode::OK);
 }
+
+#[tokio::test]
+async fn oversized_body_is_rejected() {
+    let (app, _dir) = build_app();
+
+    // ~5 MiB payload — over the 4 MiB DefaultBodyLimit.
+    let big = "x".repeat(5 * 1024 * 1024);
+    let body = format!(r#"{{"name":"c","dim":3,"metric":"l2","junk":"{big}"}}"#);
+
+    let res = app
+        .oneshot(json_req("POST", "/collections", body))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}

--- a/crates/likhadb-server/tests/query_limits_integration.rs
+++ b/crates/likhadb-server/tests/query_limits_integration.rs
@@ -1,0 +1,56 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use likhadb_persist::WalManager;
+use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToken, AppState};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn build_app() -> (axum::Router, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let wal = WalManager::open(dir.path()).unwrap();
+    let prometheus = install_prometheus();
+    seed_collection_gauges(&wal);
+    let state = AppState::new(wal);
+    (router(state, prometheus, ApiToken::new(None)), dir)
+}
+
+fn json_req(method: &str, uri: &str, body: impl Into<String>) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.into()))
+        .unwrap()
+}
+
+async fn query_status(app: &axum::Router, k: usize) -> StatusCode {
+    let body = format!(r#"{{"vector":[0.1,0.2,0.3],"k":{k}}}"#);
+    app.clone()
+        .oneshot(json_req("POST", "/collections/c/query", body))
+        .await
+        .unwrap()
+        .status()
+}
+
+#[tokio::test]
+async fn k_is_clamped() {
+    let (app, _dir) = build_app();
+
+    let res = app
+        .clone()
+        .oneshot(json_req(
+            "POST",
+            "/collections",
+            r#"{"name":"c","dim":3,"metric":"l2"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+
+    // k = 0 is rejected.
+    assert_eq!(query_status(&app, 0).await, StatusCode::BAD_REQUEST);
+    // k beyond MAX_K (1024) is rejected.
+    assert_eq!(query_status(&app, 5000).await, StatusCode::BAD_REQUEST);
+    // A sane k succeeds (empty collection still returns 200 with no results).
+    assert_eq!(query_status(&app, 5).await, StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

Locks down a fully-open deployment: every REST and gRPC endpoint was unauthenticated, Grafana ran as anonymous Admin, queries allowed unbounded scans, and the parquet endpoints accepted arbitrary filesystem paths. Implemented as 9 small, individually-verified commits.

## Changes

| Area | Fix |
|------|-----|
| **Config** | Grafana anon-Admin removed (admin password from env), MinIO creds from env, exposed ports bound to `127.0.0.1`; `.env.example` added, `.env` gitignored |
| **Auth** | New `auth.rs`: `ApiToken` with constant-time compare. REST middleware gates every route except `/health` (incl. `/metrics`, which leaks collection names/counts). gRPC `InterceptedService` interceptor gates the whole service |
| **Scan/exfil** | `k` clamped to `MAX_K=1024` on REST + gRPC (`query`, `hybrid_query`, `query_stream`) — rejects `k=0` and `k>MAX_K` |
| **DoS** | 4 MiB request-body limit + global concurrency cap (256) on REST; `max_decoding_message_size(4 MiB)` on gRPC |
| **Arbitrary file r/w** | Parquet import/export paths confined to `LIKHADB_PARQUET_ROOT`; traversal and absolute-path escapes rejected (403); disabled by default when unset |

## Verification

- **23 tests pass** (`cargo test -p likhadb-server`): 6 auth unit + 5 REST auth integration + k-clamp + body-limit + parquet-traversal + existing suites
- `cargo clippy` clean, `cargo fmt --check` clean
- `--features enriched-search` builds

## Operational notes

- **Auth is opt-in by env**: unset `LIKHADB_API_TOKEN` → server logs a loud warning and runs open (dev mode). Set it in every real deploy.
- **Parquet endpoints are disabled** (403) until `LIKHADB_PARQUET_ROOT` is set.
- **gRPC health is gated** by the interceptor — give LB probes the token, or use REST `/health` (still public).
- **mTLS** can slot in at the transport layer later without touching the token logic.
- **Per-IP rate limiting** (beyond the global concurrency cap) would need a new dep like `tower_governor` — left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
