### PR TITLE
#36 wal: add format version validation

### DIFF
--- a/crates/likhadb-persist/src/error.rs
+++ b/crates/likhadb-persist/src/error.rs
@@ -8,6 +8,8 @@ pub enum PersistError {
     Encode(#[source] bincode::Error),
     #[error("decode error: {0}")]
     Decode(#[source] bincode::Error),
+    #[error("unsupported WAL version {found}; maximum supported version is {max}")]
+    UnsupportedVersion { found: u8, max: u8 },
     #[error("WAL CRC mismatch at mid-log frame: expected {expected:#010x}, got {got:#010x}")]
     Crc { expected: u32, got: u32 },
     #[error("WAL replay error: {0}")]

--- a/crates/likhadb-persist/src/wal/entry.rs
+++ b/crates/likhadb-persist/src/wal/entry.rs
@@ -1,6 +1,13 @@
 use likhadb_core::{Metric, SourceBinding, VecId};
 use serde_json::Value;
 
+/// WAL entry format emitted and understood by this release.
+///
+/// The version is serialized as the first byte of every [`WalEntry`] so a
+/// reader can reject an unsupported format before attempting to decode a
+/// potentially unknown [`WalOp`] variant.
+pub const CURRENT_WAL_VERSION: u8 = 1;
+
 /// Index configuration captured at collection-creation time so WAL replay can
 /// reconstruct the right index type without touching the store layer.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -54,8 +61,19 @@ pub enum WalOp {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct WalEntry {
+    pub version: u8,
     pub lsn: u64,
     pub op: WalOp,
+}
+
+impl WalEntry {
+    pub fn new(lsn: u64, op: WalOp) -> Self {
+        Self {
+            version: CURRENT_WAL_VERSION,
+            lsn,
+            op,
+        }
+    }
 }
 
 /// Serialize `Option<serde_json::Value>` as `Option<String>` so bincode (which

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -2,7 +2,7 @@ mod entry;
 mod frame;
 mod recovery;
 
-pub use entry::{IndexKind, WalEntry, WalOp};
+pub use entry::{IndexKind, WalEntry, WalOp, CURRENT_WAL_VERSION};
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Write};
@@ -16,6 +16,25 @@ use serde_json::Value;
 use crate::{bincode_opts, PersistError};
 use frame::{checksum, write_frame, FrameIter};
 use recovery::apply_op;
+
+fn decode_entry(payload: &[u8]) -> Result<WalEntry, PersistError> {
+    // `version` is deliberately the first serialized field, and bincode
+    // encodes a u8 as one byte. Inspect it before decoding `WalOp` so future
+    // variants produce a useful version error instead of a generic decode
+    // failure.
+    if let Some(&found) = payload.first() {
+        if found != CURRENT_WAL_VERSION {
+            return Err(PersistError::UnsupportedVersion {
+                found,
+                max: CURRENT_WAL_VERSION,
+            });
+        }
+    }
+
+    bincode_opts()
+        .deserialize(payload)
+        .map_err(PersistError::Decode)
+}
 
 // ── WalWriter ──────────────────────────────────────────────────────────────
 
@@ -201,9 +220,7 @@ impl WalManager {
                 });
             }
 
