### PR TITLE
#34 wal: make insert/delete replay idempotent

### DIFF
--- a/crates/likhadb-persist/src/wal/recovery.rs
+++ b/crates/likhadb-persist/src/wal/recovery.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use likhadb_core::LikhaDbError;
-use likhadb_store::CollectionManager;
+use likhadb_store::{CollectionManager, DeltaRow};
 
 use crate::PersistError;
 
@@ -9,8 +9,8 @@ use super::entry::{IndexKind, WalOp};
 
 /// Apply a single WAL operation to a live `CollectionManager`.
 ///
-/// `CreateCollection` is idempotent: if the collection already exists (e.g.
-/// replaying after a partial checkpoint), the op is silently skipped.
+/// Operations are applied idempotently so replaying entries that were already
+/// captured by a partial checkpoint converges on the WAL's requested state.
 pub fn apply_op(
     mgr: &mut CollectionManager,
     op: WalOp,
@@ -54,13 +54,30 @@ pub fn apply_op(
             id,
             vector,
             payload,
-        } => mgr
-            .get_mut(&collection)
-            .and_then(|col| col.insert(id, vector, payload, lsn))
-            .map_err(PersistError::Apply),
+        } => {
+            let col = mgr.get_mut(&collection).map_err(PersistError::Apply)?;
+
+            // A snapshot may already contain this exact write. Avoid applying
+            // it again, which is logically harmless but can leave an extra
+            // overwrite tombstone in indexes such as HNSW.
+            if col.get(id).map_err(PersistError::Apply)? == Some((vector.clone(), payload.clone()))
+            {
+                return Ok(());
+            }
+
+            col.apply_delta_row(
+                DeltaRow::Upsert {
+                    id,
+                    vector,
+                    payload,
+                },
+                lsn,
+            )
+            .map_err(PersistError::Apply)
+        }
         WalOp::Delete { collection, id } => mgr
             .get_mut(&collection)
-            .and_then(|col| col.delete(id, lsn).map(|_| ()))
+            .and_then(|col| col.apply_delta_row(DeltaRow::Delete { id }, lsn))
             .map_err(PersistError::Apply),
         WalOp::EnableFts { collection } => {
             #[cfg(feature = "fts")]
@@ -84,5 +101,115 @@ pub fn apply_op(
             Ok(()) | Err(LikhaDbError::CollectionNotFound(_)) => Ok(()),
             Err(e) => Err(PersistError::Apply(e)),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use likhadb_core::Metric;
+    use serde_json::json;
+
+    use super::*;
+
+    fn manager_with_collection() -> CollectionManager {
+        let mut mgr = CollectionManager::new();
+        mgr.create_collection("col", 3, Metric::L2).unwrap();
+        mgr
+    }
+
+    #[test]
+    fn replaying_identical_insert_is_idempotent() {
+        let mut mgr = manager_with_collection();
+        let op = WalOp::Insert {
+            collection: "col".into(),
+            id: 5,
+            vector: vec![1.0, 2.0, 3.0],
+            payload: Some(json!({"version": 1})),
+        };
+
+        apply_op(&mut mgr, op, 1, None).unwrap();
+        apply_op(
+            &mut mgr,
+            WalOp::Insert {
+                collection: "col".into(),
+                id: 5,
+                vector: vec![1.0, 2.0, 3.0],
+                payload: Some(json!({"version": 1})),
+            },
+            1,
+            None,
+        )
+        .unwrap();
+
+        let col = mgr.get("col").unwrap();
+        assert_eq!(col.len(), 1);
+        assert_eq!(
+            col.get(5).unwrap(),
+            Some((vec![1.0, 2.0, 3.0], Some(json!({"version": 1}))))
+        );
+    }
+
+    #[test]
+    fn replaying_insert_uses_last_write_wins() {
+        let mut mgr = manager_with_collection();
+        apply_op(
+            &mut mgr,
+            WalOp::Insert {
+                collection: "col".into(),
+                id: 5,
+                vector: vec![1.0, 2.0, 3.0],
+                payload: Some(json!({"version": 1})),
+            },
+            1,
+            None,
+        )
+        .unwrap();
+        apply_op(
+            &mut mgr,
+            WalOp::Insert {
+                collection: "col".into(),
+                id: 5,
+                vector: vec![3.0, 2.0, 1.0],
+                payload: Some(json!({"version": 2})),
+            },
+            2,
+            None,
+        )
+        .unwrap();
+
+        let col = mgr.get("col").unwrap();
+        assert_eq!(col.len(), 1);
+        assert_eq!(
+            col.get(5).unwrap(),
+            Some((vec![3.0, 2.0, 1.0], Some(json!({"version": 2}))))
+        );
+    }
+
+    #[test]
+    fn replaying_delete_of_missing_vector_is_idempotent() {
+        let mut mgr = manager_with_collection();
+
+        apply_op(
+            &mut mgr,
+            WalOp::Delete {
+                collection: "col".into(),
+                id: 5,
+            },
+            1,
+            None,
+        )
+        .unwrap();
+        apply_op(
+            &mut mgr,
+            WalOp::Delete {
+                collection: "col".into(),
+                id: 5,
+            },
+            1,
+            None,
+        )
+        .unwrap();
+
+        assert!(mgr.get("col").unwrap().get(5).unwrap().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- skip exact duplicate WAL inserts already present in recovered snapshot state
- apply differing inserts and deletes through the shared idempotent delta path
- add regression coverage for duplicate inserts, last-write-wins updates, and repeated missing-vector deletes

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist --all-features` — passed (3 unit, 8 round-trip, 15 WAL recovery tests; 1 doctest ignored)
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed

Closes #34