### PR TITLE
#104 lakehouse: run incremental index maintenance

### DIFF
--- a/crates/likhadb-core/src/binding.rs
+++ b/crates/likhadb-core/src/binding.rs
@@ -8,10 +8,9 @@
 /// the table. A collection with no binding behaves exactly as before — the
 /// feature is opt-in and additive.
 ///
-/// In this phase the binding is plumbed through create-collection and persisted,
-/// but nothing consumes it yet: the background maintenance task that reads source
-/// deltas lands in a later phase.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// The lakehouse maintenance task consumes persisted bindings to resolve and
+/// poll their source tables.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SourceBinding {
     /// Namespace path of the source table, e.g. `["lake", "embeddings"]`.
     pub source_namespace: Vec<String>,

--- a/crates/likhadb-lakehouse/src/index_maintenance_task.rs
+++ b/crates/likhadb-lakehouse/src/index_maintenance_task.rs
@@ -1,0 +1,327 @@
+//! Background synchronization of bound collections from Iceberg snapshot deltas.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use iceberg::Catalog;
+use likhadb_core::SourceBinding;
+use likhadb_persist::WalManager;
+use tokio::sync::RwLock;
+
+use crate::{load_source_table, scan_delta, LakehouseError, SnapshotDelta};
+
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+struct BoundCollection {
+    name: String,
+    binding: SourceBinding,
+    source_snapshot_id: Option<i64>,
+}
+
+/// Polls source Iceberg tables and applies committed snapshot deltas to the
+/// corresponding live collections.
+pub struct IndexMaintenanceTask {
+    wal: Arc<RwLock<WalManager>>,
+    catalog: Arc<dyn Catalog>,
+    interval: Duration,
+}
+
+impl IndexMaintenanceTask {
+    pub fn new(wal: Arc<RwLock<WalManager>>, catalog: Arc<dyn Catalog>) -> Self {
+        Self {
+            wal,
+            catalog,
+            interval: DEFAULT_INTERVAL,
+        }
+    }
+
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    /// Spawn the periodic maintenance loop.
+    pub fn spawn(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            self.run().await;
+        })
+    }
+
+    async fn run(self) {
+        let mut ticker = tokio::time::interval(self.interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            ticker.tick().await;
+            self.run_once().await;
+        }
+    }
+
+    /// Run one maintenance tick across every currently bound collection.
+    ///
+    /// Failures are isolated per collection so one unavailable or malformed
+    /// source does not prevent other collections from advancing.
+    pub async fn run_once(&self) {
+        let collections = self.bound_collections().await;
+        for collection in collections {
+            if let Err(error) = self.maintain_collection(&collection).await {
+                tracing::warn!(
+                    collection = %collection.name,
+                    error = %error,
+                    "index maintenance tick failed"
+                );
+            }
+        }
+    }
+
+    async fn bound_collections(&self) -> Vec<BoundCollection> {
+        let guard = self.wal.read().await;
+        guard
+            .list()
+            .into_iter()
+            .filter_map(|name| {
+                let collection = guard.get(name).ok()?;
+                Some(BoundCollection {
+                    name: name.to_owned(),
+                    binding: collection.source_binding.clone()?,
+                    source_snapshot_id: collection.source_snapshot_id,
+                })
+            })
+            .collect()
+    }
+
+    async fn maintain_collection(
+        &self,
+        collection: &BoundCollection,
+    ) -> Result<(), LakehouseError> {
+        // First-bind full scans are deliberately handled by issue #105. Until
+        // then, do not silently establish a baseline that omits existing rows.
+        let Some(from_snapshot_id) = collection.source_snapshot_id else {
+            tracing::debug!(
+                collection = %collection.name,
+                "source snapshot watermark is unset; waiting for first-bind scan"
+            );
+            return Ok(());
+        };
+
+        // Catalog and file I/O happen without holding the store lock.
+        let table = load_source_table(self.catalog.as_ref(), &collection.binding).await?;
+        let Some(to_snapshot_id) = table.metadata().current_snapshot_id() else {
+            return Ok(());
+        };
+        if to_snapshot_id == from_snapshot_id {
+            return Ok(());
+        }
+
+        let result = scan_delta(
+            &table,
+            SnapshotDelta {
+                from_snapshot_id: Some(from_snapshot_id),
+                to_snapshot_id,
+            },
+            &collection.binding,
+        )
+        .await?;
+        let row_count = result.rows.len();
+
+        // Revalidate the state observed before the scan while holding the same
+        // write lock used to apply every row and advance the watermark.
+        let applied = self.wal.write().await.apply_source_delta(
+            &collection.name,
+            &collection.binding,
+            Some(from_snapshot_id),
+            to_snapshot_id,
+            result.rows,
+        )?;
+        if !applied {
+            tracing::debug!(
+                collection = %collection.name,
+                from_snapshot_id,
+                to_snapshot_id,
+                "discarding stale source snapshot scan"
+            );
+            return Ok(());
+        }
+
+        tracing::info!(
+            collection = %collection.name,
+            from_snapshot_id,
+            to_snapshot_id,
+            rows_applied = row_count,
+            unresolved_delete_files = result.unresolved_delete_files,
+            "source snapshot delta applied"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use arrow::array::{ArrayRef, FixedSizeListArray, Float32Array, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use arrow::record_batch::RecordBatch;
+    use bytes::Bytes;
+    use iceberg::arrow::arrow_schema_to_schema;
+    use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
+    use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Struct};
+    use iceberg::transaction::{ApplyTransactionAction, Transaction};
+    use iceberg::{CatalogBuilder, NamespaceIdent, TableCreation, TableIdent};
+    use likhadb_core::Metric;
+    use parquet::arrow::ArrowWriter;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn default_poll_interval_is_sixty_seconds() {
+        assert_eq!(DEFAULT_INTERVAL, Duration::from_secs(60));
+    }
+
+    fn field(name: &str, data_type: DataType, nullable: bool, id: i32) -> Field {
+        Field::new(name, data_type, nullable).with_metadata(HashMap::from([(
+            "PARQUET:field_id".to_string(),
+            id.to_string(),
+        )]))
+    }
+
+    fn arrow_schema() -> Arc<ArrowSchema> {
+        let vector_element = Arc::new(field("element", DataType::Float32, false, 3));
+        Arc::new(ArrowSchema::new(vec![
+            field("id", DataType::Int64, false, 1),
+            field(
+                "embedding",
+                DataType::FixedSizeList(vector_element, 2),
+                false,
+                2,
+            ),
+        ]))
+    }
+
+    fn parquet_bytes(id: i64, vector: [f32; 2]) -> Vec<u8> {
+        let schema = arrow_schema();
+        let ids: ArrayRef = Arc::new(Int64Array::from(vec![id]));
+        let vectors: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(field("element", DataType::Float32, false, 3)),
+                2,
+                Arc::new(Float32Array::from(vector.to_vec())),
+                None,
+            )
+            .unwrap(),
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, vectors]).unwrap();
+        let mut bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        bytes
+    }
+
+    async fn append_row(
+        catalog: &dyn Catalog,
+        table: &iceberg::table::Table,
+        file_name: &str,
+        id: i64,
+        vector: [f32; 2],
+    ) -> iceberg::table::Table {
+        let bytes = parquet_bytes(id, vector);
+        let file_path = format!("{}/data/{file_name}.parquet", table.metadata().location());
+        table
+            .file_io()
+            .new_output(&file_path)
+            .unwrap()
+            .write(Bytes::from(bytes.clone()))
+            .await
+            .unwrap();
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(file_path)
+            .file_format(DataFileFormat::Parquet)
+            .partition(Struct::empty())
+            .record_count(1)
+            .file_size_in_bytes(bytes.len() as u64)
+            .build()
+            .unwrap();
+        let tx = Transaction::new(table);
+        let tx = tx
+            .fast_append()
+            .add_data_files([data_file])
+            .apply(tx)
+            .unwrap();
+        tx.commit(catalog).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn tick_applies_external_append_and_advances_watermark() {
+        let warehouse = TempDir::new().unwrap();
+        let catalog = Arc::new(
+            MemoryCatalogBuilder::default()
+                .load(
+                    "maintenance-test",
+                    HashMap::from([(
+                        MEMORY_CATALOG_WAREHOUSE.to_string(),
+                        format!("file://{}", warehouse.path().display()),
+                    )]),
+                )
+                .await
+                .unwrap(),
+        );
+        let namespace = NamespaceIdent::new("source".to_string());
+        catalog
+            .create_namespace(&namespace, HashMap::new())
+            .await
+            .unwrap();
+        let table_ident = TableIdent::new(namespace.clone(), "vectors".to_string());
+        let table = catalog
+            .create_table(
+                &namespace,
+                TableCreation::builder()
+                    .name(table_ident.name().to_string())
+                    .schema(arrow_schema_to_schema(arrow_schema().as_ref()).unwrap())
+                    .build(),
+            )
+            .await
+            .unwrap();
+        let table = append_row(catalog.as_ref(), &table, "baseline", 1, [1.0, 0.0]).await;
+        let baseline_snapshot = table.metadata().current_snapshot_id().unwrap();
+
+        let data_dir = TempDir::new().unwrap();
+        let mut wal = WalManager::open(data_dir.path()).unwrap();
+        wal.create_hnsw_collection("documents", 2, Metric::L2, 4, 8, 10)
+            .unwrap();
+        let binding = SourceBinding {
+            source_namespace: namespace.as_ref().clone(),
+            source_table: table_ident.name().to_string(),
+            id_column: "id".to_string(),
+            vector_column: "embedding".to_string(),
+            payload_columns: vec![],
+        };
+        wal.set_source_binding("documents", binding.clone())
+            .unwrap();
+        wal.apply_source_delta("documents", &binding, None, baseline_snapshot, [])
+            .unwrap();
+
+        // Reloading before the append models a writer independent from the
+        // maintenance task's later catalog read.
+        let writer_table = catalog.load_table(&table_ident).await.unwrap();
+        let writer_table =
+            append_row(catalog.as_ref(), &writer_table, "external", 2, [2.0, 0.0]).await;
+        let external_snapshot = writer_table.metadata().current_snapshot_id().unwrap();
+
+        let wal = Arc::new(RwLock::new(wal));
+        let task = IndexMaintenanceTask::new(wal.clone(), catalog);
+        task.run_once().await;
+
+        let guard = wal.read().await;
+        let collection = guard.get("documents").unwrap();
+        assert_eq!(collection.source_snapshot_id, Some(external_snapshot));
+        assert_eq!(
+            collection.search(&[2.0, 0.0], 1, None, false).unwrap()[0].id,
+            2
+        );
+        assert!(collection.get(1).unwrap().is_none());
+    }
+}