-            let entry: WalEntry = bincode_opts()
-                .deserialize(&payload)
-                .map_err(PersistError::Decode)?;
+            let entry = decode_entry(&payload)?;
 
             if entry.lsn <= snapshot_lsn {
                 continue;
@@ -222,10 +239,7 @@ impl WalManager {
         F: FnOnce(&mut CollectionManager) -> likhadb_core::Result<()>,
     {
         let _span = tracing::debug_span!("wal_append", lsn = self.next_lsn).entered();
-        let entry = WalEntry {
-            lsn: self.next_lsn,
-            op,
-        };
+        let entry = WalEntry::new(self.next_lsn, op);
         self.wal.append(&entry)?;
         #[cfg(feature = "iceberg-recovery")]
         if let Ok(payload) = bincode_opts().serialize(&entry) {
@@ -282,9 +296,7 @@ impl WalManager {
                 if frame::checksum(&payload) != stored_crc {
                     break; // Treat corrupt tail as end of log.
                 }
-                let entry: WalEntry = bincode_opts()
-                    .deserialize(&payload)
-                    .map_err(PersistError::Decode)?;
+                let entry = decode_entry(&payload)?;
                 if entry.lsn > watermark {
                     kept.push(entry);
                 }
@@ -419,15 +431,15 @@ impl WalManager {
         let col = collection.to_owned();
         let lsn = self.next_lsn;
         let _span = tracing::debug_span!("wal_append", lsn = lsn).entered();
-        let entry = WalEntry {
+        let entry = WalEntry::new(
             lsn,
-            op: WalOp::Insert {
+            WalOp::Insert {
                 collection: col.clone(),
                 id,
                 vector: vector.clone(),
                 payload: payload.clone(),
             },
-        };
+        );
         self.wal.append(&entry)?;
         #[cfg(feature = "iceberg-recovery")]
         if let Ok(payload_bytes) = bincode_opts().serialize(&entry) {
@@ -443,13 +455,13 @@ impl WalManager {
     pub fn delete(&mut self, collection: &str, id: VecId) -> Result<bool, PersistError> {
         let col = collection.to_owned();
         let lsn = self.next_lsn;
-        let entry = WalEntry {
+        let entry = WalEntry::new(
             lsn,
-            op: WalOp::Delete {
+            WalOp::Delete {
                 collection: col.clone(),
                 id,
             },
-        };
+        );
         self.wal.append(&entry)?;
         #[cfg(feature = "iceberg-recovery")]
         if let Ok(payload) = bincode_opts().serialize(&entry) {

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,5 +1,5 @@
 use likhadb_core::Metric;
-use likhadb_persist::{PersistError, WalManager};
+use likhadb_persist::{wal::CURRENT_WAL_VERSION, PersistError, WalManager};
 use serde_json::json;
 
 fn tmp_dir(label: &str) -> std::path::PathBuf {
@@ -15,6 +15,43 @@ fn open_empty_dir_succeeds() {
     let dir = tmp_dir("open_empty");
     let mgr = WalManager::open(&dir).unwrap();
     assert!(mgr.list().is_empty());
+}
+
+#[test]
+fn wal_entry_starts_with_current_format_version() {
+    let dir = tmp_dir("format_version");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+    }
+
+    let wal = std::fs::read(dir.join("wal.log")).unwrap();
+    assert!(wal.len() > 8, "WAL must contain a complete frame");
+    assert_eq!(wal[8], CURRENT_WAL_VERSION);
+}
+
+#[test]
+fn unsupported_wal_version_is_reported_before_entry_decode() {
+    let dir = tmp_dir("unsupported_version");
+    let future_version = CURRENT_WAL_VERSION.checked_add(1).unwrap();
+    let payload = [future_version];
+    let checksum = crc32fast::hash(&payload);
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&checksum.to_le_bytes());
+    frame.extend_from_slice(&payload);
+    std::fs::write(dir.join("wal.log"), frame).unwrap();
+
+    let result = WalManager::open(&dir);
+    assert!(
+        matches!(
+            result,
+            Err(PersistError::UnsupportedVersion { found, max })
+                if found == future_version && max == CURRENT_WAL_VERSION
+        ),
+        "future WAL format should surface PersistError::UnsupportedVersion"
+    );
 }
 
 // ── Insert survives restart ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `CURRENT_WAL_VERSION` and serialize the version as the first byte of every `WalEntry`
- validate the version before decoding `WalOp`, returning a clear `UnsupportedVersion` error for unsupported formats
- apply version-aware decoding during normal recovery and Iceberg WAL truncation, with regression coverage for emitted and future versions

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist --all-features` — passed (8 round-trip tests, 17 WAL recovery tests; 1 doctest ignored)
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed

Closes #36