### PR TITLE
#109 lakehouse: expose incremental maintenance metrics

### DIFF
--- a/crates/likhadb-lakehouse/src/index_maintenance_task.rs
+++ b/crates/likhadb-lakehouse/src/index_maintenance_task.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use iceberg::Catalog;
 use likhadb_core::SourceBinding;
 use likhadb_persist::WalManager;
+use likhadb_store::DeltaRow;
 use tokio::sync::RwLock;
 
 use crate::{load_source_table, scan_delta, LakehouseError, MaintenanceConfig, SnapshotDelta};
@@ -17,6 +18,72 @@ struct BoundCollection {
     name: String,
     binding: SourceBinding,
     source_snapshot_id: Option<i64>,
+    tombstone_ratio: f32,
+}
+
+fn initialize_metrics(collection: &BoundCollection) {
+    let name = collection.name.clone();
+    metrics::gauge!("likhadb_source_snapshot_lag", "collection" => name.clone()).set(f64::NAN);
+    metrics::gauge!("likhadb_index_tombstone_ratio", "collection" => name.clone())
+        .set(collection.tombstone_ratio as f64);
+    for op in ["upsert", "delete"] {
+        metrics::counter!(
+            "likhadb_delta_rows_applied_total",
+            "collection" => name.clone(),
+            "op" => op
+        )
+        .increment(0);
+    }
+    for result in ["success", "failure", "stale"] {
+        metrics::counter!(
+            "likhadb_index_compactions_total",
+            "collection" => name.clone(),
+            "result" => result
+        )
+        .increment(0);
+    }
+    metrics::counter!("likhadb_source_full_rescan_total", "collection" => name.clone())
+        .increment(0);
+    metrics::counter!(
+        "likhadb_unresolved_delete_files_total",
+        "collection" => name
+    )
+    .increment(0);
+}
+
+fn snapshot_lag_seconds(
+    table: &iceberg::table::Table,
+    from_snapshot_id: Option<i64>,
+    to_snapshot_id: i64,
+) -> f64 {
+    let metadata = table.metadata();
+    let Some(from) = from_snapshot_id.and_then(|id| metadata.snapshot_by_id(id)) else {
+        return f64::NAN;
+    };
+    let Some(to) = metadata.snapshot_by_id(to_snapshot_id) else {
+        return f64::NAN;
+    };
+    // Iceberg stores snapshot timestamps in milliseconds. Expose their
+    // non-negative age difference in seconds while retaining the RFC's metric
+    // name for compatibility.
+    to.timestamp_ms().saturating_sub(from.timestamp_ms()).max(0) as f64 / 1_000.0
+}
+
+fn row_counts(rows: &[DeltaRow]) -> (u64, u64) {
+    rows.iter()
+        .fold((0, 0), |(upserts, deletes), row| match row {
+            DeltaRow::Upsert { .. } => (upserts + 1, deletes),
+            DeltaRow::Delete { .. } => (upserts, deletes + 1),
+        })
+}
+
+fn record_compaction(collection: &str, result: &'static str) {
+    metrics::counter!(
+        "likhadb_index_compactions_total",
+        "collection" => collection.to_owned(),
+        "result" => result
+    )
+    .increment(1);
 }
 
 /// Polls source Iceberg tables and applies committed snapshot deltas to the
