### PR TITLE
#33 wal: add configurable auto-checkpoints

### DIFF
--- a/crates/likhadb-persist/src/lib.rs
+++ b/crates/likhadb-persist/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 pub mod wal;
 
 pub use error::PersistError;
-pub use wal::WalManager;
+pub use wal::{WalConfig, WalManager};
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -21,13 +21,16 @@ use recovery::apply_op;
 
 struct WalWriter {
     file: BufWriter<File>,
+    bytes_written: u64,
 }
 
 impl WalWriter {
     fn open_append(path: &Path) -> std::io::Result<Self> {
         let file = OpenOptions::new().create(true).append(true).open(path)?;
+        let bytes_written = file.metadata()?.len();
         Ok(Self {
             file: BufWriter::new(file),
+            bytes_written,
         })
     }
 
@@ -40,6 +43,7 @@ impl WalWriter {
         write_frame(&mut self.file, &payload).map_err(PersistError::Io)?;
         self.file.flush().map_err(PersistError::Io)?;
         self.file.get_mut().sync_data().map_err(PersistError::Io)?;
+        self.bytes_written = self.bytes_written.saturating_add(frame_bytes);
         metrics::counter!("likhadb_wal_bytes_written_total").increment(frame_bytes);
         metrics::counter!("likhadb_wal_appends_total").increment(1);
         Ok(())
@@ -52,6 +56,27 @@ impl WalWriter {
 }
 
 // ── WalManager ─────────────────────────────────────────────────────────────
+
+/// Thresholds that control automatic WAL checkpoints.
+///
+/// A threshold of zero disables that trigger. When both thresholds are
+/// enabled, a checkpoint runs as soon as either one is reached.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WalConfig {
+    /// Trigger a checkpoint after this many WAL entries (`0` = disabled).
+    pub checkpoint_every_n_entries: u64,
+    /// Trigger a checkpoint after `wal.log` reaches this size (`0` = disabled).
+    pub checkpoint_every_n_bytes: u64,
+}
+
+impl Default for WalConfig {
+    fn default() -> Self {
+        Self {
+            checkpoint_every_n_entries: 100_000,
+            checkpoint_every_n_bytes: 256 * 1024 * 1024,
+        }
+    }
+}
 
 /// A `CollectionManager` wrapper that durably logs every mutation to a
 /// Write-Ahead Log before applying it in memory.
@@ -76,6 +101,8 @@ impl WalWriter {
 pub struct WalManager {
     inner: CollectionManager,
     wal: WalWriter,
+    config: WalConfig,
+    wal_entries: u64,
     next_lsn: u64,
     dir: PathBuf,
     /// Highest LSN confirmed durably committed to Iceberg staging.  Zero means
@@ -93,8 +120,14 @@ impl WalManager {
     const WAL_FILE: &'static str = "wal.log";
 
     /// Open (or create) a data directory, recovering from any existing
-    /// snapshot + WAL.
+    /// snapshot + WAL using [`WalConfig::default`].
     pub fn open(dir: &Path) -> Result<Self, PersistError> {
+        Self::open_with_config(dir, WalConfig::default())
+    }
+
+    /// Open (or create) a data directory with custom auto-checkpoint
+    /// thresholds.
+    pub fn open_with_config(dir: &Path, config: WalConfig) -> Result<Self, PersistError> {
         std::fs::create_dir_all(dir).map_err(PersistError::Io)?;
 
         let snapshot_path = dir.join(Self::SNAPSHOT_FILE);
@@ -117,8 +150,9 @@ impl WalManager {
 
         // 2. Replay WAL entries newer than the snapshot.
         let mut next_lsn = snapshot_lsn + 1;
+        let mut wal_entries = 0;
         if wal_path.exists() {
-            next_lsn = Self::replay_wal(&wal_path, &mut inner, snapshot_lsn, dir)?;
+            (next_lsn, wal_entries) = Self::replay_wal(&wal_path, &mut inner, snapshot_lsn, dir)?;
         }
 
         // 3. Open WAL for appending.
@@ -127,6 +161,8 @@ impl WalManager {
         Ok(Self {
             inner,
             wal,
+            config,
+            wal_entries,
             next_lsn,
             dir: dir.to_path_buf(),
             #[cfg(feature = "iceberg-recovery")]
@@ -149,19 +185,39 @@ impl WalManager {
         inner: CollectionManager,
         iceberg_watermark: u64,
     ) -> Result<Self, PersistError> {
+        Self::open_from_iceberg_state_with_config(
+            dir,
+            inner,
+            iceberg_watermark,
+            WalConfig::default(),
+        )
+    }
+
+    /// Iceberg recovery variant of [`WalManager::open_with_config`].
+    #[cfg(feature = "iceberg-recovery")]
+    pub fn open_from_iceberg_state_with_config(
+        dir: &Path,
+        inner: CollectionManager,
+        iceberg_watermark: u64,
+        config: WalConfig,
+    ) -> Result<Self, PersistError> {
         std::fs::create_dir_all(dir).map_err(PersistError::Io)?;
         let wal_path = dir.join(Self::WAL_FILE);
 
         let mut inner = inner;
         let mut next_lsn = iceberg_watermark + 1;
+        let mut wal_entries = 0;
         if wal_path.exists() {
-            next_lsn = Self::replay_wal(&wal_path, &mut inner, iceberg_watermark, dir)?;
+            (next_lsn, wal_entries) =
+                Self::replay_wal(&wal_path, &mut inner, iceberg_watermark, dir)?;
         }
 
         let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
         Ok(Self {
             inner,
             wal,
+            config,
+            wal_entries,
             next_lsn,
             dir: dir.to_path_buf(),
             iceberg_watermark,
@@ -169,18 +225,19 @@ impl WalManager {
         })
     }
 
-    /// Replay WAL entries with LSN > `snapshot_lsn`.  Returns the `next_lsn`
-    /// to use for new writes.
+    /// Replay WAL entries with LSN > `snapshot_lsn`. Returns the `next_lsn`
+    /// and number of valid entries currently occupying the WAL.
     fn replay_wal(
         path: &Path,
         mgr: &mut CollectionManager,
         snapshot_lsn: u64,
         data_dir: &Path,
-    ) -> Result<u64, PersistError> {
+    ) -> Result<(u64, u64), PersistError> {
         let file = File::open(path).map_err(PersistError::Io)?;
         let reader = BufReader::new(file);
         let mut iter = FrameIter::new(reader);
         let mut last_lsn = snapshot_lsn;
+        let mut wal_entries = 0u64;
 
         for item in &mut iter {
             let (payload, stored_crc) = item.map_err(PersistError::Io)?;
@@ -204,6 +261,7 @@ impl WalManager {
             let entry: WalEntry = bincode_opts()
                 .deserialize(&payload)
                 .map_err(PersistError::Decode)?;
+            wal_entries = wal_entries.saturating_add(1);
 
             if entry.lsn <= snapshot_lsn {
                 continue;
@@ -213,13 +271,13 @@ impl WalManager {
             last_lsn = entry.lsn;
         }
 
-        Ok(last_lsn + 1)
+        Ok((last_lsn + 1, wal_entries))
     }
 
     /// Append a WAL entry then apply `f` to the inner manager.
-    fn log_and_apply<F>(&mut self, op: WalOp, f: F) -> Result<(), PersistError>
+    fn log_and_apply<T, F>(&mut self, op: WalOp, f: F) -> Result<T, PersistError>
     where
-        F: FnOnce(&mut CollectionManager) -> likhadb_core::Result<()>,
+        F: FnOnce(&mut CollectionManager) -> likhadb_core::Result<T>,
     {
         let _span = tracing::debug_span!("wal_append", lsn = self.next_lsn).entered();
         let entry = WalEntry {
@@ -227,12 +285,27 @@ impl WalManager {
             op,
         };
         self.wal.append(&entry)?;
+        self.wal_entries = self.wal_entries.saturating_add(1);
         #[cfg(feature = "iceberg-recovery")]
         if let Ok(payload) = bincode_opts().serialize(&entry) {
             self.unflushed.push((entry.lsn, payload));
         }
         self.next_lsn += 1;
-        f(&mut self.inner).map_err(PersistError::Apply)
+        let result = f(&mut self.inner).map_err(PersistError::Apply)?;
+        self.maybe_checkpoint()?;
+        Ok(result)
+    }
+
+    fn maybe_checkpoint(&mut self) -> Result<(), PersistError> {
+        let entries_due = self.config.checkpoint_every_n_entries > 0
+            && self.wal_entries >= self.config.checkpoint_every_n_entries;
+        let bytes_due = self.config.checkpoint_every_n_bytes > 0
+            && self.wal.bytes_written >= self.config.checkpoint_every_n_bytes;
+
+        if entries_due || bytes_due {
+            self.checkpoint()?;
+        }
+        Ok(())
     }
 
     // ── Iceberg recovery helpers ────────────────────────────────────────────
@@ -311,6 +384,7 @@ impl WalManager {
         // Atomic rename then reopen.
         std::fs::rename(&tmp_path, &wal_path).map_err(PersistError::Io)?;
         self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal_entries = entries_to_keep.len() as u64;
 
         Ok(())
     }
@@ -418,48 +492,27 @@ impl WalManager {
     ) -> Result<(), PersistError> {
         let col = collection.to_owned();
         let lsn = self.next_lsn;
-        let _span = tracing::debug_span!("wal_append", lsn = lsn).entered();
-        let entry = WalEntry {
-            lsn,
-            op: WalOp::Insert {
+        self.log_and_apply(
+            WalOp::Insert {
                 collection: col.clone(),
                 id,
                 vector: vector.clone(),
                 payload: payload.clone(),
             },
-        };
-        self.wal.append(&entry)?;
-        #[cfg(feature = "iceberg-recovery")]
-        if let Ok(payload_bytes) = bincode_opts().serialize(&entry) {
-            self.unflushed.push((lsn, payload_bytes));
-        }
-        self.next_lsn += 1;
-        self.inner
-            .get_mut(&col)?
-            .insert(id, vector, payload, lsn)
-            .map_err(PersistError::Apply)
+            |mgr| mgr.get_mut(&col)?.insert(id, vector, payload, lsn),
+        )
     }
 
     pub fn delete(&mut self, collection: &str, id: VecId) -> Result<bool, PersistError> {
         let col = collection.to_owned();
         let lsn = self.next_lsn;
-        let entry = WalEntry {
-            lsn,
-            op: WalOp::Delete {
+        self.log_and_apply(
+            WalOp::Delete {
                 collection: col.clone(),
                 id,
             },
-        };
-        self.wal.append(&entry)?;
-        #[cfg(feature = "iceberg-recovery")]
-        if let Ok(payload) = bincode_opts().serialize(&entry) {
-            self.unflushed.push((lsn, payload));
-        }
-        self.next_lsn += 1;
-        self.inner
-            .get_mut(&col)?
-            .delete(id, lsn)
-            .map_err(PersistError::Apply)
+            |mgr| mgr.get_mut(&col)?.delete(id, lsn),
+        )
     }
 
     // ── FTS ────────────────────────────────────────────────────────────────
@@ -529,6 +582,7 @@ impl WalManager {
         // Truncate WAL and reopen for appending.
         WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;
         self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal_entries = 0;
 
         Ok(())
     }

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,5 +1,5 @@
 use likhadb_core::Metric;
-use likhadb_persist::{PersistError, WalManager};
+use likhadb_persist::{PersistError, WalConfig, WalManager};
 use serde_json::json;
 
 fn tmp_dir(label: &str) -> std::path::PathBuf {
@@ -15,6 +15,13 @@ fn open_empty_dir_succeeds() {
     let dir = tmp_dir("open_empty");
     let mgr = WalManager::open(&dir).unwrap();
     assert!(mgr.list().is_empty());
+}
+
+#[test]
+fn wal_config_has_bounded_defaults() {
+    let config = WalConfig::default();
+    assert_eq!(config.checkpoint_every_n_entries, 100_000);
+    assert_eq!(config.checkpoint_every_n_bytes, 256 * 1024 * 1024);
 }
 
 // ── Insert survives restart ────────────────────────────────────────────────
@@ -182,6 +189,93 @@ fn checkpoint_clears_wal() {
         .search(&[0.0; 4], 1, None, false)
         .unwrap();
     assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn auto_checkpoint_after_entry_threshold() {
+    let dir = tmp_dir("auto_checkpoint_entries");
+    let config = WalConfig {
+        checkpoint_every_n_entries: 2,
+        checkpoint_every_n_bytes: 0,
+    };
+
+    {
+        let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        assert!(!dir.join("snapshot.bin").exists());
+
+        mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None)
+            .unwrap();
+        assert!(dir.join("snapshot.bin").exists());
+        assert_eq!(std::fs::metadata(dir.join("wal.log")).unwrap().len(), 0);
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    assert_eq!(
+        mgr.get("col")
+            .unwrap()
+            .search(&[0.0; 4], 10, None, false)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn auto_checkpoint_after_byte_threshold() {
+    let dir = tmp_dir("auto_checkpoint_bytes");
+    let config = WalConfig {
+        checkpoint_every_n_entries: 0,
+        checkpoint_every_n_bytes: 1,
+    };
+
+    let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+    mgr.create_collection("col", 4, Metric::L2).unwrap();
+
+    assert!(dir.join("snapshot.bin").exists());
+    assert_eq!(std::fs::metadata(dir.join("wal.log")).unwrap().len(), 0);
+}
+
+#[test]
+fn zero_auto_checkpoint_thresholds_disable_triggers() {
+    let dir = tmp_dir("auto_checkpoint_disabled");
+    let config = WalConfig {
+        checkpoint_every_n_entries: 0,
+        checkpoint_every_n_bytes: 0,
+    };
+
+    let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+    mgr.create_collection("col", 4, Metric::L2).unwrap();
+    mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None)
+        .unwrap();
+
+    assert!(!dir.join("snapshot.bin").exists());
+    assert!(std::fs::metadata(dir.join("wal.log")).unwrap().len() > 0);
+}
+
+#[test]
+fn recovered_entries_count_toward_auto_checkpoint_threshold() {
+    let dir = tmp_dir("auto_checkpoint_recovered_entries");
+    let disabled = WalConfig {
+        checkpoint_every_n_entries: 0,
+        checkpoint_every_n_bytes: 0,
+    };
+
+    {
+        let mut mgr = WalManager::open_with_config(&dir, disabled).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+    }
+
+    let config = WalConfig {
+        checkpoint_every_n_entries: 2,
+        checkpoint_every_n_bytes: 0,
+    };
+    let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+    mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None)
+        .unwrap();
+
+    assert!(dir.join("snapshot.bin").exists());
+    assert_eq!(std::fs::metadata(dir.join("wal.log")).unwrap().len(), 0);
 }
 
 // ── Recovery across checkpoint boundary ───────────────────────────────────


### PR DESCRIPTION
## Summary
- add public `WalConfig` thresholds with 100,000-entry and 256 MiB defaults plus a custom open path
- track current WAL bytes and valid entry count across appends, recovery, checkpoints, and Iceberg truncation
- route every WAL-backed mutation through the auto-checkpoint check and cover entry, byte, disabled, and restart behavior

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist --all-features` — passed (8 round-trip tests, 20 WAL recovery tests; 1 doctest ignored)
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed

Closes #33