--- a/crates/likhadb-lakehouse/src/lib.rs
+++ b/crates/likhadb-lakehouse/src/lib.rs
@@ -34,6 +34,8 @@ pub mod iceberg_flusher;
 #[cfg(feature = "iceberg-recovery")]
 pub mod iceberg_recovery;
 #[cfg(feature = "iceberg-recovery")]
+pub mod index_maintenance_task;
+#[cfg(feature = "iceberg-recovery")]
 pub mod index_snapshot_io;
 #[cfg(feature = "iceberg-recovery")]
 pub mod staging_io;
@@ -44,6 +46,8 @@ pub use iceberg::NamespaceIdent;
 pub use iceberg_flusher::IcebergFlusher;
 #[cfg(feature = "iceberg-recovery")]
 pub use iceberg_recovery::{open_with_iceberg, RecoveryError};
+#[cfg(feature = "iceberg-recovery")]
+pub use index_maintenance_task::IndexMaintenanceTask;
 #[cfg(feature = "iceberg-recovery")]
 pub use index_snapshot_io::{load_collection_snapshots, write_collection_snapshot};
 #[cfg(feature = "iceberg-recovery")]

--- a/crates/likhadb-lakehouse/src/maintenance.rs
+++ b/crates/likhadb-lakehouse/src/maintenance.rs
@@ -1,8 +1,8 @@
 //! Configuration and per-tick backpressure for source-table maintenance.
 //!
