### PR TITLE
#41 wal: upgrade frame checksum to xxHash64

### DIFF
--- a/crates/likhadb-persist/Cargo.toml
+++ b/crates/likhadb-persist/Cargo.toml
@@ -16,7 +16,7 @@ bincode       = { workspace = true }
 thiserror     = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
-crc32fast     = "1"
+xxhash-rust   = { version = "0.8", features = ["xxh64"] }
 metrics       = "0.23"
 tracing       = "0.1"
 

--- a/crates/likhadb-persist/src/error.rs
+++ b/crates/likhadb-persist/src/error.rs
@@ -10,8 +10,8 @@ pub enum PersistError {
     Decode(#[source] bincode::Error),
     #[error("unsupported WAL version {found}; maximum supported version is {max}")]
     UnsupportedVersion { found: u8, max: u8 },
-    #[error("WAL CRC mismatch at mid-log frame: expected {expected:#010x}, got {got:#010x}")]
-    Crc { expected: u32, got: u32 },
+    #[error("WAL checksum mismatch at mid-log frame: expected {expected:#018x}, got {got:#018x}")]
+    Crc { expected: u64, got: u64 },
     #[error("WAL replay error: {0}")]
     Apply(#[from] likhadb_core::LikhaDbError),
 }

--- a/crates/likhadb-persist/src/wal/entry.rs
+++ b/crates/likhadb-persist/src/wal/entry.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 /// The version is serialized as the first byte of every [`WalEntry`] so a
 /// reader can reject an unsupported format before attempting to decode a
 /// potentially unknown [`WalOp`] variant.
-pub const CURRENT_WAL_VERSION: u8 = 1;
+pub const CURRENT_WAL_VERSION: u8 = 2;
 
 /// Index configuration captured at collection-creation time so WAL replay can
 /// reconstruct the right index type without touching the store layer.

--- a/crates/likhadb-persist/src/wal/frame.rs
+++ b/crates/likhadb-persist/src/wal/frame.rs
@@ -1,22 +1,23 @@
 use std::io::{self, Read, Write};
 
-use crc32fast::Hasher;
+use xxhash_rust::xxh64::xxh64;
 
-/// Write a length-prefixed, CRC32-checksummed frame.
+pub const HEADER_BYTES: u64 = 12;
+
+/// Write a length-prefixed, xxHash64-checksummed frame.
 ///
-/// Format: `[payload_len: u32 LE][crc32: u32 LE][payload: payload_len bytes]`
+/// Format: `[payload_len: u32 LE][xxhash64: u64 LE][payload: payload_len bytes]`
 pub fn write_frame(w: &mut impl Write, payload: &[u8]) -> io::Result<()> {
     let len = payload.len() as u32;
-    let crc = checksum(payload);
+    let hash = checksum(payload);
     w.write_all(&len.to_le_bytes())?;
-    w.write_all(&crc.to_le_bytes())?;
+    w.write_all(&hash.to_le_bytes())?;
     w.write_all(payload)
 }
 
 /// Read one frame.  Returns `None` when the stream ends cleanly at a frame
-/// boundary *or* when the last frame is truncated / CRC-mismatched (crash at
-/// tail).  Returns `Some(Err(_))` only for genuine mid-log I/O or CRC errors.
-pub fn read_frame(r: &mut impl Read) -> io::Result<Option<(Vec<u8>, u32)>> {
+/// boundary *or* when the last frame is truncated (crash at tail).
+pub fn read_frame(r: &mut impl Read) -> io::Result<Option<(Vec<u8>, u64)>> {
     // Read the 4-byte length prefix.
     let mut len_buf = [0u8; 4];
     match r.read_exact(&mut len_buf) {
@@ -26,14 +27,14 @@ pub fn read_frame(r: &mut impl Read) -> io::Result<Option<(Vec<u8>, u32)>> {
     }
     let payload_len = u32::from_le_bytes(len_buf) as usize;
 
-    // Read the 4-byte stored CRC.
-    let mut crc_buf = [0u8; 4];
-    match r.read_exact(&mut crc_buf) {
+    // Read the 8-byte stored xxHash64 checksum.
+    let mut hash_buf = [0u8; 8];
+    match r.read_exact(&mut hash_buf) {
         Ok(()) => {}
         Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
         Err(e) => return Err(e),
     }
-    let stored_crc = u32::from_le_bytes(crc_buf);
+    let stored_hash = u64::from_le_bytes(hash_buf);
 
     // Read the payload.
     let mut payload = vec![0u8; payload_len];
@@ -43,13 +44,11 @@ pub fn read_frame(r: &mut impl Read) -> io::Result<Option<(Vec<u8>, u32)>> {
         Err(e) => return Err(e),
     }
 
-    Ok(Some((payload, stored_crc)))
+    Ok(Some((payload, stored_hash)))
 }
 
-pub fn checksum(data: &[u8]) -> u32 {
-    let mut h = Hasher::new();
-    h.update(data);
-    h.finalize()
+pub fn checksum(data: &[u8]) -> u64 {
+    xxh64(data, 0)
 }
 
 /// Iterator over frames in a WAL file.  Stops at the first truncated/corrupt
@@ -79,8 +78,8 @@ impl<R: std::io::BufRead> FrameIter<R> {
 }
 
 impl<R: Read> Iterator for FrameIter<R> {
-    /// `(raw_payload_bytes, stored_crc)`
-    type Item = io::Result<(Vec<u8>, u32)>;
+    /// `(raw_payload_bytes, stored_xxhash64)`
+    type Item = io::Result<(Vec<u8>, u64)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -97,5 +96,15 @@ impl<R: Read> Iterator for FrameIter<R> {
                 Some(Err(e))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::checksum;
+
+    #[test]
+    fn checksum_matches_xxhash64_seed_zero_test_vector() {
+        assert_eq!(checksum(b""), 0xef46_db37_51d8_e999);
     }
 }

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -5,7 +5,7 @@ mod recovery;
 pub use entry::{IndexKind, WalEntry, WalOp, CURRENT_WAL_VERSION};
 
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, BufWriter, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use bincode::Options as _;
@@ -16,6 +16,8 @@ use serde_json::Value;
 use crate::{bincode_opts, PersistError};
 use frame::{checksum, write_frame, FrameIter};
 use recovery::apply_op;
+
+const LEGACY_CRC_FRAME_HEADER_BYTES: u64 = 8;
 
 fn decode_entry(payload: &[u8]) -> Result<WalEntry, PersistError> {
     // `version` is deliberately the first serialized field, and bincode
@@ -34,6 +36,51 @@ fn decode_entry(payload: &[u8]) -> Result<WalEntry, PersistError> {
     bincode_opts()
         .deserialize(payload)
         .map_err(PersistError::Decode)
+}
+
+/// Reject a complete v1 frame before its narrower checksum header can make it
+/// look like an incomplete v2 crash tail. A WAL uses one frame format, so the
+/// first complete entry identifies the whole file.
+fn reject_legacy_frame_format(file: &mut File) -> Result<(), PersistError> {
+    let file_len = file.metadata().map_err(PersistError::Io)?.len();
+    if file_len < 4 {
+        return Ok(());
+    }
+
+    let mut len_buf = [0u8; 4];
+    file.read_exact(&mut len_buf).map_err(PersistError::Io)?;
+    let payload_len = u32::from_le_bytes(len_buf) as u64;
+
+    // A valid current frame is authoritative, even if bytes within its hash
+    // happen to resemble a legacy entry prefix.
+    if file_len >= frame::HEADER_BYTES.saturating_add(payload_len) {
+        let mut hash_buf = [0u8; 8];
+        file.read_exact(&mut hash_buf).map_err(PersistError::Io)?;
+        let mut payload = vec![0u8; payload_len as usize];
+        file.read_exact(&mut payload).map_err(PersistError::Io)?;
+        if checksum(&payload) == u64::from_le_bytes(hash_buf) {
+            file.rewind().map_err(PersistError::Io)?;
+            return Ok(());
+        }
+    }
+
+    if file_len >= LEGACY_CRC_FRAME_HEADER_BYTES.saturating_add(payload_len) {
+        file.seek(SeekFrom::Start(LEGACY_CRC_FRAME_HEADER_BYTES))
+            .map_err(PersistError::Io)?;
+        let mut payload = vec![0u8; payload_len as usize];
+        file.read_exact(&mut payload).map_err(PersistError::Io)?;
+        if let Ok(entry) = bincode_opts().deserialize::<WalEntry>(&payload) {
+            if entry.version < CURRENT_WAL_VERSION {
+                return Err(PersistError::UnsupportedVersion {
+                    found: entry.version,
+                    max: CURRENT_WAL_VERSION,
+                });
+            }
+        }
+    }
+
+    file.rewind().map_err(PersistError::Io)?;
+    Ok(())
 }
 
 // ── WalWriter ──────────────────────────────────────────────────────────────
@@ -74,8 +121,8 @@ impl WalWriter {
         let mut frame_bytes = 0u64;
         for payload in &payloads {
             write_frame(&mut self.file, payload).map_err(PersistError::Io)?;
-            // Frame layout: 4-byte length prefix + 4-byte CRC + payload.
-            frame_bytes += 8u64 + payload.len() as u64;
+            // Frame layout: 4-byte length + 8-byte xxHash64 + payload.
+            frame_bytes += frame::HEADER_BYTES + payload.len() as u64;
         }
         self.file.flush().map_err(PersistError::Io)?;
         self.file.get_mut().sync_data().map_err(PersistError::Io)?;
@@ -150,7 +197,7 @@ impl Default for WalConfig {
 /// # Recovery
 /// On [`WalManager::open`], if a snapshot exists it is loaded first.  Then any
 /// WAL entries with LSN greater than the snapshot's `last_lsn` are replayed in
-/// order.  A truncated or CRC-corrupt tail frame (crash mid-write) is silently
+/// order.  A truncated or checksum-corrupt tail frame (crash mid-write) is silently
 /// discarded — it was never committed.
 ///
 /// # Error type
@@ -305,7 +352,8 @@ impl WalManager {
         snapshot_lsn: u64,
         data_dir: &Path,
     ) -> Result<(u64, u64, u64), PersistError> {
-        let file = File::open(path).map_err(PersistError::Io)?;
+        let mut file = File::open(path).map_err(PersistError::Io)?;
+        reject_legacy_frame_format(&mut file)?;
         let reader = BufReader::new(file);
         let mut iter = FrameIter::new(reader);
         let mut last_lsn = snapshot_lsn;
@@ -313,10 +361,10 @@ impl WalManager {
         let mut entries_since_checkpoint = 0u64;
 
         for item in &mut iter {
-            let (payload, stored_crc) = item.map_err(PersistError::Io)?;
+            let (payload, stored_hash) = item.map_err(PersistError::Io)?;
 
             let computed = checksum(&payload);
-            if computed != stored_crc {
+            if computed != stored_hash {
                 // If no bytes follow this frame it is a crash-truncated tail
                 // (the last write never completed); discard it and stop replay.
                 // If bytes remain after it, the corruption is mid-log and must
@@ -326,7 +374,7 @@ impl WalManager {
                     break;
                 }
                 return Err(PersistError::Crc {
-                    expected: stored_crc,
+                    expected: stored_hash,
                     got: computed,
                 });
             }
@@ -426,8 +474,8 @@ impl WalManager {
             let mut iter = frame::FrameIter::new(reader);
             let mut kept = Vec::new();
             for item in &mut iter {
-                let (payload, stored_crc) = item.map_err(PersistError::Io)?;
-                if frame::checksum(&payload) != stored_crc {
+                let (payload, stored_hash) = item.map_err(PersistError::Io)?;
+                if frame::checksum(&payload) != stored_hash {
                     break; // Treat corrupt tail as end of log.
                 }
                 let entry = decode_entry(&payload)?;
@@ -625,14 +673,16 @@ impl WalManager {
         let entries: Vec<_> = rows
             .iter()
             .enumerate()
-            .map(|(offset, (id, vector, payload))| WalEntry {
-                lsn: self.next_lsn + offset as u64,
-                op: WalOp::Insert {
-                    collection: col.clone(),
-                    id: *id,
-                    vector: vector.clone(),
-                    payload: payload.clone(),
-                },
+            .map(|(offset, (id, vector, payload))| {
+                WalEntry::new(
+                    self.next_lsn + offset as u64,
+                    WalOp::Insert {
+                        collection: col.clone(),
+                        id: *id,
+                        vector: vector.clone(),
+                        payload: payload.clone(),
+                    },
+                )
             })
             .collect();
 

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -1,6 +1,10 @@
 use likhadb_core::Metric;
-use likhadb_persist::{wal::CURRENT_WAL_VERSION, PersistError, WalConfig, WalManager};
+use likhadb_persist::{
+    wal::{WalEntry, WalOp, CURRENT_WAL_VERSION},
+    PersistError, WalConfig, WalManager,
+};
 use serde_json::json;
+use xxhash_rust::xxh64::xxh64;
 
 fn tmp_dir(label: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!("likhadb_wal_{label}_{}", std::process::id()));
@@ -100,8 +104,13 @@ fn wal_entry_starts_with_current_format_version() {
     }
 
     let wal = std::fs::read(dir.join("wal.log")).unwrap();
-    assert!(wal.len() > 8, "WAL must contain a complete frame");
-    assert_eq!(wal[8], CURRENT_WAL_VERSION);
+    assert!(wal.len() > 12, "WAL must contain a complete frame");
+    assert_eq!(wal[12], CURRENT_WAL_VERSION);
+
+    let payload_len = u32::from_le_bytes(wal[0..4].try_into().unwrap()) as usize;
+    let stored_hash = u64::from_le_bytes(wal[4..12].try_into().unwrap());
+    assert_eq!(wal.len(), 12 + payload_len);
+    assert_eq!(stored_hash, xxh64(&wal[12..], 0));
 }
 
 #[test]
@@ -109,7 +118,7 @@ fn unsupported_wal_version_is_reported_before_entry_decode() {
     let dir = tmp_dir("unsupported_version");
     let future_version = CURRENT_WAL_VERSION.checked_add(1).unwrap();
     let payload = [future_version];
-    let checksum = crc32fast::hash(&payload);
+    let checksum = xxh64(&payload, 0);
     let mut frame = Vec::new();
     frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
     frame.extend_from_slice(&checksum.to_le_bytes());
@@ -124,6 +133,42 @@ fn unsupported_wal_version_is_reported_before_entry_decode() {
                 if found == future_version && max == CURRENT_WAL_VERSION
         ),
         "future WAL format should surface PersistError::UnsupportedVersion"
+    );
+}
+
+#[test]
+fn legacy_crc32_frame_is_rejected_instead_of_ignored_as_a_crash_tail() {
+    use bincode::Options as _;
+
+    let dir = tmp_dir("legacy_crc32_frame");
+    let entry = WalEntry {
+        version: 1,
+        lsn: 1,
+        op: WalOp::CreateCollection {
+            name: "col".into(),
+            dim: 4,
+            metric: Metric::L2,
+            kind: likhadb_persist::wal::IndexKind::Flat,
+        },
+    };
+    let payload = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .serialize(&entry)
+        .unwrap();
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&[0u8; 4]);
+    frame.extend_from_slice(&payload);
+    std::fs::write(dir.join("wal.log"), frame).unwrap();
+
+    let result = WalManager::open(&dir);
+    assert!(
+        matches!(
+            result,
+            Err(PersistError::UnsupportedVersion { found: 1, max })
+                if max == CURRENT_WAL_VERSION
+        ),
+        "legacy frame format should be rejected explicitly"
     );
 }
 
@@ -621,7 +666,7 @@ fn truncated_wal_tail_is_ignored() {
     );
 }
 
-// ── Mid-log CRC corruption returns an error ────────────────────────────────
+// ── Mid-log checksum corruption returns an error ───────────────────────────
 
 #[test]
 fn mid_log_corruption_is_error() {
@@ -646,7 +691,7 @@ fn mid_log_corruption_is_error() {
     let result = WalManager::open(&dir);
     assert!(
         matches!(result, Err(PersistError::Crc { .. })),
-        "mid-log CRC corruption should surface as PersistError::Crc"
+        "mid-log checksum corruption should surface as PersistError::Crc"
     );
 }
 
@@ -676,8 +721,8 @@ fn second_frame_mid_log_corruption_is_error() {
     let wal_path = dir.join("wal.log");
     let mut data = std::fs::read(&wal_path).unwrap();
     let first_frame_payload_len = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
-    let second_frame_start = 4 + 4 + first_frame_payload_len;
-    data[second_frame_start + 8 + 1] ^= 0xFF;
+    let second_frame_start = 4 + 8 + first_frame_payload_len;
+    data[second_frame_start + 12 + 1] ^= 0xFF;
     std::fs::write(&wal_path, &data).unwrap();
 
     let result = WalManager::open(&dir);


### PR DESCRIPTION
## Summary
- replace per-frame CRC32 checksums with seeded xxHash64 and widen the WAL frame header from 8 to 12 bytes
- bump the WAL entry format to version 2 and explicitly reject complete legacy v1/CRC32 frames instead of misclassifying them as truncated crash tails
- update byte accounting, recovery, Iceberg WAL rewrites, batch-entry construction, and corruption/layout regression coverage for the new format
- retain the existing `PersistError::Crc` variant for API compatibility while widening its checksum fields to `u64` and making its message algorithm-neutral

## Verification
- `cargo test -p likhadb-persist --all-features` — passed (42 tests; 1 doctest ignored)
- `cargo clippy -p likhadb-persist --all-targets --all-features -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo build --release -p likhadb-server` — passed
- `docker build .` — local Docker engine did not respond; stopped after more than seven minutes with no build output. The required GitHub Docker check will validate the image build.

Closes #41