@@ -73,6 +140,7 @@ impl IndexMaintenanceTask {
     pub async fn run_once(&self) {
         let collections = self.bound_collections().await;
         for collection in collections {
+            initialize_metrics(&collection);
             if let Err(error) = self.maintain_collection(&collection).await {
                 tracing::warn!(
                     collection = %collection.name,
@@ -94,6 +162,7 @@ impl IndexMaintenanceTask {
                     name: name.to_owned(),
                     binding: collection.source_binding.clone()?,
                     source_snapshot_id: collection.source_snapshot_id,
+                    tombstone_ratio: collection.tombstone_ratio(),
                 })
             })
             .collect()
@@ -109,7 +178,21 @@ impl IndexMaintenanceTask {
             return Ok(());
         };
         let from_snapshot_id = collection.source_snapshot_id;
+        metrics::gauge!(
+            "likhadb_source_snapshot_lag",
+            "collection" => collection.name.clone()
+        )
+        .set(snapshot_lag_seconds(
+            &table,
+            from_snapshot_id,
+            to_snapshot_id,
+        ));
         if from_snapshot_id == Some(to_snapshot_id) {
+            metrics::gauge!(
+                "likhadb_source_snapshot_lag",
+                "collection" => collection.name.clone()
+            )
+            .set(0.0);
             return Ok(());
         }
 
@@ -154,16 +237,27 @@ impl IndexMaintenanceTask {
             Err(error) => return Err(error),
         };
         let row_count = result.rows.len();
+        let (upserts, deletes) = row_counts(&result.rows);
+        let unresolved_delete_files = result.unresolved_delete_files;
 
         // Revalidate the state observed before the scan while holding the same
         // write lock used to apply every row and advance the watermark.
-        let applied = self.wal.write().await.apply_source_delta(
-            &collection.name,
-            &collection.binding,
-            from_snapshot_id,
-            to_snapshot_id,
-            result.rows,
-        )?;
+        let (applied, tombstone_ratio) = {
+            let mut wal = self.wal.write().await;
+            let applied = wal.apply_source_delta(
+                &collection.name,
+                &collection.binding,
+                from_snapshot_id,
+                to_snapshot_id,
+                result.rows,
+            )?;
+            let tombstone_ratio = if applied {
+                wal.get(&collection.name)?.tombstone_ratio()
+            } else {
+                collection.tombstone_ratio
+            };
+            (applied, tombstone_ratio)
+        };
         if !applied {
             tracing::debug!(
                 collection = %collection.name,
@@ -174,12 +268,47 @@ impl IndexMaintenanceTask {
             return Ok(());
         }
 
+        metrics::counter!(
+            "likhadb_delta_rows_applied_total",
+            "collection" => collection.name.clone(),
+            "op" => "upsert"
+        )
+        .increment(upserts);
+        metrics::counter!(
+            "likhadb_delta_rows_applied_total",
+            "collection" => collection.name.clone(),
+            "op" => "delete"
+        )
+        .increment(deletes);
+        metrics::counter!(
+            "likhadb_unresolved_delete_files_total",
+            "collection" => collection.name.clone()
+        )
+        .increment(unresolved_delete_files as u64);
+        if full_rescan {
+            metrics::counter!(
+                "likhadb_source_full_rescan_total",
+                "collection" => collection.name.clone()
+            )
+            .increment(1);
+        }
+        metrics::gauge!(
+            "likhadb_source_snapshot_lag",
+            "collection" => collection.name.clone()
+        )
+        .set(0.0);
+        metrics::gauge!(
+            "likhadb_index_tombstone_ratio",
+            "collection" => collection.name.clone()
+        )
+        .set(tombstone_ratio as f64);
+
         tracing::info!(
             collection = %collection.name,
             ?from_snapshot_id,
             to_snapshot_id,
             rows_applied = row_count,
-            unresolved_delete_files = result.unresolved_delete_files,
+            unresolved_delete_files,
             full_rescan,
             "source snapshot maintenance applied"
         );
@@ -194,11 +323,18 @@ impl IndexMaintenanceTask {
         &self,
         collection: &str,
     ) -> Result<Option<tokio::task::JoinHandle<()>>, LakehouseError> {
-        let prepared = self
+        let prepared = match self
             .wal
             .write()
             .await
-            .prepare_index_compaction(collection, self.hnsw_compaction_tombstone_ratio)?;
+            .prepare_index_compaction(collection, self.hnsw_compaction_tombstone_ratio)
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                record_compaction(collection, "failure");
+                return Err(error.into());
+            }
+        };
         let Some(prepared) = prepared else {
             return Ok(None);
         };
@@ -215,26 +351,51 @@ impl IndexMaintenanceTask {
         Ok(Some(tokio::spawn(async move {
             let build = tokio::task::spawn_blocking(move || prepared.build()).await;
             match build {
-                Ok(Ok(built)) => match wal
-                    .write()
-                    .await
-                    .finish_index_compaction(&collection, built)
-                {
-                    Ok(true) => tracing::info!(
-                        collection = %collection,
-                        "HNSW index compaction completed"
-                    ),
-                    Ok(false) => tracing::debug!(
-                        collection = %collection,
-                        "discarding stale HNSW index compaction"
-                    ),
-                    Err(error) => tracing::warn!(
-                        collection = %collection,
-                        error = %error,
-                        "HNSW index compaction swap failed"
-                    ),
-                },
+                Ok(Ok(built)) => {
+                    let finish = wal
+                        .write()
+                        .await
+                        .finish_index_compaction(&collection, built);
+                    match finish {
+                        Ok(true) => {
+                            record_compaction(&collection, "success");
+                            let tombstone_ratio = wal
+                                .read()
+                                .await
+                                .get(&collection)
+                                .map(|value| value.tombstone_ratio())
+                                .ok();
+                            if let Some(tombstone_ratio) = tombstone_ratio {
+                                metrics::gauge!(
+                                    "likhadb_index_tombstone_ratio",
+                                    "collection" => collection.clone()
+                                )
+                                .set(tombstone_ratio as f64);
+                            }
+                            tracing::info!(
+                                collection = %collection,
+                                "HNSW index compaction completed"
+                            );
+                        }
+                        Ok(false) => {
+                            record_compaction(&collection, "stale");
+                            tracing::debug!(
+                                collection = %collection,
+                                "discarding stale HNSW index compaction"
+                            );
+                        }
+                        Err(error) => {
+                            record_compaction(&collection, "failure");
+                            tracing::warn!(
+                                collection = %collection,
+                                error = %error,
+                                "HNSW index compaction swap failed"
+                            );
+                        }
+                    }
+                }
                 Ok(Err(error)) => {
+                    record_compaction(&collection, "failure");
                     let cancel_error = wal.write().await.cancel_index_compaction(&collection);
                     tracing::warn!(
                         collection = %collection,
@@ -244,6 +405,7 @@ impl IndexMaintenanceTask {
                     );
                 }
                 Err(error) => {
+                    record_compaction(&collection, "failure");
                     let cancel_error = wal.write().await.cancel_index_compaction(&collection);
                     tracing::warn!(
                         collection = %collection,

--- a/crates/likhadb-server/Cargo.toml
+++ b/crates/likhadb-server/Cargo.toml
@@ -38,4 +38,7 @@ http                         = "1"
 tonic-build = "0.12"
 
 [dev-dependencies]
+arrow    = "57.1"
+iceberg  = "0.9.1"
+parquet  = { version = "57.1", features = ["arrow"] }
 tempfile = "3"

--- a/crates/likhadb-server/tests/metrics_integration.rs
+++ b/crates/likhadb-server/tests/metrics_integration.rs
@@ -5,6 +5,34 @@ use likhadb_server::{install_prometheus, router, seed_collection_gauges, ApiToke
 use tempfile::TempDir;
 use tower::ServiceExt;
 
+#[cfg(feature = "iceberg-recovery")]
+use std::{collections::HashMap, sync::Arc};
+
+#[cfg(feature = "iceberg-recovery")]
+use arrow::array::{ArrayRef, FixedSizeListArray, Float32Array, Int64Array};
+#[cfg(feature = "iceberg-recovery")]
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+#[cfg(feature = "iceberg-recovery")]
+use arrow::record_batch::RecordBatch;
+#[cfg(feature = "iceberg-recovery")]
+use bytes::Bytes;
+#[cfg(feature = "iceberg-recovery")]
+use iceberg::arrow::arrow_schema_to_schema;
+#[cfg(feature = "iceberg-recovery")]
+use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
+#[cfg(feature = "iceberg-recovery")]
+use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Struct};
+#[cfg(feature = "iceberg-recovery")]
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
+#[cfg(feature = "iceberg-recovery")]
+use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent};
+#[cfg(feature = "iceberg-recovery")]
+use likhadb_core::{Metric, SourceBinding};
+#[cfg(feature = "iceberg-recovery")]
+use likhadb_server::IndexMaintenanceTask;
+#[cfg(feature = "iceberg-recovery")]
+use parquet::arrow::ArrowWriter;
+
 fn build_app() -> (axum::Router, TempDir) {
     let dir = TempDir::new().unwrap();
     let wal = WalManager::open(dir.path()).unwrap();
@@ -29,6 +57,22 @@ async fn body_text(res: axum::response::Response) -> String {
         .await
         .unwrap();
     String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[cfg(feature = "iceberg-recovery")]
+async fn scrape_metrics(app: &axum::Router) -> String {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    body_text(response).await
 }
 
 #[tokio::test]
@@ -153,4 +197,251 @@ async fn metrics_histogram_uses_custom_buckets() {
         text.contains("le=\"0.0001\""),
         "custom 100µs bucket missing — default buckets may be in use\n---\n{text}"
     );
+}
+
+#[cfg(feature = "iceberg-recovery")]
+fn source_field(name: &str, data_type: DataType, nullable: bool, id: i32) -> Field {
+    Field::new(name, data_type, nullable).with_metadata(HashMap::from([(
+        "PARQUET:field_id".to_string(),
+        id.to_string(),
+    )]))
+}
+
+#[cfg(feature = "iceberg-recovery")]
+fn source_schema() -> Arc<ArrowSchema> {
+    let vector_element = Arc::new(source_field("element", DataType::Float32, false, 3));
+    Arc::new(ArrowSchema::new(vec![
+        source_field("id", DataType::Int64, false, 1),
+        source_field(
+            "embedding",
+            DataType::FixedSizeList(vector_element, 2),
+            false,
+            2,
+        ),
+    ]))
+}
+
+#[cfg(feature = "iceberg-recovery")]
+fn source_parquet(id: i64, vector: [f32; 2]) -> Vec<u8> {
+    let schema = source_schema();
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![id]));
+    let vectors: ArrayRef = Arc::new(
+        FixedSizeListArray::try_new(
+            Arc::new(source_field("element", DataType::Float32, false, 3)),
+            2,
+            Arc::new(Float32Array::from(vector.to_vec())),
+            None,
+        )
+        .unwrap(),
+    );
+    let batch = RecordBatch::try_new(schema.clone(), vec![ids, vectors]).unwrap();
+    let mut bytes = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    bytes
+}
+
+#[cfg(feature = "iceberg-recovery")]
+async fn append_source_row(
+    catalog: &dyn Catalog,
+    table: &iceberg::table::Table,
+    file_name: &str,
+    id: i64,
+    vector: [f32; 2],
+) -> iceberg::table::Table {
+    let bytes = source_parquet(id, vector);
+    let file_path = format!("{}/data/{file_name}.parquet", table.metadata().location());
+    table
+        .file_io()
+        .new_output(&file_path)
+        .unwrap()
+        .write(Bytes::from(bytes.clone()))
+        .await
+        .unwrap();
+    let data_file = DataFileBuilder::default()
+        .content(DataContentType::Data)
+        .file_path(file_path)
+        .file_format(DataFileFormat::Parquet)
+        .partition(Struct::empty())
+        .record_count(1)
+        .file_size_in_bytes(bytes.len() as u64)
+        .build()
+        .unwrap();
+    let tx = Transaction::new(table);
+    let tx = tx
+        .fast_append()
+        .add_data_files([data_file])
+        .apply(tx)
+        .unwrap();
+    tx.commit(catalog).await.unwrap()
+}
+
+#[cfg(feature = "iceberg-recovery")]
+fn metric_value(text: &str, name: &str, labels: &[(&str, &str)]) -> f64 {
+    text.lines()
+        .find(|line| {
+            line.starts_with(name)
+                && labels
+                    .iter()
+                    .all(|(key, value)| line.contains(&format!(r#"{key}="{value}""#)))
+        })
+        .unwrap_or_else(|| panic!("metric '{name}' with labels {labels:?} missing\n---\n{text}"))
+        .split_whitespace()
+        .last()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+#[cfg(feature = "iceberg-recovery")]
+#[tokio::test]
+async fn maintenance_tick_exposes_snapshot_metrics() {
+    let warehouse = TempDir::new().unwrap();
+    let catalog: Arc<dyn Catalog> = Arc::new(
+        MemoryCatalogBuilder::default()
+            .load(
+                "maintenance-metrics-test",
+                HashMap::from([(
+                    MEMORY_CATALOG_WAREHOUSE.to_string(),
+                    format!("file://{}", warehouse.path().display()),
+                )]),
+            )
+            .await
+            .unwrap(),
+    );
+    let namespace = NamespaceIdent::new("source_metrics".to_string());
+    catalog
+        .create_namespace(&namespace, HashMap::new())
+        .await
+        .unwrap();
+    let table_ident = TableIdent::new(namespace.clone(), "vectors".to_string());
+    let table = catalog
+        .create_table(
+            &namespace,
+            TableCreation::builder()
+                .name(table_ident.name().to_string())
+                .schema(arrow_schema_to_schema(source_schema().as_ref()).unwrap())
+                .build(),
+        )
+        .await
+        .unwrap();
+    let table = append_source_row(catalog.as_ref(), &table, "baseline", 1, [1.0, 0.0]).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let mut wal = WalManager::open(data_dir.path()).unwrap();
+    let collection = "maintenance_observability";
+    wal.create_hnsw_collection(collection, 2, Metric::L2, 4, 8, 10)
+        .unwrap();
+    for id in 10..20 {
+        wal.insert(collection, id, vec![id as f32, 0.0], None)
+            .unwrap();
+    }
+    for id in 10..13 {
+        wal.delete(collection, id).unwrap();
+    }
+    let binding = SourceBinding {
+        source_namespace: namespace.as_ref().clone(),
+        source_table: table_ident.name().to_string(),
+        id_column: "id".to_string(),
+        vector_column: "embedding".to_string(),
+        payload_columns: vec![],
+    };
+    wal.set_source_binding(collection, binding.clone()).unwrap();
+    wal.apply_source_delta(collection, &binding, None, i64::MAX, [])
+        .unwrap();
+
+    let prometheus = install_prometheus();
+    let state = AppState::new(wal);
+    let task = IndexMaintenanceTask::new(state.wal_arc(), catalog.clone());
+    let app = router(state, prometheus, ApiToken::new(None));
+
+    // The invalid watermark forces the non-ancestor fallback path. The first
+    // successful tick must count that full rescan exactly once.
+    task.run_once().await;
+    let writer_table = catalog.load_table(&table_ident).await.unwrap();
+    append_source_row(
+        catalog.as_ref(),
+        &writer_table,
+        "incremental",
+        2,
+        [0.0, 1.0],
+    )
+    .await;
+    task.run_once().await;
+
+    let text = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let text = scrape_metrics(&app).await;
+            if metric_value(
+                &text,
+                "likhadb_index_compactions_total",
+                &[("collection", collection), ("result", "success")],
+            ) == 1.0
+            {
+                break text;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("maintenance compaction did not complete");
+    let collection_label = [("collection", collection)];
+
+    assert_eq!(
+        metric_value(
+            &text,
+            "likhadb_delta_rows_applied_total",
+            &[("collection", collection), ("op", "upsert")],
+        ),
+        2.0
+    );
+    assert_eq!(
+        metric_value(
+            &text,
+            "likhadb_delta_rows_applied_total",
+            &[("collection", collection), ("op", "delete")],
+        ),
+        0.0
+    );
+    assert_eq!(
+        metric_value(&text, "likhadb_source_full_rescan_total", &collection_label),
+        1.0
+    );
+    assert_eq!(
+        metric_value(
+            &text,
+            "likhadb_unresolved_delete_files_total",
+            &collection_label,
+        ),
+        0.0
+    );
+    assert_eq!(
+        metric_value(&text, "likhadb_source_snapshot_lag", &collection_label),
+        0.0
+    );
+    assert_eq!(
+        metric_value(&text, "likhadb_index_tombstone_ratio", &collection_label),
+        0.0
+    );
+    assert_eq!(
+        metric_value(
+            &text,
+            "likhadb_index_compactions_total",
+            &[("collection", collection), ("result", "success")],
+        ),
+        1.0
+    );
+    for result in ["failure", "stale"] {
+        assert_eq!(
+            metric_value(
+                &text,
+                "likhadb_index_compactions_total",
+                &[("collection", collection), ("result", result)],
+            ),
+            0.0
+        );
+    }
+
+    drop(table);
 }


### PR DESCRIPTION
## Summary
- expose source snapshot lag, applied delta rows by operation, index tombstone ratio, full rescans, and unresolved delete-file counters per collection
- record HNSW compaction success, failure, and stale outcomes and refresh the tombstone gauge after a successful swap
- initialize stable label series and add an all-features metrics endpoint integration test covering fallback, incremental apply, and off-thread compaction

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo clippy -p likhadb-lakehouse -p likhadb-server --all-targets --all-features -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p likhadb-lakehouse --all-features` — passed (34 passed, 4 external-service tests ignored)
- `cargo test -p likhadb-server --all-features` — passed
- `PATH=/tmp/codex-likhadb-docker-bin:$PATH docker build .` — passed; anonymous helper shim bypassed a hung local Docker credential helper, build exported image `sha256:8fef96876fbd33f130bbd8b5e08fe1300f171efd0d3e21477769f23066adb707`
- `git diff --check` — passed

Closes #109