-//! The catalog polling loop is introduced separately. Keeping the row budget
-//! here makes the opt-in/disabled behavior and carry-over semantics independent
-//! of the source used by that loop.
+//! The catalog polling loop lives in `index_maintenance_task`. Keeping the row
+//! budget here makes the opt-in/disabled behavior and carry-over semantics
+//! independent of the source used by that loop.
 
 use std::collections::VecDeque;
 use std::time::Duration;

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -9,8 +9,8 @@ use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use bincode::Options as _;
-use likhadb_core::{Metric, VecId, Vector};
-use likhadb_store::{Collection, CollectionManager};
+use likhadb_core::{Metric, SourceBinding, VecId, Vector};
+use likhadb_store::{Collection, CollectionManager, DeltaRow};
 use serde_json::Value;
 
 use crate::{bincode_opts, PersistError};
@@ -590,6 +590,38 @@ impl WalManager {
             },
             |mgr| mgr.set_source_binding(&col, binding),
         )
+    }
+
+    /// Apply a source-table snapshot delta without writing it to the internal WAL.
+    ///
+    /// The caller must supply the binding and watermark observed before scanning.
+    /// Both are revalidated under the store write lock so rows from a stale scan
+    /// are never applied after a rebind or a concurrent maintenance tick. `Ok(false)`
+    /// means that validation failed and the caller should discard the scan.
+    ///
+    /// The source watermark advances only after every row applies successfully.
+    /// A partial failure therefore leaves the old watermark in place and the
+    /// idempotent range can be retried on the next tick.
+    pub fn apply_source_delta(
+        &mut self,
+        collection: &str,
+        expected_binding: &SourceBinding,
+        from_snapshot_id: Option<i64>,
+        to_snapshot_id: i64,
+        rows: impl IntoIterator<Item = DeltaRow>,
+    ) -> likhadb_core::Result<bool> {
+        let col = self.inner.get_mut(collection)?;
+        if col.source_binding.as_ref() != Some(expected_binding)
+            || col.source_snapshot_id != from_snapshot_id
+        {
+            return Ok(false);
+        }
+
+        for row in rows {
+            col.apply_delta_row(row, u64::MAX)?;
+        }
+        col.source_snapshot_id = Some(to_snapshot_id);
+        Ok(true)
     }
 
     // ── Read-through ────────────────────────────────────────────────────────

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,5 +1,6 @@
-use likhadb_core::Metric;
+use likhadb_core::{Metric, SourceBinding};
 use likhadb_persist::{PersistError, WalConfig, WalManager};
