### PR TITLE
#43 wal: keep checkpoint writer valid after truncation

### DIFF
--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -49,8 +49,10 @@ impl WalWriter {
         Ok(())
     }
 
-    fn truncate(path: &Path) -> std::io::Result<()> {
-        File::create(path)?; // O_TRUNC
+    fn truncate(&mut self) -> std::io::Result<()> {
+        self.file.flush()?;
+        self.file.get_mut().set_len(0)?;
+        self.bytes_written = 0;
         Ok(())
     }
 }
@@ -563,7 +565,6 @@ impl WalManager {
         let last_lsn = self.next_lsn.saturating_sub(1);
         let snapshot_path = self.dir.join(Self::SNAPSHOT_FILE);
         let tmp_path = self.dir.join("snapshot.bin.tmp");
-        let wal_path = self.dir.join(Self::WAL_FILE);
 
         // Write snapshot to tmp then atomically rename.
         {
@@ -579,11 +580,50 @@ impl WalManager {
         }
         std::fs::rename(&tmp_path, &snapshot_path).map_err(PersistError::Io)?;
 
-        // Truncate WAL and reopen for appending.
-        WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;
-        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        // Truncate through the existing, known-good handle.  Reopening after
+        // truncation could fail and leave the manager holding stale writer
+        // bookkeeping for a WAL that had already been cleared.
+        self.wal.truncate().map_err(PersistError::Io)?;
         self.wal_entries = 0;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use likhadb_core::Metric;
+
+    use super::WalManager;
+
+    #[test]
+    fn checkpoint_keeps_the_open_wal_handle() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "likhadb_checkpoint_handle_{}_{}",
+            std::process::id(),
+            unique
+        ));
+
+        let mut manager = WalManager::open(&dir).unwrap();
+        manager.create_collection("col", 4, Metric::L2).unwrap();
+        let handle_before = manager.wal.file.get_ref().as_raw_fd();
+
+        manager.checkpoint().unwrap();
+
+        let handle_after = manager.wal.file.get_ref().as_raw_fd();
+        assert_eq!(
+            handle_after, handle_before,
+            "checkpoint must not reopen the WAL after truncating it"
+        );
+
+        drop(manager);
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- truncate `wal.log` through the existing known-good writer handle instead of reopening after destructive truncation
- reset WAL byte and entry bookkeeping only after truncation succeeds, leaving the active writer installed on failure
- add regression coverage proving checkpoint does not replace the live WAL descriptor

## Verification
- `cargo test -p likhadb-persist --all-features wal::tests::checkpoint_keeps_the_open_wal_handle -- --exact` — passed
- `cargo test -p likhadb-persist --all-features` — passed (4 unit tests, 8 round-trip tests, 20 WAL recovery tests; 1 doctest ignored)
- `cargo clippy -p likhadb-persist --all-targets --all-features -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Docker build check — not run locally because the Docker daemon is unavailable; repository CI will run it

Closes #43