### PR TITLE
#38 wal: add optional zstd frame compression

### DIFF
--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [features]
 fts              = ["likhadb-store/fts"]
 iceberg-recovery = []
+zstd             = ["dep:zstd"]
 
 [dependencies]
 likhadb-core  = { path = "../likhadb-core" }
@@ -19,6 +20,7 @@ serde_json    = { workspace = true }
 crc32fast     = "1"
 metrics       = "0.23"
 tracing       = "0.1"
+zstd          = { version = "0.13", optional = true }
 
 [dev-dependencies]
 rand          = { workspace = true }

--- a/crates/likhadb-persist/src/lib.rs
+++ b/crates/likhadb-persist/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 pub mod wal;
 
 pub use error::PersistError;
-pub use wal::{WalConfig, WalManager};
+pub use wal::{Compression, WalConfig, WalManager};
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};

--- a/crates/likhadb-persist/src/wal/frame.rs
+++ b/crates/likhadb-persist/src/wal/frame.rs
@@ -2,9 +2,72 @@ use std::io::{self, Read, Write};
 
 use crc32fast::Hasher;
 
+use super::Compression;
+
+const FLAG_ZSTD: u8 = 0x01;
+const KNOWN_FLAGS: u8 = FLAG_ZSTD;
+
+/// Add the per-frame flags byte and optionally compress the serialized entry.
+///
+/// Compression is kept only when it makes the frame smaller, so enabling zstd
+/// cannot inflate small WAL operations such as collection creation or deletes.
+pub fn encode_payload(payload: &[u8], compression: &Compression) -> io::Result<Vec<u8>> {
+    let (flags, encoded) = match compression {
+        Compression::None => (0, payload.to_vec()),
+        #[cfg(feature = "zstd")]
+        Compression::Zstd { level } => {
+            let compressed = zstd::stream::encode_all(payload, *level)?;
+            if compressed.len() < payload.len() {
+                (FLAG_ZSTD, compressed)
+            } else {
+                (0, payload.to_vec())
+            }
+        }
+    };
+
+    let mut framed = Vec::with_capacity(1 + encoded.len());
+    framed.push(flags);
+    framed.extend_from_slice(&encoded);
+    Ok(framed)
+}
+
+/// Remove the flags byte and decompress a frame payload when required.
+pub fn decode_payload(payload: Vec<u8>) -> io::Result<Vec<u8>> {
+    let Some((&flags, encoded)) = payload.split_first() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "WAL frame payload is missing its flags byte",
+        ));
+    };
+
+    if flags & !KNOWN_FLAGS != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("WAL frame uses unsupported flags {flags:#04x}"),
+        ));
+    }
+
+    if flags & FLAG_ZSTD != 0 {
+        #[cfg(feature = "zstd")]
+        {
+            return zstd::stream::decode_all(encoded);
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "WAL frame is zstd-compressed but likhadb-persist was built without the `zstd` feature",
+            ));
+        }
+    }
+
+    Ok(encoded.to_vec())
+}
+
 /// Write a length-prefixed, CRC32-checksummed frame.
 ///
