### PR TITLE
#37 wal: add group-committed batch insert API

### DIFF
--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -32,17 +32,34 @@ impl WalWriter {
     }
 
     fn append(&mut self, entry: &WalEntry) -> Result<(), PersistError> {
-        let payload = bincode_opts()
-            .serialize(entry)
-            .map_err(PersistError::Encode)?;
-        // Frame layout: 4-byte length prefix + 4-byte CRC + payload
-        let frame_bytes = 8u64 + payload.len() as u64;
-        write_frame(&mut self.file, &payload).map_err(PersistError::Io)?;
+        self.append_batch(std::slice::from_ref(entry)).map(|_| ())
+    }
+
+    /// Serialize and durably append a group of entries with one flush/fsync.
+    ///
+    /// Serialization finishes before the first frame is written, so an encode
+    /// failure cannot leave a partially-written batch in the WAL.
+    fn append_batch(&mut self, entries: &[WalEntry]) -> Result<Vec<Vec<u8>>, PersistError> {
+        let payloads: Vec<Vec<u8>> = entries
+            .iter()
+            .map(|entry| {
+                bincode_opts()
+                    .serialize(entry)
+                    .map_err(PersistError::Encode)
+            })
+            .collect::<Result<_, _>>()?;
+
+        let mut frame_bytes = 0u64;
+        for payload in &payloads {
+            write_frame(&mut self.file, payload).map_err(PersistError::Io)?;
+            // Frame layout: 4-byte length prefix + 4-byte CRC + payload.
+            frame_bytes += 8u64 + payload.len() as u64;
+        }
         self.file.flush().map_err(PersistError::Io)?;
         self.file.get_mut().sync_data().map_err(PersistError::Io)?;
         metrics::counter!("likhadb_wal_bytes_written_total").increment(frame_bytes);
-        metrics::counter!("likhadb_wal_appends_total").increment(1);
-        Ok(())
+        metrics::counter!("likhadb_wal_appends_total").increment(entries.len() as u64);
+        Ok(payloads)
     }
 
     fn truncate(path: &Path) -> std::io::Result<()> {
@@ -438,6 +455,93 @@ impl WalManager {
             .get_mut(&col)?
             .insert(id, vector, payload, lsn)
             .map_err(PersistError::Apply)
+    }
+
+    /// Durably insert a group of vectors using a single WAL flush and fsync.
+    ///
+    /// The entire batch is validated and serialized before any WAL frame is
+    /// written. Each row still receives its own LSN, preserving replay order,
+    /// while the collection can use its optimized bulk-index construction path.
+    pub fn insert_batch(
+        &mut self,
+        collection: &str,
+        items: impl IntoIterator<Item = (VecId, Vector, Option<Value>)>,
+    ) -> Result<usize, PersistError> {
+        let rows: Vec<_> = items.into_iter().collect();
+        let expected_dim = self.inner.get(collection)?.dim;
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        // Validate before logging so a bad row cannot make an otherwise
+        // rejected batch durable and break recovery on the next restart.
+        if let Some((_, vector, _)) = rows
+            .iter()
+            .find(|(_, vector, _)| vector.len() != expected_dim)
+        {
+            return Err(PersistError::Apply(
+                likhadb_core::LikhaDbError::DimMismatch {
+                    expected: expected_dim,
+                    got: vector.len(),
+                },
+            ));
+        }
+
+        let count = rows.len();
+        let count_u64 = u64::try_from(count).map_err(|_| {
+            PersistError::Apply(likhadb_core::LikhaDbError::InvalidArgument(
+                "WAL batch length exceeds u64".to_owned(),
+            ))
+        })?;
+        let next_lsn = self.next_lsn.checked_add(count_u64).ok_or_else(|| {
+            PersistError::Apply(likhadb_core::LikhaDbError::InvalidArgument(
+                "WAL LSN overflow".to_owned(),
+            ))
+        })?;
+        let col = collection.to_owned();
+        let entries: Vec<_> = rows
+            .iter()
+            .enumerate()
+            .map(|(offset, (id, vector, payload))| WalEntry {
+                lsn: self.next_lsn + offset as u64,
+                op: WalOp::Insert {
+                    collection: col.clone(),
+                    id: *id,
+                    vector: vector.clone(),
+                    payload: payload.clone(),
+                },
+            })
+            .collect();
+
+        let _span = tracing::debug_span!(
+            "wal_append_batch",
+            first_lsn = self.next_lsn,
+            entries = count
+        )
+        .entered();
+        let serialized = self.wal.append_batch(&entries)?;
+        #[cfg(feature = "iceberg-recovery")]
+        self.unflushed.extend(
+            entries
+                .iter()
+                .zip(serialized)
+                .map(|(entry, payload)| (entry.lsn, payload)),
+        );
+        #[cfg(not(feature = "iceberg-recovery"))]
+        drop(serialized);
+        self.next_lsn = next_lsn;
+
+        let rows_with_lsns = rows
+            .into_iter()
+            .enumerate()
+            .map(|(offset, (id, vector, payload))| (id, vector, payload, entries[offset].lsn))
+            .collect();
+        self.inner
+            .get_mut(&col)?
+            .insert_batch_with_lsns(rows_with_lsns)
+            .map_err(PersistError::Apply)?;
+
+        Ok(count)
     }
 
     pub fn delete(&mut self, collection: &str, id: VecId) -> Result<bool, PersistError> {

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -41,6 +41,174 @@ fn insert_survives_restart() {
     assert_eq!(results.len(), 10);
 }
 
+// ── Batch insert uses one group commit and survives restart ────────────────
+
+#[test]
+fn batch_insert_survives_restart() {
+    let dir = tmp_dir("batch_insert_restart");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+        let inserted = mgr
+            .insert_batch(
+                "col",
+                [
+                    (1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"tag": "first"}))),
+                    (2, vec![2.0, 0.0, 0.0, 0.0], None),
+                    (3, vec![3.0, 0.0, 0.0, 0.0], Some(json!({"tag": "third"}))),
+                ],
+            )
+            .unwrap();
+        assert_eq!(inserted, 3);
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let col = mgr.get("col").unwrap();
+    assert_eq!(col.len(), 3);
+    assert_eq!(col.get(1).unwrap().unwrap().1.unwrap()["tag"], "first");
+    assert_eq!(col.get(3).unwrap().unwrap().1.unwrap()["tag"], "third");
+}
+
+#[test]
+fn empty_batch_does_not_write_to_wal() {
+    let dir = tmp_dir("empty_batch");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("col", 4, Metric::L2).unwrap();
+    let wal_path = dir.join("wal.log");
+    let len_before = std::fs::metadata(&wal_path).unwrap().len();
+
+    let inserted = mgr
+        .insert_batch(
+            "col",
+            std::iter::empty::<(u64, Vec<f32>, Option<serde_json::Value>)>(),
+        )
+        .unwrap();
+
+    assert_eq!(inserted, 0);
+    assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), len_before);
+    assert!(mgr.get("col").unwrap().is_empty());
+}
+
+#[test]
+fn invalid_batch_is_rejected_before_wal_write() {
+    let dir = tmp_dir("invalid_batch");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("col", 4, Metric::L2).unwrap();
+    let wal_path = dir.join("wal.log");
+    let len_before = std::fs::metadata(&wal_path).unwrap().len();
+
+    let result = mgr.insert_batch(
+        "col",
+        [
+            (1, vec![1.0, 0.0, 0.0, 0.0], None),
+            (2, vec![2.0, 0.0, 0.0], None),
+        ],
+    );
+
+    assert!(matches!(
+        result,
+        Err(PersistError::Apply(
+            likhadb_core::LikhaDbError::DimMismatch {
+                expected: 4,
+                got: 3
+            }
+        ))
+    ));
+    assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), len_before);
+    assert!(mgr.get("col").unwrap().is_empty());
+}
+
+#[test]
+fn batch_insert_preserves_duplicate_input_order() {
+    let dir = tmp_dir("batch_duplicate_ids");
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_hnsw_collection("col", 4, Metric::L2, 4, 8, 4)
+            .unwrap();
+        mgr.insert_batch(
+            "col",
+            [
+                (7, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"v": 1}))),
+                (7, vec![2.0, 0.0, 0.0, 0.0], Some(json!({"v": 2}))),
+            ],
+        )
+        .unwrap();
+
+        let (vector, payload) = mgr.get("col").unwrap().get(7).unwrap().unwrap();
+        assert_eq!(vector, vec![2.0, 0.0, 0.0, 0.0]);
+        assert_eq!(payload.unwrap()["v"], 2);
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let (vector, payload) = mgr.get("col").unwrap().get(7).unwrap().unwrap();
+    assert_eq!(vector, vec![2.0, 0.0, 0.0, 0.0]);
+    assert_eq!(payload.unwrap()["v"], 2);
+}
+
+#[cfg(feature = "fts")]
+#[test]
+fn batch_insert_indexes_every_payload_for_fts() {
+    let dir = tmp_dir("batch_fts");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("docs", 4, Metric::L2).unwrap();
+    mgr.enable_fts("docs").unwrap();
+
+    mgr.insert_batch(
+        "docs",
+        [
+            (
+                1,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(json!({"body": "alpha canary"})),
+            ),
+            (
+                2,
+                vec![2.0, 0.0, 0.0, 0.0],
+                Some(json!({"body": "beta canary"})),
+            ),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        mgr.get("docs").unwrap().fts_search("alpha", 5).unwrap()[0].id,
+        1
+    );
+    assert_eq!(
+        mgr.get("docs").unwrap().fts_search("beta", 5).unwrap()[0].id,
+        2
+    );
+}
+
+#[cfg(feature = "iceberg-recovery")]
+#[test]
+fn batch_insert_tracks_each_unflushed_entry() {
+    let dir = tmp_dir("batch_unflushed");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("col", 4, Metric::L2).unwrap();
+    mgr.set_iceberg_watermark(1);
+
+    mgr.insert_batch(
+        "col",
+        [
+            (1, vec![1.0, 0.0, 0.0, 0.0], None),
+            (2, vec![2.0, 0.0, 0.0, 0.0], None),
+        ],
+    )
+    .unwrap();
+
+    let unflushed = mgr.collect_unflushed();
+    assert_eq!(
+        unflushed.iter().map(|entry| entry.lsn).collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+    assert!(unflushed
+        .iter()
+        .all(|entry| matches!(&entry.op, likhadb_persist::wal::WalOp::Insert { .. })));
+}
+
 // ── Delete survives restart ────────────────────────────────────────────────
 
 #[test]

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -185,12 +185,27 @@ impl Collection {
         rows: Vec<(VecId, Vector, Option<Value>)>,
         lsn: u64,
     ) -> Result<()> {
+        self.insert_batch_with_lsns(
+            rows.into_iter()
+                .map(|(id, vector, payload)| (id, vector, payload, lsn))
+                .collect(),
+        )
+    }
+
+    /// Insert a batch whose rows have distinct WAL sequence numbers.
+    ///
+    /// This keeps bulk index construction available to persistence callers
+    /// while ensuring payload and FTS updates observe each row's actual LSN.
+    pub fn insert_batch_with_lsns(
+        &mut self,
+        rows: Vec<(VecId, Vector, Option<Value>, u64)>,
+    ) -> Result<()> {
         let index_rows: Vec<_> = rows
             .iter()
-            .map(|(id, vector, _)| (*id, vector.clone()))
+            .map(|(id, vector, _, _)| (*id, vector.clone()))
             .collect();
         self.index.insert_batch(&index_rows)?;
-        for (id, _, payload) in rows {
+        for (id, _, payload, lsn) in rows {
             self.apply_insert_payload(id, payload, lsn)?;
         }
         Ok(())


### PR DESCRIPTION
## Summary
- add `WalManager::insert_batch` with one WAL flush and `sync_data` per batch while preserving one ordered LSN per row
- validate the full batch before logging and use the collection bulk-index path with per-row payload/FTS LSN handling
- preserve Iceberg unflushed-entry tracking and cover restart recovery, empty/invalid batches, duplicate ordering, FTS, and Iceberg behavior

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist --all-features` — passed (8 round-trip tests, 21 WAL recovery tests; 1 doctest ignored)
- `cargo clippy -p likhadb-persist --all-targets --all-features -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed

Closes #37