### PR TITLE
#42 wal: configure write buffer capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ BM25, DataFusion enrichment, ACL filtering, score fusion, and reranking in one r
 Parquet and Iceberg integration keep the application connected to the same tables used by
 Spark, Trino, and dbt, while the local WAL protects writes between durable checkpoints.
 
+```mermaid
+flowchart LR
+    Client["Applications and agents"]
+
+    subgraph LikhaDB["LikhaDB — one application"]
+        API["REST / gRPC"]
+        Search["ANN + BM25<br/>candidate retrieval"]
+        Query["DataFusion<br/>enrichment · ACL · score fusion · reranking"]
+        WAL[("Local WAL<br/>write protection")]
+
+        API --> Search --> Query
+        API -. "durable writes" .-> WAL
+    end
+
+    subgraph Lakehouse["Lakehouse — source of truth"]
+        Tables[("Apache Iceberg / Parquet<br/>on object storage")]
+    end
+
+    Tools["Spark · Trino · dbt"]
+
+    Client -->|"one query"| API
+    Query <-->|"native read / write"| Tables
+    WAL -. "checkpoint" .-> Tables
+    Tools <-->|"use the same tables"| Tables
+    Query -->|"ranked, enriched results"| Client
+```
+
 ## Getting started
 
 **Prerequisites:** Rust stable toolchain.

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -44,11 +44,11 @@ struct WalWriter {
 }
 
 impl WalWriter {
-    fn open_append(path: &Path) -> std::io::Result<Self> {
+    fn open_append(path: &Path, write_buffer_bytes: usize) -> std::io::Result<Self> {
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         let bytes_written = file.metadata()?.len();
         Ok(Self {
-            file: BufWriter::new(file),
+            file: BufWriter::with_capacity(write_buffer_bytes, file),
             bytes_written,
         })
     }
@@ -116,7 +116,7 @@ pub struct WalStats {
     pub snapshot_lsn: u64,
 }
 
-/// Thresholds that control automatic WAL checkpoints.
+/// Settings that control WAL buffering and automatic checkpoints.
 ///
 /// A threshold of zero disables that trigger. When both thresholds are
 /// enabled, a checkpoint runs as soon as either one is reached.
@@ -126,6 +126,9 @@ pub struct WalConfig {
     pub checkpoint_every_n_entries: u64,
     /// Trigger a checkpoint after `wal.log` reaches this size (`0` = disabled).
     pub checkpoint_every_n_bytes: u64,
+    /// Capacity of the buffered writer for `wal.log`, in bytes (`0` disables
+    /// buffering).
+    pub write_buffer_bytes: usize,
 }
 
 impl Default for WalConfig {
@@ -133,6 +136,7 @@ impl Default for WalConfig {
         Self {
             checkpoint_every_n_entries: 100_000,
             checkpoint_every_n_bytes: 256 * 1024 * 1024,
+            write_buffer_bytes: 64 * 1024,
         }
     }
 }
@@ -187,8 +191,7 @@ impl WalManager {
         Self::open_with_config(dir, WalConfig::default())
     }
 
-    /// Open (or create) a data directory with custom auto-checkpoint
-    /// thresholds.
+    /// Open (or create) a data directory with custom WAL settings.
     pub fn open_with_config(dir: &Path, config: WalConfig) -> Result<Self, PersistError> {
         std::fs::create_dir_all(dir).map_err(PersistError::Io)?;
 
@@ -220,7 +223,8 @@ impl WalManager {
         }
 
         // 3. Open WAL for appending.
-        let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        let wal = WalWriter::open_append(&wal_path, config.write_buffer_bytes)
+            .map_err(PersistError::Io)?;
 
         Ok(Self {
             inner,
@@ -280,7 +284,8 @@ impl WalManager {
                 Self::replay_wal(&wal_path, &mut inner, iceberg_watermark, dir)?;
         }
 
-        let wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        let wal = WalWriter::open_append(&wal_path, config.write_buffer_bytes)
+            .map_err(PersistError::Io)?;
         Ok(Self {
             inner,
             wal,
@@ -443,7 +448,7 @@ impl WalManager {
         // Write kept entries to tmp file.
         {
             let file = File::create(&tmp_path).map_err(PersistError::Io)?;
-            let mut writer = BufWriter::new(file);
+            let mut writer = BufWriter::with_capacity(self.config.write_buffer_bytes, file);
             for entry in &entries_to_keep {
                 let payload = bincode_opts()
                     .serialize(entry)
@@ -456,7 +461,8 @@ impl WalManager {
 
         // Atomic rename then reopen.
         std::fs::rename(&tmp_path, &wal_path).map_err(PersistError::Io)?;
-        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal = WalWriter::open_append(&wal_path, self.config.write_buffer_bytes)
+            .map_err(PersistError::Io)?;
         self.wal_entries = entries_to_keep.len() as u64;
         self.entries_since_checkpoint = entries_to_keep
             .iter()
@@ -758,9 +764,54 @@ impl WalManager {
 
         // Truncate WAL and reopen for appending.
         WalWriter::truncate(&wal_path).map_err(PersistError::Io)?;
-        self.wal = WalWriter::open_append(&wal_path).map_err(PersistError::Io)?;
+        self.wal = WalWriter::open_append(&wal_path, self.config.write_buffer_bytes)
+            .map_err(PersistError::Io)?;
         self.wal_entries = 0;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WalConfig, WalManager};
+
+    struct TestDir(std::path::PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "likhadb-{name}-{}-{}",
+                std::process::id(),
+                rand::random::<u64>()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn wal_write_buffer_defaults_to_64_kib() {
+        assert_eq!(WalConfig::default().write_buffer_bytes, 64 * 1024);
+    }
+
+    #[test]
+    fn custom_wal_write_buffer_capacity_survives_checkpoint() {
+        let dir = TestDir::new("wal-write-buffer");
+        let config = WalConfig {
+            write_buffer_bytes: 32 * 1024,
+            ..WalConfig::default()
+        };
+        let mut manager = WalManager::open_with_config(&dir.0, config).unwrap();
+
+        assert_eq!(manager.wal.file.capacity(), 32 * 1024);
+        manager.checkpoint().unwrap();
+        assert_eq!(manager.wal.file.capacity(), 32 * 1024);
     }
 }

--- a/crates/likhadb-persist/tests/wal_recovery.rs
+++ b/crates/likhadb-persist/tests/wal_recovery.rs
@@ -468,6 +468,7 @@ fn auto_checkpoint_after_entry_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 2,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     {
@@ -503,6 +504,7 @@ fn auto_checkpoint_after_byte_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 1,
+        ..WalConfig::default()
     };
 
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
@@ -518,6 +520,7 @@ fn zero_auto_checkpoint_thresholds_disable_triggers() {
     let config = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
@@ -535,6 +538,7 @@ fn recovered_entries_count_toward_auto_checkpoint_threshold() {
     let disabled = WalConfig {
         checkpoint_every_n_entries: 0,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
 
     {
@@ -545,6 +549,7 @@ fn recovered_entries_count_toward_auto_checkpoint_threshold() {
     let config = WalConfig {
         checkpoint_every_n_entries: 2,
         checkpoint_every_n_bytes: 0,
+        ..WalConfig::default()
     };
     let mut mgr = WalManager::open_with_config(&dir, config).unwrap();
     mgr.insert("col", 1, vec![1.0, 0.0, 0.0, 0.0], None)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Summary
- add a public `WalConfig.write_buffer_bytes` setting with a 64 KiB default
- use the configured capacity whenever the WAL writer is opened or reopened, including checkpoint and Iceberg truncation paths
- update existing configuration literals and add regression coverage for default/custom capacity
- install the `rust-analyzer` component through `rust-toolchain.toml`

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test -p likhadb-persist --all-features` — passed (44 tests; 1 doctest ignored)
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo build --release -p likhadb-server` — passed
- `docker build -t likhadb-pr-134-ci .` — passed
- `git diff --check` — passed
- GitHub Unit Tests, fmt + clippy, and Docker build checks — passed

Closes #42