-/// Format: `[payload_len: u32 LE][crc32: u32 LE][payload: payload_len bytes]`
+/// Format: `[payload_len: u32 LE][crc32: u32 LE][flags: u8][payload bytes]`.
+/// The length and CRC cover the flags byte plus the encoded payload.
 pub fn write_frame(w: &mut impl Write, payload: &[u8]) -> io::Result<()> {
     let len = payload.len() as u32;
     let crc = checksum(payload);

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -14,31 +14,48 @@ use likhadb_store::{Collection, CollectionManager};
 use serde_json::Value;
 
 use crate::{bincode_opts, PersistError};
-use frame::{checksum, write_frame, FrameIter};
+use frame::{checksum, decode_payload, encode_payload, write_frame, FrameIter};
 use recovery::apply_op;
+
+/// Compression used for newly appended WAL frames.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Compression {
+    /// Store serialized WAL entries without compression.
+    #[default]
+    None,
+    /// Compress entries with zstd at the supplied compression level.
+    ///
+    /// Requires the `zstd` crate feature. Frames that do not become smaller
+    /// are stored raw even when this option is selected.
+    #[cfg(feature = "zstd")]
+    Zstd { level: i32 },
+}
 
 // ── WalWriter ──────────────────────────────────────────────────────────────
 
 struct WalWriter {
     file: BufWriter<File>,
     bytes_written: u64,
+    compression: Compression,
 }
 
 impl WalWriter {
-    fn open_append(path: &Path) -> std::io::Result<Self> {
+    fn open_append(path: &Path, compression: Compression) -> std::io::Result<Self> {
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         let bytes_written = file.metadata()?.len();
         Ok(Self {
             file: BufWriter::new(file),
             bytes_written,
+            compression,
         })
     }
 
     fn append(&mut self, entry: &WalEntry) -> Result<(), PersistError> {
-        let payload = bincode_opts()
+        let serialized = bincode_opts()
             .serialize(entry)
             .map_err(PersistError::Encode)?;
-        // Frame layout: 4-byte length prefix + 4-byte CRC + payload
+        let payload = encode_payload(&serialized, &self.compression).map_err(PersistError::Io)?;
+        // Frame layout: 4-byte length prefix + 4-byte CRC + flags + payload.
         let frame_bytes = 8u64 + payload.len() as u64;
         write_frame(&mut self.file, &payload).map_err(PersistError::Io)?;
         self.file.flush().map_err(PersistError::Io)?;
@@ -67,6 +84,8 @@ pub struct WalConfig {
     pub checkpoint_every_n_entries: u64,
     /// Trigger a checkpoint after `wal.log` reaches this size (`0` = disabled).
     pub checkpoint_every_n_bytes: u64,
+    /// Compression used for newly appended frames.
+    pub compression: Compression,
 }
 
 impl Default for WalConfig {
@@ -74,6 +93,7 @@ impl Default for WalConfig {
         Self {
             checkpoint_every_n_entries: 100_000,
             checkpoint_every_n_bytes: 256 * 1024 * 1024,
+            compression: Compression::None,
         }
     }
 }
@@ -156,7 +176,8 @@ impl WalManager {
         }
 
         // 3. Open WAL for appending.
-        let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        let wal = WalWriter::open_append(&wal_path, config.compression.clone())
+            .map_err(PersistError::Io)?;
 
         Ok(Self {
             inner,
@@ -212,7 +233,8 @@ impl WalManager {
                 Self::replay_wal(&wal_path, &mut inner, iceberg_watermark, dir)?;
         }
 
-        let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        let wal = WalWriter::open_append(&wal_path, config.compression.clone())
+            .map_err(PersistError::Io)?;
         Ok(Self {
             inner,
             wal,
@@ -258,8 +280,9 @@ impl WalManager {
                 });
             }
 
+            let decoded = decode_payload(payload).map_err(PersistError::Io)?;
             let entry: WalEntry = bincode_opts()
-                .deserialize(&payload)
+                .deserialize(&decoded)
                 .map_err(PersistError::Decode)?;
             wal_entries = wal_entries.saturating_add(1);
 
@@ -355,8 +378,9 @@ impl WalManager {
                 if frame::checksum(&payload) != stored_crc {
                     break; // Treat corrupt tail as end of log.
                 }
+                let decoded = frame::decode_payload(payload).map_err(PersistError::Io)?;
                 let entry: WalEntry = bincode_opts()
-                    .deserialize(&payload)
+                    .deserialize(&decoded)
                     .map_err(PersistError::Decode)?;
                 if entry.lsn > watermark {
                     kept.push(entry);
@@ -375,7 +399,9 @@ impl WalManager {
                 let payload = bincode_opts()
                     .serialize(entry)
                     .map_err(PersistError::Encode)?;
-                frame::write_frame(&mut writer, &payload).map_err(PersistError::Io)?;
+                let encoded = frame::encode_payload(&payload, &self.config.compression)
+                    .map_err(PersistError::Io)?;
+                frame::write_frame(&mut writer, &encoded).map_err(PersistError::Io)?;
             }
             writer.flush().map_err(PersistError::Io)?;
             writer.get_mut().sync_all().map_err(PersistError::Io)?;
@@ -383,7 +409,8 @@ impl WalManager {
 
         // Atomic rename then reopen.
         std::fs::rename(&tmp_path, &wal_path).map_err(PersistError::Io)?;
-        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal = WalWriter::open_append(&wal_path, self.config.compression.clone())
+            .map_err(PersistError::Io)?;
         self.wal_entries = entries_to_keep.len() as u64;
 
         Ok(())
@@ -581,7 +608,8 @@ impl WalManager {
 
         // Truncate WAL and reopen for appending.
         WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;
-        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal = WalWriter::open_append(&wal_path, self.config.compression.clone())
+            .map_err(PersistError::Io)?;
         self.wal_entries = 0;
 
         Ok(())

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,5 +1,5 @@
 use likhadb_core::Metric;
-use likhadb_persist::{PersistError, WalConfig, WalManager};
+use likhadb_persist::{Compression, PersistError, WalConfig, WalManager};
 use serde_json::json;
 
 fn tmp_dir(label: &str) -> std::path::PathBuf {
@@ -22,6 +22,147 @@ fn wal_config_has_bounded_defaults() {
     let config = WalConfig::default();
     assert_eq!(config.checkpoint_every_n_entries, 100_000);
     assert_eq!(config.checkpoint_every_n_bytes, 256 * 1024 * 1024);
+    assert_eq!(config.compression, Compression::None);
+}
+
+#[test]
+fn uncompressed_frames_include_a_clear_flags_byte() {
+    let dir = tmp_dir("raw_frame_flags");
+    let config = WalConfig {
+        checkpoint_every_n_entries: 0,
+        checkpoint_every_n_bytes: 0,
+        compression: Compression::None,
+    };
+
+    {
+        let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+        mgr.create_collection("col", 4, Metric::L2).unwrap();
+    }
+
+    let wal = std::fs::read(dir.join("wal.log")).unwrap();
+    assert!(wal.len() > 8);
+    assert_eq!(wal[8], 0, "raw frames must clear all compression flags");
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn zstd_frames_are_smaller_and_recover_across_mixed_write_settings() {
+    fn write_compressible_wal(dir: &std::path::Path, compression: Compression) {
+        let config = WalConfig {
+            checkpoint_every_n_entries: 0,
+            checkpoint_every_n_bytes: 0,
+            compression,
+        };
+        let mut mgr = WalManager::open_with_config(dir, config).unwrap();
+        mgr.create_collection("col", 384, Metric::L2).unwrap();
+        for id in 0..16 {
+            mgr.insert(
+                "col",
+                id,
+                vec![0.25; 384],
+                Some(json!({"text": "repeated payload ".repeat(128)})),
+            )
+            .unwrap();
+        }
+    }
+
+    fn frame_flags(path: &std::path::Path) -> Vec<u8> {
+        let wal = std::fs::read(path).unwrap();
+        let mut flags = Vec::new();
+        let mut offset = 0usize;
+        while offset < wal.len() {
+            let payload_len =
+                u32::from_le_bytes(wal[offset..offset + 4].try_into().unwrap()) as usize;
+            assert!(payload_len >= 1);
+            flags.push(wal[offset + 8]);
+            offset += 8 + payload_len;
+        }
+        assert_eq!(offset, wal.len());
+        flags
+    }
+
+    let raw_dir = tmp_dir("zstd_size_raw");
+    let compressed_dir = tmp_dir("zstd_size_compressed");
+    write_compressible_wal(&raw_dir, Compression::None);
+    write_compressible_wal(&compressed_dir, Compression::Zstd { level: 1 });
+
+    let raw_path = raw_dir.join("wal.log");
+    let compressed_path = compressed_dir.join("wal.log");
+    let raw_size = std::fs::metadata(&raw_path).unwrap().len();
+    let compressed_size = std::fs::metadata(&compressed_path).unwrap().len();
+    assert!(
+        compressed_size * 2 < raw_size,
+        "expected zstd WAL ({compressed_size} bytes) to be less than half the raw WAL ({raw_size} bytes)"
+    );
+    assert!(frame_flags(&raw_path).iter().all(|flag| *flag == 0));
+    assert!(
+        frame_flags(&compressed_path)
+            .iter()
+            .any(|flag| flag & 0x01 != 0),
+        "at least one compressible frame should carry the zstd flag"
+    );
+
+    // The frame flag, rather than the current write configuration, controls
+    // recovery. Reopen with compression disabled and append a raw frame.
+    {
+        let config = WalConfig {
+            checkpoint_every_n_entries: 0,
+            checkpoint_every_n_bytes: 0,
+            compression: Compression::None,
+        };
+        let mut mgr = WalManager::open_with_config(&compressed_dir, config).unwrap();
+        mgr.insert("col", 99, vec![0.5; 384], None).unwrap();
+    }
+
+    let mixed_flags = frame_flags(&compressed_path);
+    assert_eq!(mixed_flags.last(), Some(&0));
+    let mgr = WalManager::open(&compressed_dir).unwrap();
+    let results = mgr
+        .get("col")
+        .unwrap()
+        .search(&vec![0.25; 384], 32, None, true)
+        .unwrap();
+    assert_eq!(results.len(), 17);
+    assert_eq!(
+        results
+            .iter()
+            .find(|result| result.id == 0)
+            .unwrap()
+            .payload
+            .as_ref()
+            .unwrap()["text"],
+        json!("repeated payload ".repeat(128))
+    );
+}
+
+#[cfg(all(feature = "iceberg-recovery", feature = "zstd"))]
+#[test]
+fn zstd_frames_survive_iceberg_wal_rewrite() {
+    let dir = tmp_dir("zstd_iceberg_rewrite");
+    let config = WalConfig {
+        checkpoint_every_n_entries: 0,
+        checkpoint_every_n_bytes: 0,
+        compression: Compression::Zstd { level: 1 },
+    };
+
+    {
+        let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
+        mgr.create_collection("col", 128, Metric::L2).unwrap();
+        for id in 0..8 {
+            mgr.insert("col", id, vec![0.125; 128], None).unwrap();
+        }
+        // Keeping every entry still exercises the decode/re-encode path used
+        // when Iceberg advances its durable watermark.
+        mgr.truncate_wal_up_to(0).unwrap();
+    }
+
+    let mgr = WalManager::open(&dir).unwrap();
+    let results = mgr
+        .get("col")
+        .unwrap()
+        .search(&vec![0.125; 128], 16, None, false)
+        .unwrap();
+    assert_eq!(results.len(), 8);
 }
 
 // ── Insert survives restart ────────────────────────────────────────────────
@@ -197,6 +338,7 @@ fn auto_checkpoint_after_entry_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 2,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     {
@@ -227,6 +369,7 @@ fn auto_checkpoint_after_byte_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 1,
+        ..WalConfig::default()
     };
 
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
@@ -242,6 +385,7 @@ fn zero_auto_checkpoint_thresholds_disable_triggers() {
     let config = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
@@ -259,6 +403,7 @@ fn recovered_entries_count_toward_auto_checkpoint_threshold() {
     let disabled = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     {
@@ -269,6 +414,7 @@ fn recovered_entries_count_toward_auto_checkpoint_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 2,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
     mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None)


### PR DESCRIPTION
## Summary
- add an optional `zstd` feature and public `Compression` setting on `WalConfig`, defaulting to raw frames
- add a CRC-protected per-frame flags byte and selectively keep zstd output only when it reduces frame size
- decode mixed raw and compressed WAL frames during normal recovery and Iceberg WAL rewrites
- cover raw flags, compression ratio, mixed-mode restart recovery, payload recovery, and Iceberg rewrite behavior

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist` — passed (8 round-trip tests, 20 WAL recovery tests; 1 doctest ignored)
- `cargo test -p likhadb-persist --all-features` — passed (8 round-trip tests, 23 WAL recovery tests; 1 doctest ignored)
- `cargo clippy -p likhadb-persist --all-targets --all-features -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed

Closes #38