### PR TITLE
#106 lakehouse: trigger off-thread HNSW compaction

### DIFF
--- a/crates/likhadb-index/src/hnsw.rs
+++ b/crates/likhadb-index/src/hnsw.rs
@@ -16,7 +16,7 @@ use rayon::prelude::*;
 use likhadb_core::{FilterFn, LikhaDbError, Metric, Result, ScoredResult, VecId, Vector};
 
 use crate::flat::simd_distance;
-use crate::traits::VectorIndex;
+use crate::traits::{PreparedIndexCompaction, VectorIndex};
 
 const MAX_LEVEL: usize = 16;
 
@@ -607,31 +607,41 @@ impl VectorIndex for HnswIndex {
         dead as f32 / physical as f32
     }
 
-    /// Rebuild a fresh graph containing only the live nodes, dropping all
-    /// tombstones and overwrite ghosts. Live nodes are re-inserted in their
-    /// original insertion order (canonical node per id) via the normal `insert`
-    /// path, so graph quality matches a from-scratch build.
-    fn compact(&self) -> Option<Box<dyn VectorIndex>> {
-        let mut fresh = HnswIndex::new(
+    fn prepare_compaction(&self) -> Option<PreparedIndexCompaction> {
+        let replacement = HnswIndex::new(
             self.dim,
             self.metric,
             self.m,
             self.ef_construction,
             self.ef_search,
         )
-        .expect("compact reuses already-validated parameters")
+        .expect("compaction reuses already-validated parameters")
         .with_heuristic(self.use_heuristic);
-        for (i, node) in self.nodes.iter().enumerate() {
-            // Skip ghosts (id remapped to a newer node) and tombstoned deletes.
-            if self.id_to_node.get(&node.id) != Some(&i) || self.deleted.contains(&node.id) {
-                continue;
-            }
-            let vec = self.vec_of(i).to_vec();
-            fresh
-                .insert(node.id, vec)
-                .expect("live vectors already satisfy the dimension invariant");
-        }
-        Some(Box::new(fresh))
+        let live_vectors = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(index, node)| {
+                self.id_to_node.get(&node.id) == Some(index) && !self.deleted.contains(&node.id)
+            })
+            .map(|(index, node)| (node.id, self.vec_of(index).to_vec()))
+            .collect();
+        Some(PreparedIndexCompaction::new(
+            Box::new(replacement),
+            live_vectors,
+        ))
+    }
+
+    /// Rebuild a fresh graph containing only the live nodes, dropping all
+    /// tombstones and overwrite ghosts. Live nodes are captured in their
+    /// original insertion order (canonical node per id) and passed through the
+    /// normal bulk-build path, so graph quality matches a from-scratch build.
+    fn compact(&self) -> Option<Box<dyn VectorIndex>> {
+        Some(
+            self.prepare_compaction()?
+                .build()
+                .expect("live vectors already satisfy the dimension invariant"),
+        )
     }
 
     #[cfg(feature = "serde")]

--- a/crates/likhadb-index/src/lib.rs
+++ b/crates/likhadb-index/src/lib.rs
@@ -10,4 +10,4 @@ pub use hnsw::HnswIndex;
 pub use ivf::IvfIndex;
 #[cfg(feature = "serde")]
 pub use snapshot::IndexSnapshot;
-pub use traits::VectorIndex;
+pub use traits::{PreparedIndexCompaction, VectorIndex};

--- a/crates/likhadb-index/src/traits.rs
+++ b/crates/likhadb-index/src/traits.rs
@@ -1,5 +1,30 @@
 use likhadb_core::{FilterFn, Result, ScoredResult, VecId, Vector};
 
+/// A lightweight snapshot of the data and configuration needed to rebuild an
+/// index away from the live collection lock.
+pub struct PreparedIndexCompaction {
+    replacement: Box<dyn VectorIndex>,
+    live_vectors: Vec<(VecId, Vector)>,
+}
+
+impl PreparedIndexCompaction {
+    pub(crate) fn new(
+        replacement: Box<dyn VectorIndex>,
+        live_vectors: Vec<(VecId, Vector)>,
+    ) -> Self {
+        Self {
+            replacement,
+            live_vectors,
+        }
+    }
+
+    /// Build the replacement index from the captured live vectors.
+    pub fn build(mut self) -> Result<Box<dyn VectorIndex>> {
+        self.replacement.insert_batch(&self.live_vectors)?;
+        Ok(self.replacement)
+    }
+}
+
 /// The sole coupling point between collections and any index implementation.
 /// Flat, IVF, and HNSW indexes implement the same contract.
 pub trait VectorIndex: Send + Sync {
@@ -52,6 +77,13 @@ pub trait VectorIndex: Send + Sync {
     /// compaction trigger.
     fn tombstone_ratio(&self) -> f32 {
         0.0
+    }
+
+    /// Capture the live vectors and index configuration needed for an
+    /// off-thread compaction. The returned plan performs the expensive rebuild
+    /// only when [`PreparedIndexCompaction::build`] is called.
+    fn prepare_compaction(&self) -> Option<PreparedIndexCompaction> {
+        None
     }
 
     /// Rebuild compactly from live entries, dropping tombstones and refreshing

--- a/crates/likhadb-lakehouse/src/index_maintenance_task.rs
+++ b/crates/likhadb-lakehouse/src/index_maintenance_task.rs
@@ -8,7 +8,7 @@ use likhadb_core::SourceBinding;
 use likhadb_persist::WalManager;
 use tokio::sync::RwLock;
 
-use crate::{load_source_table, scan_delta, LakehouseError, SnapshotDelta};
+use crate::{load_source_table, scan_delta, LakehouseError, MaintenanceConfig, SnapshotDelta};
 
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -25,19 +25,27 @@ pub struct IndexMaintenanceTask {
     wal: Arc<RwLock<WalManager>>,
     catalog: Arc<dyn Catalog>,
     interval: Duration,
+    hnsw_compaction_tombstone_ratio: f32,
 }
 
 impl IndexMaintenanceTask {
     pub fn new(wal: Arc<RwLock<WalManager>>, catalog: Arc<dyn Catalog>) -> Self {
+        let config = MaintenanceConfig::default();
         Self {
             wal,
             catalog,
             interval: DEFAULT_INTERVAL,
+            hnsw_compaction_tombstone_ratio: config.hnsw_compaction_tombstone_ratio,
         }
     }
 
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
+        self
+    }
+
+    pub fn with_hnsw_compaction_tombstone_ratio(mut self, threshold: f32) -> Self {
+        self.hnsw_compaction_tombstone_ratio = threshold;
         self
     }
 
@@ -152,7 +160,77 @@ impl IndexMaintenanceTask {
             unresolved_delete_files = result.unresolved_delete_files,
             "source snapshot delta applied"
         );
+        drop(self.enqueue_hnsw_compaction(&collection.name).await?);
         Ok(())
+    }
+
+    /// Capture a compaction plan under the store lock, then rebuild on a
+    /// blocking worker. The worker reacquires the lock only to replay mutations
+    /// recorded since the snapshot and swap the index pointer.
+    async fn enqueue_hnsw_compaction(
+        &self,
+        collection: &str,
+    ) -> Result<Option<tokio::task::JoinHandle<()>>, LakehouseError> {
+        let prepared = self
+            .wal
+            .write()
+            .await
+            .prepare_index_compaction(collection, self.hnsw_compaction_tombstone_ratio)?;
+        let Some(prepared) = prepared else {
+            return Ok(None);
+        };
+
+        let wal = self.wal.clone();
+        let collection = collection.to_owned();
+        let threshold = self.hnsw_compaction_tombstone_ratio;
+        tracing::info!(
+            collection = %collection,
+            tombstone_threshold = threshold,
+            "HNSW index compaction started"
+        );
+
+        Ok(Some(tokio::spawn(async move {
+            let build = tokio::task::spawn_blocking(move || prepared.build()).await;
+            match build {
+                Ok(Ok(built)) => match wal
+                    .write()
+                    .await
+                    .finish_index_compaction(&collection, built)
+                {
+                    Ok(true) => tracing::info!(
+                        collection = %collection,
+                        "HNSW index compaction completed"
+                    ),
+                    Ok(false) => tracing::debug!(
+                        collection = %collection,
+                        "discarding stale HNSW index compaction"
+                    ),
+                    Err(error) => tracing::warn!(
+                        collection = %collection,
+                        error = %error,
+                        "HNSW index compaction swap failed"
+                    ),
+                },
+                Ok(Err(error)) => {
+                    let cancel_error = wal.write().await.cancel_index_compaction(&collection);
+                    tracing::warn!(
+                        collection = %collection,
+                        error = %error,
+                        cancel_error = ?cancel_error.err(),
+                        "HNSW index compaction build failed"
+                    );
+                }
+                Err(error) => {
+                    let cancel_error = wal.write().await.cancel_index_compaction(&collection);
+                    tracing::warn!(
+                        collection = %collection,
+                        error = %error,
+                        cancel_error = ?cancel_error.err(),
+                        "HNSW index compaction worker failed"
+                    );
+                }
+            }
+        })))
     }
 }
 
@@ -255,7 +333,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_applies_external_append_and_advances_watermark() {
+    async fn tick_applies_external_append_and_compacts_hnsw() {
         let warehouse = TempDir::new().unwrap();
         let catalog = Arc::new(
             MemoryCatalogBuilder::default()
@@ -303,6 +381,14 @@ mod tests {
             .unwrap();
         wal.apply_source_delta("documents", &binding, None, baseline_snapshot, [])
             .unwrap();
+        for id in 10..20 {
+            wal.insert("documents", id, vec![id as f32, 0.0], None)
+                .unwrap();
+        }
+        for id in 10..13 {
+            wal.delete("documents", id).unwrap();
+        }
+        assert!(wal.get("documents").unwrap().tombstone_ratio() > 0.2);
 
         // Reloading before the append models a writer independent from the
         // maintenance task's later catalog read.
@@ -315,13 +401,31 @@ mod tests {
         let task = IndexMaintenanceTask::new(wal.clone(), catalog);
         task.run_once().await;
 
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if wal.read().await.get("documents").unwrap().tombstone_ratio() == 0.0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("HNSW compaction should finish without holding the store lock");
+
         let guard = wal.read().await;
         let collection = guard.get("documents").unwrap();
         assert_eq!(collection.source_snapshot_id, Some(external_snapshot));
+        assert_eq!(collection.tombstone_ratio(), 0.0);
         assert_eq!(
             collection.search(&[2.0, 0.0], 1, None, false).unwrap()[0].id,
             2
         );
         assert!(collection.get(1).unwrap().is_none());
+        for id in 10..13 {
+            assert!(collection.get(id).unwrap().is_none());
+        }
+        for id in 13..20 {
+            assert!(collection.get(id).unwrap().is_some());
+        }
     }
 }

--- a/crates/likhadb-persist/src/wal/mod.rs
+++ b/crates/likhadb-persist/src/wal/mod.rs
@@ -12,7 +12,10 @@ use std::path::{Path, PathBuf};
 
 use bincode::Options as _;
 use likhadb_core::{Metric, SourceBinding, VecId, Vector};
-use likhadb_store::{Collection, CollectionManager, DeltaRow};
+use likhadb_store::{
+    BuiltCollectionCompaction, Collection, CollectionManager, DeltaRow,
+    PreparedCollectionCompaction,
+};
 use serde_json::Value;
 
 use crate::{bincode_opts, PersistError};
@@ -890,6 +893,36 @@ impl WalManager {
     }
 
     // ── Read-through ────────────────────────────────────────────────────────
+
+    /// Capture a collection's live HNSW vectors and start journaling mutations
+    /// that must be replayed before the rebuilt index is swapped in.
+    pub fn prepare_index_compaction(
+        &mut self,
+        collection: &str,
+        tombstone_threshold: f32,
+    ) -> likhadb_core::Result<Option<PreparedCollectionCompaction>> {
+        self.inner
+            .get_mut(collection)
+            .map(|col| col.prepare_index_compaction(tombstone_threshold))
+    }
+
+    /// Replay mutations made during the off-thread rebuild and swap in the
+    /// replacement index.
+    pub fn finish_index_compaction(
+        &mut self,
+        collection: &str,
+        built: BuiltCollectionCompaction,
+    ) -> likhadb_core::Result<bool> {
+        self.inner
+            .get_mut(collection)?
+            .finish_index_compaction(built)
+    }
+
+    /// Leave the existing index in place after a compaction build failure.
+    pub fn cancel_index_compaction(&mut self, collection: &str) -> likhadb_core::Result<()> {
+        self.inner.get_mut(collection)?.cancel_index_compaction();
+        Ok(())
+    }
 
     pub fn get(&self, name: &str) -> likhadb_core::Result<&Collection> {
         self.inner.get(name)

--- a/crates/likhadb-store/src/collection.rs
+++ b/crates/likhadb-store/src/collection.rs
@@ -1,13 +1,38 @@
 use std::path::Path;
 
 use likhadb_core::{Metric, Result, ScoredResult, SourceBinding, VecId, Vector};
-use likhadb_index::{FlatIndex, VectorIndex};
+use likhadb_index::{FlatIndex, PreparedIndexCompaction, VectorIndex};
 use serde_json::Value;
 
 use crate::delta::DeltaRow;
 use crate::meta::MetaStore;
 
 pub type VectorWithPayload = (Vector, Option<Value>);
+
+enum IndexMutation {
+    Upsert { id: VecId, vector: Vector },
+    Delete { id: VecId },
+}
+
+/// An HNSW rebuild captured from a collection's live vectors. Building it is
+/// CPU-intensive but does not access the live collection.
+pub struct PreparedCollectionCompaction {
+    inner: PreparedIndexCompaction,
+}
+
+/// A replacement index ready to receive mutations that arrived during its
+/// rebuild and then be swapped into the collection.
+pub struct BuiltCollectionCompaction {
+    replacement: Box<dyn VectorIndex>,
+}
+
+impl PreparedCollectionCompaction {
+    pub fn build(self) -> Result<BuiltCollectionCompaction> {
+        Ok(BuiltCollectionCompaction {
+            replacement: self.inner.build()?,
+        })
+    }
+}
 
 #[cfg(feature = "fts")]
 fn extract_text_fields(value: &Value) -> String {
@@ -55,6 +80,9 @@ pub struct Collection {
     /// `None` until a source delta has been applied. Held in memory in this
     /// phase; durable persistence arrives with the Puffin checkpoint work.
     pub source_snapshot_id: Option<i64>,
+    /// Mutations made after an off-thread compaction snapshot was captured.
+    /// This is transient coordination state and is never persisted.
+    compaction_journal: Option<Vec<IndexMutation>>,
 }
 
 impl Collection {
@@ -81,6 +109,7 @@ impl Collection {
             fts_index: None,
             source_binding: None,
             source_snapshot_id: None,
+            compaction_journal: None,
         }
     }
 
@@ -174,7 +203,12 @@ impl Collection {
         payload: Option<Value>,
         lsn: u64,
     ) -> Result<()> {
-        self.index.insert(id, vec)?;
+        if let Some(journal) = &mut self.compaction_journal {
+            self.index.insert(id, vec.clone())?;
+            journal.push(IndexMutation::Upsert { id, vector: vec });
+        } else {
+            self.index.insert(id, vec)?;
+        }
         self.apply_insert_payload(id, payload, lsn)
     }
 
@@ -205,6 +239,12 @@ impl Collection {
             .map(|(id, vector, _, _)| (*id, vector.clone()))
             .collect();
         self.index.insert_batch(&index_rows)?;
+        if let Some(journal) = &mut self.compaction_journal {
+            journal.extend(index_rows.iter().map(|(id, vector)| IndexMutation::Upsert {
+                id: *id,
+                vector: vector.clone(),
+            }));
+        }
         for (id, _, payload, lsn) in rows {
             self.apply_insert_payload(id, payload, lsn)?;
         }
@@ -233,6 +273,11 @@ impl Collection {
 
     pub fn delete(&mut self, id: VecId, lsn: u64) -> Result<bool> {
         let existed = self.index.delete(id);
+        if existed {
+            if let Some(journal) = &mut self.compaction_journal {
+                journal.push(IndexMutation::Delete { id });
+            }
+        }
         self.meta.remove(id);
         #[cfg(feature = "fts")]
         if let Some(fts) = &mut self.fts_index {
@@ -310,11 +355,63 @@ impl Collection {
     pub fn index_type(&self) -> &'static str {
         self.index.index_type()
     }
+
+    /// Fraction of physical index entries that are no longer live.
+    pub fn tombstone_ratio(&self) -> f32 {
+        self.index.tombstone_ratio()
+    }
+
+    /// Capture an HNSW compaction plan and begin journaling subsequent index
+    /// mutations. The expensive graph build happens later via
+    /// [`PreparedCollectionCompaction::build`].
+    pub fn prepare_index_compaction(
+        &mut self,
+        tombstone_threshold: f32,
+    ) -> Option<PreparedCollectionCompaction> {
+        if self.compaction_journal.is_some() || self.index.tombstone_ratio() <= tombstone_threshold
+        {
+            return None;
+        }
+
+        let inner = self.index.prepare_compaction()?;
+        self.compaction_journal = Some(Vec::new());
+        Some(PreparedCollectionCompaction { inner })
+    }
+
+    /// Replay mutations that landed during a rebuild and atomically replace the
+    /// live index. Returns `false` if this collection no longer owns the plan.
+    pub fn finish_index_compaction(
+        &mut self,
+        mut built: BuiltCollectionCompaction,
+    ) -> Result<bool> {
+        let Some(journal) = self.compaction_journal.take() else {
+            return Ok(false);
+        };
+
+        for mutation in journal {
+            match mutation {
+                IndexMutation::Upsert { id, vector } => {
+                    built.replacement.insert(id, vector)?;
+                }
+                IndexMutation::Delete { id } => {
+                    built.replacement.delete(id);
+                }
+            }
+        }
+        self.index = built.replacement;
+        Ok(true)
+    }
+
+    /// Stop journaling after a rebuild failure, leaving the live index intact.
+    pub fn cancel_index_compaction(&mut self) {
+        self.compaction_journal = None;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use likhadb_index::HnswIndex;
     use serde_json::json;
 
     fn make_collection() -> Collection {
@@ -420,6 +517,49 @@ mod tests {
         c.apply_delta_row(DeltaRow::Delete { id: 7 }, u64::MAX)
             .unwrap();
         assert!(c.get(7).unwrap().is_none());
+    }
+
+    #[test]
+    fn compaction_replays_mutations_before_swapping() {
+        let index = HnswIndex::new(2, Metric::L2, 4, 8, 10).unwrap();
+        let mut collection =
+            Collection::with_index("compacting".to_string(), 2, Metric::L2, Box::new(index));
+        for id in 0..10 {
+            collection
+                .insert(id, vec![id as f32, 0.0], None, u64::MAX)
+                .unwrap();
+        }
+        for id in 0..3 {
+            collection.delete(id, u64::MAX).unwrap();
+        }
+        assert!(collection.tombstone_ratio() > 0.2);
+
+        let prepared = collection
+            .prepare_index_compaction(0.2)
+            .expect("tombstone threshold should trigger a rebuild");
+        assert!(
+            collection.prepare_index_compaction(0.2).is_none(),
+            "only one rebuild may journal mutations at a time"
+        );
+
+        collection
+            .insert(20, vec![20.0, 0.0], None, u64::MAX)
+            .unwrap();
+        collection
+            .insert(4, vec![40.0, 0.0], None, u64::MAX)
+            .unwrap();
+        collection.delete(3, u64::MAX).unwrap();
+
+        let built = prepared.build().unwrap();
+        assert!(collection.finish_index_compaction(built).unwrap());
+        assert!(
+            collection.tombstone_ratio() < 0.3,
+            "replayed churn should still leave fewer tombstones than the original index"
+        );
+        assert!(collection.get(3).unwrap().is_none());
+        assert_eq!(collection.get(4).unwrap().unwrap().0, vec![40.0, 0.0]);
+        assert_eq!(collection.get(20).unwrap().unwrap().0, vec![20.0, 0.0]);
+        assert_eq!(collection.len(), 7);
     }
 
     #[test]

--- a/crates/likhadb-store/src/lib.rs
+++ b/crates/likhadb-store/src/lib.rs
@@ -5,7 +5,7 @@ pub mod meta;
 #[cfg(feature = "persist")]
 pub mod snapshot;
 
-pub use collection::Collection;
+pub use collection::{BuiltCollectionCompaction, Collection, PreparedCollectionCompaction};
 pub use delta::DeltaRow;
 pub use manager::CollectionManager;
 pub use meta::MetaStore;


### PR DESCRIPTION
## Summary
- evaluate the configured HNSW tombstone threshold after each applied source snapshot range
- snapshot live vectors and rebuild the replacement HNSW graph on a blocking worker, keeping the live store unlocked during construction
- journal inserts, overwrites, and deletes that arrive during the rebuild, replay them before the short final pointer swap, and suppress duplicate in-flight compactions
- add coverage for maintenance-triggered compaction, live-set/search preservation, and mutation replay during rebuilds

## Verification
- `cargo test --workspace` — passed
- `cargo test -p likhadb-persist --all-features` — passed (57 tests; 1 doctest ignored)
- `cargo test -p likhadb-lakehouse --all-features` — passed (32 tests; 4 external-service tests ignored)
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo clippy -p likhadb-index -p likhadb-store -p likhadb-persist -p likhadb-lakehouse --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

Closes #106