+use likhadb_store::DeltaRow;
 use serde_json::json;
 
 fn tmp_dir(label: &str) -> std::path::PathBuf {
@@ -225,6 +226,146 @@ fn source_binding_survives_restart() {
         .expect("binding restored after restart");
     assert_eq!(binding.source_table, "embeddings");
     assert_eq!(binding.vector_column, "embedding");
+}
+
+fn source_binding() -> SourceBinding {
+    SourceBinding {
+        source_namespace: vec!["lake".into()],
+        source_table: "embeddings".into(),
+        id_column: "id".into(),
+        vector_column: "embedding".into(),
+        payload_columns: vec!["title".into()],
+    }
+}
+
+#[test]
+fn source_delta_updates_index_and_advances_watermark() {
+    let dir = tmp_dir("source_delta_apply");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_hnsw_collection("col", 2, Metric::L2, 4, 8, 10)
+        .unwrap();
+    let binding = source_binding();
+    mgr.set_source_binding("col", binding.clone()).unwrap();
+    assert!(mgr
+        .apply_source_delta("col", &binding, None, 10, [])
+        .unwrap());
+
+    assert!(mgr
+        .apply_source_delta(
+            "col",
+            &binding,
+            Some(10),
+            11,
+            [
+                DeltaRow::Upsert {
+                    id: 1,
+                    vector: vec![1.0, 0.0],
+                    payload: Some(json!({"source": "external"})),
+                },
+                DeltaRow::Upsert {
+                    id: 2,
+                    vector: vec![2.0, 0.0],
+                    payload: None,
+                },
+                DeltaRow::Delete { id: 1 },
+            ],
+        )
+        .unwrap());
+
+    let collection = mgr.get("col").unwrap();
+    assert_eq!(collection.source_snapshot_id, Some(11));
+    assert!(collection.get(1).unwrap().is_none());
+    assert_eq!(
+        collection.search(&[2.0, 0.0], 1, None, false).unwrap()[0].id,
+        2
+    );
+}
+
+#[test]
+fn failed_source_delta_keeps_watermark_for_idempotent_retry() {
+    let dir = tmp_dir("source_delta_retry");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("col", 2, Metric::L2).unwrap();
+    let binding = source_binding();
+    mgr.set_source_binding("col", binding.clone()).unwrap();
+    assert!(mgr
+        .apply_source_delta("col", &binding, None, 20, [])
+        .unwrap());
+
+    let error = mgr
+        .apply_source_delta(
+            "col",
+            &binding,
+            Some(20),
+            21,
+            [
+                DeltaRow::Upsert {
+                    id: 1,
+                    vector: vec![1.0, 0.0],
+                    payload: None,
+                },
+                DeltaRow::Upsert {
+                    id: 2,
+                    vector: vec![2.0, 0.0, 0.0],
+                    payload: None,
+                },
+            ],
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("dimension mismatch"));
+    assert_eq!(mgr.get("col").unwrap().source_snapshot_id, Some(20));
+    assert!(mgr.get("col").unwrap().get(1).unwrap().is_some());
+
+    assert!(mgr
+        .apply_source_delta(
+            "col",
+            &binding,
+            Some(20),
+            21,
+            [
+                DeltaRow::Upsert {
+                    id: 1,
+                    vector: vec![1.0, 0.0],
+                    payload: None,
+                },
+                DeltaRow::Upsert {
+                    id: 2,
+                    vector: vec![2.0, 0.0],
+                    payload: None,
+                },
+            ],
+        )
+        .unwrap());
+    assert_eq!(mgr.get("col").unwrap().source_snapshot_id, Some(21));
+    assert_eq!(mgr.get("col").unwrap().len(), 2);
+}
+
+#[test]
+fn stale_source_delta_is_discarded() {
+    let dir = tmp_dir("source_delta_stale");
+    let mut mgr = WalManager::open(&dir).unwrap();
+    mgr.create_collection("col", 2, Metric::L2).unwrap();
+    let binding = source_binding();
+    mgr.set_source_binding("col", binding.clone()).unwrap();
+    assert!(mgr
+        .apply_source_delta("col", &binding, None, 30, [])
+        .unwrap());
+
+    assert!(!mgr
+        .apply_source_delta(
+            "col",
+            &binding,
+            Some(29),
+            31,
+            [DeltaRow::Upsert {
+                id: 1,
+                vector: vec![1.0, 0.0],
+                payload: None,
+            }],
+        )
+        .unwrap());
+    assert_eq!(mgr.get("col").unwrap().source_snapshot_id, Some(30));
+    assert!(mgr.get("col").unwrap().is_empty());
 }
 
 // ── Checkpoint clears WAL ──────────────────────────────────────────────────

--- a/crates/likhadb-server/src/lib.rs
+++ b/crates/likhadb-server/src/lib.rs
@@ -12,8 +12,8 @@ pub use auth::{grpc_interceptor, require_bearer, ApiToken};
 pub use grpc::{GrpcMetricsLayer, LikhaDbGrpc, LikhaDbServer};
 #[cfg(feature = "iceberg-recovery")]
 pub use likhadb_lakehouse::{
-    iceberg_io::IcebergConfig, iceberg_recovery::open_with_iceberg,
-    iceberg_recovery::RecoveryError, IcebergFlusher, NamespaceIdent,
+    build_rest_catalog, iceberg_io::IcebergConfig, iceberg_recovery::open_with_iceberg,
+    iceberg_recovery::RecoveryError, IcebergFlusher, IndexMaintenanceTask, NamespaceIdent,
 };
 pub use metrics::{install as install_prometheus, seed_collection_gauges};
 pub use metrics_exporter_prometheus::PrometheusHandle;

--- a/crates/likhadb-server/src/main.rs
+++ b/crates/likhadb-server/src/main.rs
@@ -86,12 +86,22 @@ async fn main() {
         state
     };
 
-    // Spawn Iceberg background flusher when catalog is configured.
+    // Spawn Iceberg background services when a catalog is configured.
     #[cfg(feature = "iceberg-recovery")]
     if let Some((config, namespace)) = iceberg_flusher_args {
-        use likhadb_server::IcebergFlusher;
+        use likhadb_server::{IcebergFlusher, IndexMaintenanceTask};
+        use std::sync::Arc;
+
+        let catalog = likhadb_server::build_rest_catalog(&config)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!(error = %e, "failed to build maintenance catalog");
+                std::process::exit(1);
+            });
+        let _maintenance = IndexMaintenanceTask::new(state.wal_arc(), Arc::new(catalog)).spawn();
         let _flusher = IcebergFlusher::new(state.wal_arc(), config, namespace).spawn();
         tracing::info!("iceberg background flusher started");
