### PR TITLE
#39 wal: expose read-only WAL iterator

### DIFF
--- a/crates/likhadb-persist/src/lib.rs
+++ b/crates/likhadb-persist/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 pub mod wal;
 
 pub use error::PersistError;
-pub use wal::{WalConfig, WalManager};
+pub use wal::{WalConfig, WalManager, WalReader};
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};

--- a/crates/likhadb-persist/src/wal/entry.rs
+++ b/crates/likhadb-persist/src/wal/entry.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 /// Index configuration captured at collection-creation time so WAL replay can
 /// reconstruct the right index type without touching the store layer.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum IndexKind {
     Flat,
     Ivf {
@@ -21,7 +21,7 @@ pub enum IndexKind {
     },
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum WalOp {
     CreateCollection {
         name: String,
@@ -52,7 +52,7 @@ pub enum WalOp {
     },
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct WalEntry {
     pub lsn: u64,
     pub op: WalOp,

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -1,8 +1,10 @@
 mod entry;
 mod frame;
+mod reader;
 mod recovery;
 
 pub use entry::{IndexKind, WalEntry, WalOp};
+pub use reader::WalReader;
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Write};
@@ -14,7 +16,7 @@ use likhadb_store::{Collection, CollectionManager};
 use serde_json::Value;
 
 use crate::{bincode_opts, PersistError};
-use frame::{checksum, write_frame, FrameIter};
+use frame::write_frame;
 use recovery::apply_op;
 
 // ── WalWriter ──────────────────────────────────────────────────────────────
@@ -105,6 +107,10 @@ pub struct WalManager {
     wal_entries: u64,
     next_lsn: u64,
     dir: PathBuf,
+    /// Highest LSN already represented by the durable recovery baseline.
+    /// This is the snapshot LSN for normal recovery and the supplied
+    /// watermark for Iceberg recovery.
+    durable_lsn: u64,
     /// Highest LSN confirmed durably committed to Iceberg staging.  Zero means
     /// none.  Only meaningful when the `iceberg-recovery` feature is active.
     #[cfg(feature = "iceberg-recovery")]
@@ -117,7 +123,7 @@ pub struct WalManager {
 
 impl WalManager {
     const SNAPSHOT_FILE: &'static str = "snapshot.bin";
-    const WAL_FILE: &'static str = "wal.log";
+    pub(super) const WAL_FILE: &'static str = "wal.log";
 
     /// Open (or create) a data directory, recovering from any existing
     /// snapshot + WAL using [`WalConfig::default`].
@@ -165,6 +171,7 @@ impl WalManager {
             wal_entries,
             next_lsn,
             dir: dir.to_path_buf(),
+            durable_lsn: snapshot_lsn,
             #[cfg(feature = "iceberg-recovery")]
             iceberg_watermark: 0,
             #[cfg(feature = "iceberg-recovery")]
@@ -220,6 +227,7 @@ impl WalManager {
             wal_entries,
             next_lsn,
             dir: dir.to_path_buf(),
+            durable_lsn: iceberg_watermark,
             iceberg_watermark,
             unflushed: Vec::new(),
         })
@@ -233,34 +241,11 @@ impl WalManager {
         snapshot_lsn: u64,
         data_dir: &Path,
     ) -> Result<(u64, u64), PersistError> {
-        let file = File::open(path).map_err(PersistError::Io)?;
-        let reader = BufReader::new(file);
-        let mut iter = FrameIter::new(reader);
         let mut last_lsn = snapshot_lsn;
         let mut wal_entries = 0u64;
 
-        for item in &mut iter {
-            let (payload, stored_crc) = item.map_err(PersistError::Io)?;
-
-            let computed = checksum(&payload);
-            if computed != stored_crc {
-                // If no bytes follow this frame it is a crash-truncated tail
-                // (the last write never completed); discard it and stop replay.
-                // If bytes remain after it, the corruption is mid-log and must
-                // be surfaced as a hard error.
-                let more = iter.has_remaining_bytes().map_err(PersistError::Io)?;
-                if !more {
-                    break;
-                }
-                return Err(PersistError::Crc {
-                    expected: stored_crc,
-                    got: computed,
-                });
-            }
-
-            let entry: WalEntry = bincode_opts()
-                .deserialize(&payload)
-                .map_err(PersistError::Decode)?;
+        for item in WalReader::open_file(path)? {
+            let entry = item?;
             wal_entries = wal_entries.saturating_add(1);
 
             if entry.lsn <= snapshot_lsn {
@@ -319,6 +304,7 @@ impl WalManager {
     pub fn set_iceberg_watermark(&mut self, lsn: u64) {
         if lsn > self.iceberg_watermark {
             self.iceberg_watermark = lsn;
+            self.durable_lsn = self.durable_lsn.max(lsn);
             self.unflushed.retain(|(entry_lsn, _)| *entry_lsn > lsn);
         }
     }
@@ -554,6 +540,12 @@ impl WalManager {
         self.inner.list()
     }
 
+    /// Open a side-effect-free iterator over WAL entries newer than the
+    /// durable recovery baseline (normally the latest snapshot).
+    pub fn pending_entries(&self) -> Result<WalReader, PersistError> {
+        WalReader::open_after(&self.dir, self.durable_lsn)
+    }
+
     // ── Checkpoint ─────────────────────────────────────────────────────────
 
     /// Write a snapshot capturing the current state (including `last_lsn`),
@@ -578,6 +570,7 @@ impl WalManager {
             writer.get_mut().sync_all().map_err(PersistError::Io)?;
         }
         std::fs::rename(&tmp_path, &snapshot_path).map_err(PersistError::Io)?;
+        self.durable_lsn = last_lsn;
 
         // Truncate WAL and reopen for appending.
         WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;

--- a/crates/likhadb-persist/src/wal/reader.rs
+++ b/crates/likhadb-persist/src/wal/reader.rs
@@ -1,0 +1,98 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use bincode::Options as _;
+
+use crate::{bincode_opts, PersistError};
+
+use super::entry::WalEntry;
+use super::frame::{checksum, FrameIter};
+
+/// A read-only iterator over entries in `wal.log`.
+///
+/// Opening a reader never creates or modifies files and does not replay any
+/// operations. A crash-truncated or CRC-mismatched final frame is treated as
+/// an uncommitted tail and ignored, matching [`super::WalManager`] recovery.
+/// Corruption before the final frame is returned as an error.
+pub struct WalReader {
+    iter: FrameIter<BufReader<File>>,
+    after_lsn: Option<u64>,
+    done: bool,
+}
+
+impl WalReader {
+    /// Open `<dir>/wal.log` for side-effect-free inspection.
+    pub fn open(dir: &Path) -> Result<Self, PersistError> {
+        Self::open_path(&dir.join(super::WalManager::WAL_FILE), None)
+    }
+
+    pub(super) fn open_after(dir: &Path, after_lsn: u64) -> Result<Self, PersistError> {
+        Self::open_path(&dir.join(super::WalManager::WAL_FILE), Some(after_lsn))
+    }
+
+    pub(super) fn open_file(path: &Path) -> Result<Self, PersistError> {
+        Self::open_path(path, None)
+    }
+
+    fn open_path(path: &Path, after_lsn: Option<u64>) -> Result<Self, PersistError> {
+        let file = File::open(path).map_err(PersistError::Io)?;
+        Ok(Self {
+            iter: FrameIter::new(BufReader::new(file)),
+            after_lsn,
+            done: false,
+        })
+    }
+
+    fn fail(&mut self, error: PersistError) -> Option<Result<WalEntry, PersistError>> {
+        self.done = true;
+        Some(Err(error))
+    }
+}
+
+impl Iterator for WalReader {
+    type Item = Result<WalEntry, PersistError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        loop {
+            let (payload, stored_crc) = match self.iter.next()? {
+                Ok(frame) => frame,
+                Err(error) => return self.fail(PersistError::Io(error)),
+            };
+
+            let computed_crc = checksum(&payload);
+            if computed_crc != stored_crc {
+                return match self.iter.has_remaining_bytes() {
+                    // The final frame was not durably committed.
+                    Ok(false) => {
+                        self.done = true;
+                        None
+                    }
+                    Ok(true) => self.fail(PersistError::Crc {
+                        expected: stored_crc,
+                        got: computed_crc,
+                    }),
+                    Err(error) => self.fail(PersistError::Io(error)),
+                };
+            }
+
+            let entry: WalEntry = match bincode_opts().deserialize(&payload) {
+                Ok(entry) => entry,
+                Err(error) => return self.fail(PersistError::Decode(error)),
+            };
+
+            if self
+                .after_lsn
+                .is_some_and(|after_lsn| entry.lsn <= after_lsn)
+            {
+                continue;
+            }
+
+            return Some(Ok(entry));
+        }
+    }
+}

--- a/crates/likhadb-persist/tests/wal_reader.rs
+++ b/crates/likhadb-persist/tests/wal_reader.rs
@@ -1,0 +1,139 @@
+use std::io::{Seek, SeekFrom, Write};
+
+use likhadb_core::Metric;
+use likhadb_persist::wal::WalOp;
+use likhadb_persist::{PersistError, WalManager, WalReader};
+
+fn tmp_dir(label: &str) -> std::path::PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("likhadb_wal_reader_{label}_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn reader_inspects_entries_without_replay() {
+    let dir = tmp_dir("inspect");
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("docs", 2, Metric::Cosine).unwrap();
+        mgr.insert("docs", 7, vec![1.0, 0.0], None).unwrap();
+    }
+
+    let entries = WalReader::open(&dir)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].lsn, 1);
+    assert!(matches!(
+        &entries[0].op,
+        WalOp::CreateCollection { name, .. } if name == "docs"
+    ));
+    assert_eq!(entries[1].lsn, 2);
+    assert!(matches!(
+        &entries[1].op,
+        WalOp::Insert {
+            collection,
+            id: 7,
+            ..
+        } if collection == "docs"
+    ));
+}
+
+#[test]
+fn reader_does_not_create_a_missing_wal() {
+    let dir =
+        std::env::temp_dir().join(format!("likhadb_wal_reader_missing_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(matches!(WalReader::open(&dir), Err(PersistError::Io(_))));
+    assert!(!dir.exists());
+}
+
+#[test]
+fn pending_entries_exclude_records_already_in_snapshot() {
+    let dir = tmp_dir("pending");
+    let stale_wal;
+
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("docs", 2, Metric::L2).unwrap();
+        mgr.insert("docs", 1, vec![1.0, 0.0], None).unwrap();
+        stale_wal = std::fs::read(dir.join("wal.log")).unwrap();
+        mgr.checkpoint().unwrap();
+    }
+
+    // Simulate the recoverable state where snapshot rename succeeded but WAL
+    // truncation did not: the log still contains entries captured by snapshot.
+    std::fs::write(dir.join("wal.log"), stale_wal).unwrap();
+
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.insert("docs", 2, vec![2.0, 0.0], None).unwrap();
+
+    let all_lsns = WalReader::open(&dir)
+        .unwrap()
+        .map(|entry| entry.map(|entry| entry.lsn))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(all_lsns, vec![1, 2, 3]);
+
+    let pending_lsns = mgr
+        .pending_entries()
+        .unwrap()
+        .map(|entry| entry.map(|entry| entry.lsn))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(pending_lsns, vec![3]);
+}
+
+#[test]
+fn reader_reports_mid_log_crc_corruption_and_stops() {
+    let dir = tmp_dir("mid_log_crc");
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("docs", 2, Metric::L2).unwrap();
+        mgr.insert("docs", 1, vec![1.0, 0.0], None).unwrap();
+        mgr.insert("docs", 2, vec![2.0, 0.0], None).unwrap();
+    }
+
+    let wal_path = dir.join("wal.log");
+    let mut data = std::fs::read(&wal_path).unwrap();
+    let first_payload_len = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
+    let second_frame_start = 8 + first_payload_len;
+    data[second_frame_start + 8] ^= 0xff;
+    std::fs::write(&wal_path, data).unwrap();
+
+    let mut reader = WalReader::open(&dir).unwrap();
+    assert!(reader.next().unwrap().is_ok());
+    assert!(matches!(reader.next(), Some(Err(PersistError::Crc { .. }))));
+    assert!(reader.next().is_none());
+}
+
+#[test]
+fn reader_ignores_a_crc_mismatched_tail() {
+    let dir = tmp_dir("tail_crc");
+    {
+        let mut mgr = WalManager::open(&dir).unwrap();
+        mgr.create_collection("docs", 2, Metric::L2).unwrap();
+        mgr.insert("docs", 1, vec![1.0, 0.0], None).unwrap();
+    }
+
+    let wal_path = dir.join("wal.log");
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&wal_path)
+        .unwrap();
+    file.seek(SeekFrom::End(-1)).unwrap();
+    let last = std::fs::read(&wal_path).unwrap().last().copied().unwrap();
+    file.write_all(&[last ^ 0xff]).unwrap();
+
+    let entries = WalReader::open(&dir)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+    assert!(matches!(entries[0].op, WalOp::CreateCollection { .. }));
+}


### PR DESCRIPTION
## Summary
- add a public read-only WalReader that validates and deserializes WAL frames without replaying operations
- add WalManager::pending_entries to filter entries above the durable snapshot/recovery watermark
- share reader validation with WAL recovery and expose debug formatting for WAL entries
- cover inspection, missing files, stale pre-snapshot frames, mid-log corruption, and crash-tail handling

## Verification
- cargo fmt --all -- --check — passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- cargo test -p likhadb-persist --all-features — passed
- cargo test --workspace — passed
- Docker build check could not run locally because the Docker daemon is unavailable; repository CI will execute it

Closes #39