+        tracing::info!("index maintenance task started");
     }
 
     let checkpoint_task =

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -48,8 +48,8 @@ pub struct Collection {
     #[cfg(feature = "fts")]
     pub(crate) fts_index: Option<Box<dyn likhadb_fts::FtsIndex>>,
     /// Optional binding to an externally-written Iceberg source table. `None`
-    /// means internal-writes-only (the default). Consumed by the maintenance
-    /// task in a later phase.
+    /// means internal-writes-only (the default). Consumed by the lakehouse
+    /// maintenance task.
     pub source_binding: Option<SourceBinding>,
     /// The source-table snapshot id whose rows are reflected in this index.
     /// `None` until a source delta has been applied. Held in memory in this
@@ -200,11 +200,14 @@ impl Collection {
         if let Some(p) = payload {
             #[cfg(feature = "fts")]
             if let Some(fts) = &mut self.fts_index {
-                if lsn > fts.last_lsn() {
+                let out_of_band = lsn == u64::MAX;
+                if out_of_band || lsn > fts.last_lsn() {
                     let text = extract_text_fields(&p);
                     if !text.is_empty() {
                         fts.index_document(id, &text)?;
-                        fts.set_lsn(lsn)?;
+                        if !out_of_band {
+                            fts.set_lsn(lsn)?;
+                        }
                     }
                 }
             }
@@ -218,9 +221,12 @@ impl Collection {
         self.meta.remove(id);
         #[cfg(feature = "fts")]
         if let Some(fts) = &mut self.fts_index {
-            if lsn > fts.last_lsn() {
+            let out_of_band = lsn == u64::MAX;
+            if out_of_band || lsn > fts.last_lsn() {
                 fts.delete_document(id)?;
-                fts.set_lsn(lsn)?;
+                if !out_of_band {
+                    fts.set_lsn(lsn)?;
+                }
             }
         }
         Ok(existed)
@@ -232,6 +238,8 @@ impl Collection {
     /// and the source-table incremental-maintenance path. `Upsert` overwrites and
     /// `Delete` is idempotent, so re-applying a partially-applied range is safe.
     /// `lsn` gates FTS writes exactly as [`Collection::insert`] / [`Collection::delete`] do.
+    /// Use `u64::MAX` for out-of-band source rows that must update FTS without
+    /// advancing its internal-WAL recovery watermark.
     pub fn apply_delta_row(&mut self, row: DeltaRow, lsn: u64) -> Result<()> {
         match row {
             DeltaRow::Upsert {
@@ -496,6 +504,44 @@ mod tests {
             c.delete(1, u64::MAX).unwrap();
             let after = c.fts_search("tantivy", 5).unwrap();
             assert!(after.is_empty(), "deleted doc should not appear");
+        }
+
+        #[test]
+        fn out_of_band_deltas_do_not_poison_fts_lsn_watermark() {
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!(
+                "likhadb_fts_source_delta_{}_{}",
+                std::process::id(),
+                unique
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            let mut c = Collection::new("fts_test".into(), 3, Metric::L2);
+            c.enable_fts(Some(&dir)).unwrap();
+
+            for (id, text) in [(1, "external alpha"), (2, "external beta")] {
+                c.apply_delta_row(
+                    DeltaRow::Upsert {
+                        id,
+                        vector: vec![id as f32, 0.0, 0.0],
+                        payload: Some(json!({"body": text})),
+                    },
+                    u64::MAX,
+                )
+                .unwrap();
+            }
+            assert_eq!(c.fts_search("external", 10).unwrap().len(), 2);
+
+            c.insert(
+                3,
+                vec![3.0, 0.0, 0.0],
+                Some(json!({"body": "internal gamma"})),
+                1,
+            )
+            .unwrap();
+            assert_eq!(c.fts_search("internal", 10).unwrap()[0].id, 3);
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- add a 60-second background `IndexMaintenanceTask` that polls every bound Iceberg source table, scans committed snapshot deltas, and is started with the existing Iceberg server services
- keep catalog and file I/O outside the store lock, then revalidate the binding and prior watermark before applying rows so stale scans are discarded safely
- apply append and delete rows through the shared delta path and advance `source_snapshot_id` only after the entire range succeeds; isolate failures per collection for retry on the next tick
- preserve the FTS WAL watermark for out-of-band source rows so later internal writes remain indexable
- leave first-bind and non-ancestor full-scan fallback to #105, as scoped by this issue

## Verification
- `cargo test -p likhadb-store --features fts` — passed (56 tests)
- `cargo test -p likhadb-persist --all-features` — passed (35 tests; 1 doctest ignored)
- `cargo test -p likhadb-lakehouse --all-features` — passed (31 tests; 3 external-service tests ignored)
- `cargo test --workspace` — passed
- `cargo clippy -p likhadb-lakehouse --all-targets --all-features -- -D warnings` — passed
- `cargo clippy -p likhadb-persist --all-targets --all-features -- -D warnings` — passed
- `cargo clippy -p likhadb-server --all-targets --all-features -- -D warnings` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `docker build .` — passed

Closes #104